### PR TITLE
Add unit tests for ConfigurationHandlerRouter

### DIFF
--- a/config-handler-router/pom.xml
+++ b/config-handler-router/pom.xml
@@ -44,6 +44,60 @@
             <artifactId>commons-lang</artifactId>
             <version>${commons-lang.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+
+        <!--
+    TODO: Replace all dependencies below this line with shaded jar at version 2.10.0
+    -->
+        <!--Spock dependencies-->
+        <!--
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>2.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        -->
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>5.0.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>cglib</groupId>
+            <artifactId>cglib-nodep</artifactId>
+            <version>3.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.objenesis</groupId>
+            <artifactId>objenesis</artifactId>
+            <version>2.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spockframework</groupId>
+            <artifactId>spock-core</artifactId>
+            <version>1.0-groovy-2.4</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-all</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+            <version>${groovy.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -95,20 +149,22 @@
                                 <rule>
                                     <element>BUNDLE</element>
                                     <limits>
+                                        <!--Test coverage is low since the RuntimeTypeAdapterFactory and SparkServlet were copied verbatim from other locations-->
+                                        <!--and are unchanged and should not ever change.-->
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.38</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.36</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.31</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/config-handler-router/pom.xml
+++ b/config-handler-router/pom.xml
@@ -48,54 +48,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-        </dependency>
-
-        <!--
-    TODO: Replace all dependencies below this line with shaded jar at version 2.10.0
-    -->
-        <!--Spock dependencies-->
-        <!--
-        <dependency>
-            <groupId>ddf.lib</groupId>
-            <artifactId>spock-shaded</artifactId>
-            <version>2.10.0</version>
-            <scope>test</scope>
-        </dependency>
-        -->
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>5.0.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>cglib</groupId>
-            <artifactId>cglib-nodep</artifactId>
-            <version>3.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
-            <version>2.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.spockframework</groupId>
-            <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.groovy</groupId>
-                    <artifactId>groovy-all</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.codehaus.groovy</groupId>
-            <artifactId>groovy-all</artifactId>
-            <version>${groovy.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -144,27 +96,31 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
+                            <!--The RuntimeTypeAdapterFactory and SparkServlet were copied verbatim from other locations-->
+                            <!--and are unchanged and should not ever change.-->
+                            <excludes>
+                                <exclude>**/RuntimeTypeAdapterFactory.class</exclude>
+                                <exclude>**/SparkServlet.class</exclude>
+                            </excludes>
                             <haltOnFailure>true</haltOnFailure>
                             <rules>
                                 <rule>
                                     <element>BUNDLE</element>
                                     <limits>
-                                        <!--Test coverage is low since the RuntimeTypeAdapterFactory and SparkServlet were copied verbatim from other locations-->
-                                        <!--and are unchanged and should not ever change.-->
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.38</minimum>
+                                            <minimum>0.49</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.36</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.31</minimum>
+                                            <minimum>0.52</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/config-handler-router/src/main/java/org/codice/admin/router/ConfigurationHandlerRouter.java
+++ b/config-handler-router/src/main/java/org/codice/admin/router/ConfigurationHandlerRouter.java
@@ -36,6 +36,8 @@ import org.slf4j.LoggerFactory;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import spark.Request;
+import spark.Response;
 import spark.servlet.SparkApplication;
 
 public class ConfigurationHandlerRouter implements SparkApplication {
@@ -44,6 +46,16 @@ public class ConfigurationHandlerRouter implements SparkApplication {
 
     public static final String APPLICATION_JSON = "application/json";
 
+    public static final String CONFIG_HANDLER_ID = "configHanderId";
+
+    public static final String TEST_ID = "testId";
+
+    public static final String PERSIST_ID = "persistId";
+
+    public static final String PROBE_ID = "probeId";
+
+    public static final String NO_CONFIG_ID_MSG = "No configuration handler with id of \"%s\" found.";
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfigurationHandlerRouter.class);
 
     private List<ConfigurationHandler> handlers = new ArrayList<>();
@@ -51,102 +63,17 @@ public class ConfigurationHandlerRouter implements SparkApplication {
     @Override
     public void init() {
 
-        post("/test/:configHandlerId/:testId", (req, res) -> {
-            Report testReport = new Report();
-            String configHandlerId = req.params("configHandlerId");
-            String testId = req.params("testId");
-            ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
-            if (configHandler == null) {
-                res.status(400);
-                return testReport.addMessage(createInvalidFieldMsg(
-                        "No configuration handler with id of \"" + configHandlerId + "\" found.",
-                        CONFIGURATION_TYPE_FIELD));
-            }
+        post(String.format("/test/:%s/:%s", CONFIG_HANDLER_ID, TEST_ID), this::test, this::toJson);
 
-            Configuration config = getGsonParser().fromJson(req.body(), Configuration.class);
-            testReport = configHandler.test(testId, config);
+        post(String.format("/persist/:%s/:%s", CONFIG_HANDLER_ID, PERSIST_ID), this::persist, this::toJson);
 
-            if (testReport.containsUnsuccessfulMessages()) {
-                res.status(400);
-            }
+        post(String.format("/probe/:%s/:%s", CONFIG_HANDLER_ID, PROBE_ID), this::probe, this::toJson);
 
-            return testReport;
-        }, this::toJson);
+        get(String.format("/configurations/:%s", CONFIG_HANDLER_ID), this::configurations, this::toJson);
 
-        post("/persist/:configHandlerId/:persistId", (req, res) -> {
-            Report persistReport = new Report();
-            String configHandlerId = req.params("configHandlerId");
-            String persistId = req.params("persistId");
-            ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
-            if (configHandler == null) {
-                res.status(400);
-                return persistReport.addMessage(createInvalidFieldMsg(
-                        "No configuration handler with id of \"" + configHandlerId + "\" found.",
-                        CONFIGURATION_TYPE_FIELD));
-            }
+        get("/capabilities", (req, res) -> getCapabilities(), this::toFilteredJson);
 
-            Configuration config = getGsonParser().fromJson(req.body(), Configuration.class);
-            persistReport = configHandler.persist(persistId, config);
-
-            if (persistReport.containsUnsuccessfulMessages()) {
-                res.status(400);
-            }
-
-            return persistReport;
-        }, this::toJson);
-
-        post("/probe/:configHandlerId/:probeId", (req, res) -> {
-            ProbeReport probeReport = new ProbeReport();
-            String configHandlerId = req.params("configHandlerId");
-            String probeId = req.params("probeId");
-            ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
-
-            if (configHandler == null) {
-                res.status(400);
-                return probeReport.addMessage(createInvalidFieldMsg(
-                        "No configuration handler with id of \"" + configHandlerId + "\" found.",
-                        CONFIGURATION_TYPE_FIELD));
-            }
-
-            Configuration config = getGsonParser().fromJson(req.body(), Configuration.class);
-            probeReport = configHandler.probe(probeId, config);
-
-            if (probeReport.containsUnsuccessfulMessages()) {
-                res.status(400);
-            }
-
-            return probeReport;
-        }, this::toJson);
-
-        get("/configurations/:configHandlerId", (req, res) -> {
-            String configHandlerId = req.params("configHandlerId");
-            ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
-            if (configHandler == null) {
-                res.status(400);
-                return new Report(createInvalidFieldMsg(
-                        "No configuration handler with id of \"" + configHandlerId + "\" found.",
-                        CONFIGURATION_TYPE_FIELD));
-            }
-            return configHandler.getConfigurations();
-        }, this::toJson);
-
-        get("/capabilities",
-                (req, res) -> handlers.stream()
-                        .map(handler -> handler.getCapabilities())
-                        .collect(Collectors.toList()),
-                this::toFilteredJson);
-
-        get("/capabilities/:configHandlerId", (req, res) -> {
-            String configHandlerId = req.params("configHandlerId");
-            ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
-            if (configHandler == null) {
-                res.status(400);
-                return new Report(createInvalidFieldMsg(
-                        "No configuration handler with id of: " + configHandlerId + " found.",
-                        configHandlerId));
-            }
-            return configHandler.getCapabilities();
-        }, this::toFilteredJson);
+        get(String.format("/capabilities/:%s", CONFIG_HANDLER_ID), this::configCapabilities, this::toFilteredJson);
 
         after("/*", (req, res) -> res.type(APPLICATION_JSON));
 
@@ -156,6 +83,97 @@ public class ConfigurationHandlerRouter implements SparkApplication {
             res.type(APPLICATION_JSON);
             res.body(exToJSON(ex));
         });
+    }
+
+    protected Report test(Request req, Response res) {
+        Report testReport = new Report();
+
+        String configHandlerId = req.params(CONFIG_HANDLER_ID);
+        String testId = req.params(TEST_ID);
+        ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
+        if(configHandler == null) {
+            res.status(400);
+            return testReport.addMessage(createInvalidFieldMsg(String.format(NO_CONFIG_ID_MSG, configHandlerId), CONFIGURATION_TYPE_FIELD));
+        }
+
+        Configuration config = getGsonParser().fromJson(req.body(), Configuration.class);
+        testReport = configHandler.test(testId, config);
+
+        if (testReport.containsUnsuccessfulMessages()) {
+            res.status(400);
+        }
+
+        return testReport;
+    }
+
+    protected Report persist(Request req, Response res) {
+        Report persistReport = new Report();
+
+        String configHandlerId = req.params(CONFIG_HANDLER_ID);
+        String persistId = req.params(PERSIST_ID);
+
+        ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
+        if(configHandler == null) {
+            res.status(400);
+            return persistReport.addMessage(createInvalidFieldMsg(String.format(NO_CONFIG_ID_MSG, configHandlerId), CONFIGURATION_TYPE_FIELD));
+        }
+
+        Configuration config = getGsonParser().fromJson(req.body(), Configuration.class);
+        persistReport = configHandler.persist(persistId, config);
+
+        if (persistReport.containsUnsuccessfulMessages()) {
+            res.status(400);
+        }
+
+        return persistReport;
+    }
+
+    protected Report probe(Request req, Response res) {
+        Report probeReport = new ProbeReport();
+
+        String configHandlerId = req.params(CONFIG_HANDLER_ID);
+        String probeId = req.params(PROBE_ID);
+        ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
+
+        if(configHandler == null) {
+            res.status(400);
+            return probeReport.addMessage(createInvalidFieldMsg(String.format(NO_CONFIG_ID_MSG, configHandlerId), CONFIGURATION_TYPE_FIELD));
+        }
+
+        Configuration config = getGsonParser().fromJson(req.body(), Configuration.class);
+        probeReport = configHandler.probe(probeId, config);
+
+        if (probeReport.containsUnsuccessfulMessages()) {
+            res.status(400);
+        }
+
+        return probeReport;
+    }
+
+    protected Object getCapabilities() {
+        return handlers.stream()
+                .map(ConfigurationHandler::getCapabilities)
+                .collect(Collectors.toList());
+    }
+
+    protected Object configCapabilities(Request req, Response res) {
+        String configHandlerId = req.params(CONFIG_HANDLER_ID);
+        ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
+        if(configHandler == null) {
+            res.status(400);
+            return new Report(createInvalidFieldMsg(String.format(NO_CONFIG_ID_MSG, configHandlerId), CONFIGURATION_TYPE_FIELD));
+        }
+        return configHandler.getCapabilities();
+    }
+
+    protected Object configurations(Request req, Response res) {
+        String configHandlerId = req.params(CONFIG_HANDLER_ID);
+        ConfigurationHandler configHandler = getConfigurationHandler(configHandlerId);
+        if(configHandler == null) {
+            res.status(400);
+            return new Report(createInvalidFieldMsg(String.format(NO_CONFIG_ID_MSG, configHandlerId), CONFIGURATION_TYPE_FIELD));
+        }
+        return configHandler.getConfigurations();
     }
 
     private String exToJSON(Exception ex) {
@@ -177,7 +195,7 @@ public class ConfigurationHandlerRouter implements SparkApplication {
         RuntimeTypeAdapterFactory rtaf = RuntimeTypeAdapterFactory.of(Configuration.class,
                 CONFIGURATION_TYPE_FIELD);
         handlers.stream()
-                .map(handler -> handler.getConfigurationType())
+                .map(ConfigurationHandler::getConfigurationType)
                 .forEach(configType -> rtaf.registerSubtype(configType.configClass(),
                         configType.configTypeName()));
 

--- a/config-handler-router/src/main/java/org/codice/admin/router/ConfigurationHandlerRouterException.java
+++ b/config-handler-router/src/main/java/org/codice/admin/router/ConfigurationHandlerRouterException.java
@@ -1,0 +1,47 @@
+package org.codice.admin.router;
+
+/**
+ * The {@code ConfigurationHandlerRouterException} will be thrown when an unknown {@link Throwable} has occurred
+ * that is unable to be handled up by the {@link ConfigurationHandlerRouter}.
+ */
+public class ConfigurationHandlerRouterException extends Exception {
+
+    /**
+     * Instantiates a new ConfigurationHandlerRouterException from a given string.
+     *
+     * @param string
+     *            the string to use for the exception.
+     */
+    public ConfigurationHandlerRouterException(String string) {
+        super(string);
+    }
+
+    /**
+     * Instantiates a new PluginExecutionException.
+     */
+    public ConfigurationHandlerRouterException() {
+        super();
+    }
+
+    /**
+     * Instantiates a new ConfigurationHandlerRouterException with a message.
+     *
+     * @param message
+     *            the message
+     * @param throwable
+     *            the throwable
+     */
+    public ConfigurationHandlerRouterException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+    /**
+     * Instantiates a new ConfigurationHandlerRouterException.
+     *
+     * @param throwable
+     *            the throwable
+     */
+    public ConfigurationHandlerRouterException(Throwable throwable) {
+        super(throwable);
+    }
+}

--- a/config-handler-router/src/test/groovy/org/codice/admin/router/ConfigurationHandlerRouterTest.groovy
+++ b/config-handler-router/src/test/groovy/org/codice/admin/router/ConfigurationHandlerRouterTest.groovy
@@ -1,0 +1,294 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.admin.router
+
+import org.codice.ddf.admin.api.config.Configuration
+import org.codice.ddf.admin.api.config.ConfigurationType
+import org.codice.ddf.admin.api.config.sources.WfsSourceConfiguration
+import org.codice.ddf.admin.api.handler.ConfigurationHandler
+import org.codice.ddf.admin.api.handler.report.CapabilitiesReport
+import org.codice.ddf.admin.api.handler.report.ProbeReport
+import org.codice.ddf.admin.api.handler.report.Report
+import spark.Request
+import spark.Response
+import spock.lang.Specification
+
+class ConfigurationHandlerRouterTest extends Specification {
+    
+    static final FAILURE_MESSAGE = String.format(ConfigurationHandlerRouter.NO_CONFIG_ID_MSG, NON_MATCHING_ID)
+
+    static final CONFIGURATION_TYPE = "configurationType"
+
+    static final MATCHING_ID = "myId"
+
+    static final NON_MATCHING_ID = "notMyId"
+
+    static final METHOD_ID = "someId"
+
+    ConfigurationHandlerRouter configurationHandlerRouter
+
+    Response response
+
+    ConfigurationHandler configurationHandler
+
+    Request request
+
+    def setup() {
+        configurationHandlerRouter = new ConfigurationHandlerRouter()
+    }
+
+    def 'test test(Request, Response) config handler success'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        def report = mockReport(false)
+
+        when:
+        configurationHandlerRouter.test(request, response)
+
+
+        then:
+        1 * configurationHandler.test(METHOD_ID, _ as Configuration) >> report
+        0 * response.status(400)
+    }
+
+    def 'test test(Request, Response) no config handler'() {
+        setup:
+        prepareConfigHandler(NON_MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        when:
+        def report = configurationHandlerRouter.test(request, response)
+
+        then:
+        report.messages().size() == 1
+        report.messages().get(0).message() == FAILURE_MESSAGE
+        report.messages().get(0).configFieldId() == ConfigurationHandlerRouter.CONFIGURATION_TYPE_FIELD
+        report.containsFailureMessages()
+        0 * configurationHandler.test(_ as String, _ as Configuration)
+        1 * response.status(400)
+    }
+
+    def 'test test(Request, Response) config handler but fail test'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        def report = mockReport(true)
+
+        when:
+        configurationHandlerRouter.test(request, response)
+
+
+        then:
+        1 * configurationHandler.test(METHOD_ID, _ as Configuration) >> report
+        1 * response.status(400)
+    }
+
+    def 'test persist(Request, Response) config handler success'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.PERSIST_ID)
+
+        def report = mockReport(false)
+
+        when:
+        configurationHandlerRouter.persist(request, response)
+
+
+        then:
+        1 * configurationHandler.persist(METHOD_ID, _ as Configuration) >> report
+        0 * response.status(400)
+    }
+
+    def 'test persist(Request, Response) no config handler'() {
+        setup:
+        prepareConfigHandler(NON_MATCHING_ID, ConfigurationHandlerRouter.PERSIST_ID)
+
+        when:
+        def report = configurationHandlerRouter.persist(request, response)
+
+        then:
+        report.messages().size() == 1
+        report.messages().get(0).message() == FAILURE_MESSAGE
+        report.messages().get(0).configFieldId() == ConfigurationHandlerRouter.CONFIGURATION_TYPE_FIELD
+        report.containsFailureMessages()
+        0 * configurationHandler.persist(_ as String, _ as Configuration)
+        1 * response.status(400)
+    }
+
+    def 'test persist(Request, Response) config handler but fail persist'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.PERSIST_ID)
+
+        def report = mockReport(true)
+
+        when:
+        configurationHandlerRouter.persist(request, response)
+
+        then:
+        1 * configurationHandler.persist(METHOD_ID, _ as Configuration) >> report
+        1 * response.status(400)
+    }
+
+    def 'test probe(Request, Response) config handler success'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.PROBE_ID)
+
+        def report = Mock(ProbeReport) {
+            containsUnsuccessfulMessages() >> false
+        }
+
+        when:
+        configurationHandlerRouter.probe(request, response)
+
+
+        then:
+        1 * configurationHandler.probe(METHOD_ID, _ as Configuration) >> report
+        0 * response.status(400)
+    }
+
+    def 'test probe(Request, Response) no config handler'() {
+        setup:
+        prepareConfigHandler(NON_MATCHING_ID, ConfigurationHandlerRouter.PROBE_ID)
+
+        when:
+        def report = configurationHandlerRouter.probe(request, response)
+
+        then:
+        report.messages().size() == 1
+        report.messages().get(0).message() == FAILURE_MESSAGE
+        report.messages().get(0).configFieldId() == ConfigurationHandlerRouter.CONFIGURATION_TYPE_FIELD
+        report.containsFailureMessages()
+        0 * configurationHandler.probe(_ as String, _ as Configuration)
+        1 * response.status(400)
+    }
+
+    def 'test probe(Request, Response) config handler but fail persist'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.PROBE_ID)
+
+        def report = Mock(ProbeReport) {
+            containsUnsuccessfulMessages() >> true
+        }
+
+        when:
+        configurationHandlerRouter.probe(request, response)
+
+
+        then:
+        1 * configurationHandler.probe(METHOD_ID, _ as Configuration) >> report
+        1 * response.status(400)
+    }
+
+    def 'test getCapabilities()'() {
+        setup:
+        prepareConfigHandler(NON_MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        when:
+        def reports = (List<CapabilitiesReport>)configurationHandlerRouter.getCapabilities()
+
+        then:
+        reports.size() == 1
+        reports.get(0).getConfigurationType() == CONFIGURATION_TYPE
+    }
+
+    def 'test configCapabilties(Request, Response) success'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        when:
+        configurationHandlerRouter.configCapabilities(request, response)
+
+        then:
+        1 * configurationHandler.getCapabilities()
+        configurationHandler.getCapabilities().configurationType == CONFIGURATION_TYPE
+    }
+
+    def 'test configCapabilties(Request, Response) null config handler'() {
+        setup:
+        prepareConfigHandler(NON_MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        when:
+        def report = (Report) configurationHandlerRouter.configCapabilities(request, response)
+
+        then:
+        1 * response.status(400)
+        0 * configurationHandler.getCapabilities()
+        report.messages().size() == 1
+        report.messages().get(0).message() == FAILURE_MESSAGE
+        report.messages().get(0).configFieldId() == ConfigurationHandlerRouter.CONFIGURATION_TYPE_FIELD
+        report.containsFailureMessages()
+    }
+
+    def 'test configurations(Request, Response) success'() {
+        setup:
+        prepareConfigHandler(MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        when:
+        configurationHandlerRouter.configurations(request, response)
+
+        then:
+        1 * configurationHandler.getConfigurations()
+        configurationHandler.getCapabilities().configurationType == CONFIGURATION_TYPE
+    }
+
+    def 'test configurations(Request, Response) null config handler'() {
+        setup:
+        prepareConfigHandler(NON_MATCHING_ID, ConfigurationHandlerRouter.TEST_ID)
+
+        when:
+        def report = (Report) configurationHandlerRouter.configurations(request, response)
+
+        then:
+        1 * response.status(400)
+        0 * configurationHandler.configurations()
+        report.messages().size() == 1
+        report.messages().get(0).message() == FAILURE_MESSAGE
+        report.messages().get(0).configFieldId() == ConfigurationHandlerRouter.CONFIGURATION_TYPE_FIELD
+        report.containsFailureMessages()
+    }
+
+    def prepareConfigHandler(String configHandlerId, String id) {
+        response = Mock(Response)
+        configurationHandler = mockConfigurationHandler()
+        request = mockRequest(configHandlerId, id)
+
+        configurationHandlerRouter.setConfigurationHandlers([configurationHandler])
+    }
+
+    def mockConfigurationHandler() {
+        return Mock(ConfigurationHandler) {
+            getConfigurationHandlerId() >> MATCHING_ID
+            getConfigurationType() >> Mock(ConfigurationType) {
+                configClass() >> WfsSourceConfiguration
+                configTypeName() >> "sources"
+            }
+            getCapabilities() >> Mock(CapabilitiesReport) {
+                getConfigurationType() >> CONFIGURATION_TYPE
+            }
+        }
+    }
+
+    def mockRequest(String configHandlerId, String id) {
+        return Mock(Request) {
+            params(ConfigurationHandlerRouter.CONFIG_HANDLER_ID) >> configHandlerId
+            params(id) >> METHOD_ID
+            body() >> "{\"configurationType\":\"sources\",\"sourceHostName\":\"localhost\",\"sourcePort\":8993}"
+        }
+    }
+
+    def mockReport(boolean containsUnsuccessfulMessage) {
+        return Mock(Report) {
+            containsUnsuccessfulMessages() >> containsUnsuccessfulMessage
+        }
+    }
+}


### PR DESCRIPTION
- Refactor `ConfigurationHandlerRouter` methods
- Add unit tests for `ConfigurationHandlerRouter`

@coyotesqrl @tbatie @adimka 

Test:
Full build. Verify source and LDAP wizard functionality, and `/capabilities`, `/capabilites/{handlerId}`, and `/configurations/{handlerId}` all work as expected.