### PR TITLE
DDF-2773: Add Progress Icon on Delete & Error Messages to Homepage Configs

### DIFF
--- a/ui/src/main/webapp/home/actions.js
+++ b/ui/src/main/webapp/home/actions.js
@@ -1,0 +1,54 @@
+import { poll } from 'redux-polling'
+import { get, post } from 'redux-fetch'
+
+// actions
+
+export const setConfigs = (id, value) => ({ type: 'HOME/SET_CONFIGS', id, value })
+export const beginDelete = (servicePid) => ({ type: 'HOME/BEGIN_SUBMITTING_CONFIGS', servicePid })
+export const endDelete = (servicePid) => ({ type: 'HOME/END_SUBMITTING_CONFIGS', servicePid })
+export const setErrors = (servicePid, errors) => ({ type: 'HOME/SET_ERRORS', servicePid, errors })
+export const clearErrors = (servicePid) => ({ type: 'HOME/CLEAR_ERRORS', servicePid })
+
+// async actions
+
+export const retrieve = (configHandlerId) => async (dispatch) => {
+  const res = await dispatch(get('/admin/beta/config/configurations/' + configHandlerId))
+  const json = await res.json()
+
+  if (res.status === 200) {
+    dispatch(setConfigs(configHandlerId, json))
+  }
+}
+
+export const refresh = poll('home', () => (dispatch) =>
+  Promise.all([
+    dispatch(retrieve('sources')),
+    dispatch(retrieve('ldap'))
+  ])
+)
+
+export const deleteConfig = ({ configurationHandlerId, configurationType, factoryPid, servicePid }) => async (dispatch) => {
+  dispatch(beginDelete(servicePid))
+  const url = '/admin/beta/config/persist/' + configurationHandlerId + '/delete'
+  const body = JSON.stringify({configurationType, factoryPid, servicePid})
+
+  const res = await dispatch(post(url, {body}))
+  const json = await res.json()
+
+  if (containsErrors(json)) {
+    dispatch(setErrors(servicePid, filterErrors(json.messages)))
+    dispatch(endDelete(servicePid))
+  } else {
+    dispatch(refresh())
+  }
+}
+
+// utility methods
+
+const containsErrors = (json) => {
+  return json.messages.some((message) => (message.type === 'FAILURE'))
+}
+
+const filterErrors = (messages) => {
+  return messages.filter((message) => (message.type === 'FAILURE'))
+}

--- a/ui/src/main/webapp/home/reducer.js
+++ b/ui/src/main/webapp/home/reducer.js
@@ -1,0 +1,44 @@
+import { combineReducers } from 'redux-immutable'
+import { Map } from 'immutable'
+
+export const getSourceConfigs = (state) => state.getIn(['home', 'configs', 'sources'])
+export const getLdapConfigs = (state) => state.getIn(['home', 'configs', 'ldap'])
+export const getSubmittingPids = (state) => state.getIn(['home', 'submitting']).toJS()
+export const getConfigErrors = (state, servicePid) => state.getIn(['home', 'errors', servicePid], [])
+
+const configs = (state = Map(), { type, id, value = [] }) => {
+  switch (type) {
+    case 'HOME/SET_CONFIGS':
+      return state.set(id, value)
+    default:
+      return state
+  }
+}
+
+const submitting = (state = Map(), { type, servicePid, value = [] }) => {
+  switch (type) {
+    case 'HOME/BEGIN_SUBMITTING_CONFIGS':
+      return state.set(servicePid, true)
+    case 'HOME/END_SUBMITTING_CONFIGS':
+      return state.delete(servicePid)
+    case 'HOME/SET_CONFIGS':
+      return state.filter((v, key) => (value.some((config) => (config.servicePid === key))))
+    default:
+      return state
+  }
+}
+
+const errors = (state = Map(), { type, servicePid, errors = [] }) => {
+  switch (type) {
+    case 'HOME/SET_ERRORS':
+      return state.set(servicePid, errors)
+    case 'HOME/CLEAR_ERRORS':
+      return state.delete(servicePid)
+    case 'HOME/CLEAR_ALL_ERRORS':
+      return state.clear()
+    default:
+      return state
+  }
+}
+
+export default combineReducers({ configs, submitting, errors })

--- a/ui/src/main/webapp/home/styles.less
+++ b/ui/src/main/webapp/home/styles.less
@@ -27,8 +27,11 @@
   margin: 10px 30px;
 }
 
-.config {
+.outerSpinner{
   margin: 20px;
+}
+
+.innerSpinner {
   padding: 20px;
 }
 
@@ -36,4 +39,16 @@
   font-size: 14px;
   position: relative;
   color: rgba(0, 0, 0, 0.541176);
+}
+
+.error {
+  margin-top: 15px;
+  color: white;
+  background: rgb(244, 67, 54);
+  padding: 10px;
+  box-sizing: border-box;
+  box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
+  border-radius: 2px;
+  font-size: 14px;
+  font-weight: bold;
 }

--- a/ui/src/main/webapp/lib/components/Spinner.js
+++ b/ui/src/main/webapp/lib/components/Spinner.js
@@ -6,7 +6,7 @@ import CircularProgress from 'material-ui/CircularProgress'
 import * as styles from './styles.less'
 
 export default ({ submitting = false, children }) => (
-  <div>
+  <div style={{ position: 'relative' }}>
     {submitting
       ? <div className={styles.submitting}>
         <Flexbox justifyContent='center' alignItems='center' width='100%'>

--- a/ui/src/main/webapp/lib/components/Stage.js
+++ b/ui/src/main/webapp/lib/components/Stage.js
@@ -2,11 +2,17 @@ import React from 'react'
 
 import Paper from 'material-ui/Paper'
 
+import Spinner from './Spinner'
+
 import * as styles from './styles.less'
 
-export default ({ children }) => (
+export default ({ children, submitting }) => (
   <Paper className={styles.main}>
-    {children}
+    <Spinner submitting={submitting}>
+      <div className={styles.innerSpinner}>
+        {children}
+      </div>
+    </Spinner>
   </Paper>
 )
 

--- a/ui/src/main/webapp/lib/components/styles.less
+++ b/ui/src/main/webapp/lib/components/styles.less
@@ -16,10 +16,15 @@
 
 .main {
   margin: 20px;
-  padding: 40px;
+  padding: 0px;
   width: 800px;
   position: relative;
   box-sizing: border-box;
+}
+
+.innerSpinner {
+  padding: 40px;
+  position: relative
 }
 
 .submitting {

--- a/ui/src/main/webapp/lib/system-usage/Banners.js
+++ b/ui/src/main/webapp/lib/system-usage/Banners.js
@@ -15,7 +15,6 @@ let Banners = ({ settings, fetchSystemUsageProperties, children }) => {
       color: settings.textColor,
       backgroundColor: settings.style
     }
-    console.log('should be the banners')
 
     return (
       <div>
@@ -37,7 +36,6 @@ let Banners = ({ settings, fetchSystemUsageProperties, children }) => {
       </div>
     )
   } else {
-    console.log('not the banners')
     return (
       <div>
         <Mount

--- a/ui/src/main/webapp/reducer/index.js
+++ b/ui/src/main/webapp/reducer/index.js
@@ -18,7 +18,7 @@ export const isPolling = (state, id) => pollingSelectors.isPolling(state.get('po
 
 import wizard, * as ldap from 'admin-wizard/reducer'
 import sourceWizard from '../wizards/sources/reducer'
-import home from '../home'
+import home from '../home/reducer'
 import wcpm, * as webContext from '../adminTools/webContextPolicyManager/reducer'
 import systemUsage from 'system-usage/reducer'
 

--- a/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
@@ -7,7 +7,6 @@ import { editConfig } from 'admin-wizard/actions'
 import Mount from 'react-mount'
 
 import Stage from 'components/Stage'
-import Spinner from 'components/Spinner'
 import Title from 'components/Title'
 import Description from 'components/Description'
 import Action from 'components/Action'
@@ -136,33 +135,31 @@ const LdapAttributeMappingStage = (props) => {
   } = props
 
   return (
-    <Stage>
+    <Stage submitting={submitting}>
       <Mount probeId='subject-attributes' on={probe} />
-      <Spinner submitting={submitting}>
-        <Title>LDAP User Attribute Mapping</Title>
-        <Description>
-          In order to authorize users, their attributes must be mapped to the Security Token
-          Service (STS) claims. Not all attributes must be mapped but any unmapped attributes
-          will not be used for authorization.
-        </Description>
+      <Title>LDAP User Attribute Mapping</Title>
+      <Description>
+        In order to authorize users, their attributes must be mapped to the Security Token
+        Service (STS) claims. Not all attributes must be mapped but any unmapped attributes
+        will not be used for authorization.
+      </Description>
 
-        <AttributeMapper disabled={disabled} configs={configs} />
+      <AttributeMapper disabled={disabled} configs={configs} />
 
-        <ActionGroup>
-          <Action
-            secondary
-            label='back'
-            onClick={prev}
-            disabled={disabled} />
-          <Action
-            primary
-            label='next'
-            onClick={test}
-            disabled={disabled || Object.keys(attributeMappings).length === 0}
-            testId='attribute-mapping'
-            nextStageId='confirm' />
-        </ActionGroup>
-      </Spinner>
+      <ActionGroup>
+        <Action
+          secondary
+          label='back'
+          onClick={prev}
+          disabled={disabled} />
+        <Action
+          primary
+          label='next'
+          onClick={test}
+          disabled={disabled || Object.keys(attributeMappings).length === 0}
+          testId='attribute-mapping'
+          nextStageId='confirm' />
+      </ActionGroup>
     </Stage>
   )
 }

--- a/ui/src/main/webapp/wizards/ldap/stages/bind-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/bind-settings.js
@@ -8,7 +8,6 @@ import Description from 'components/Description'
 import Action from 'components/Action'
 import ActionGroup from 'components/ActionGroup'
 import Message from 'components/Message'
-import Spinner from 'components/Spinner'
 
 import {
   Input,
@@ -41,59 +40,57 @@ const BindSettings = (props) => {
   }
 
   return (
-    <Stage>
+    <Stage submitting={submitting}>
       <Mount
         on={setDefaults}
         bindUser={ldapType === 'activeDirectory' ? 'user@domain' : 'cn=admin'}
         bindUserPassword='secret'
         bindUserMethod='Simple' />
 
-      <Spinner submitting={submitting}>
-        <Title>LDAP Bind User Settings</Title>
-        <Description>
-          In order for the system to retrieve information from the LDAP store, it needs to bind
-          a user that has permission to search it. This user will be used by the system whenever
-          it needs to access the LDAP store.
-        </Description>
-        <Description> {/* todo - left justify this one? maybe not - test if it looks bad */}
-          User credentials may be provided as a DN (distinguished name), User ID, or in the format UserID@Realm.
-          The requirements for different LDAP servers vary; please contact your LDAP administrator if you need guidance.
-        </Description>
+      <Title>LDAP Bind User Settings</Title>
+      <Description>
+        In order for the system to retrieve information from the LDAP store, it needs to bind
+        a user that has permission to search it. This user will be used by the system whenever
+        it needs to access the LDAP store.
+      </Description>
+      <Description> {/* todo - left justify this one? maybe not - test if it looks bad */}
+        User credentials may be provided as a DN (distinguished name), User ID, or in the format UserID@Realm.
+        The requirements for different LDAP servers vary; please contact your LDAP administrator if you need guidance.
+      </Description>
 
-        <Input id='bindUser' disabled={disabled} label='Bind User' />
-        <Password id='bindUserPassword' disabled={disabled} label='Bind User Password' />
-        <Select id='bindUserMethod'
-          label='Bind User Method'
+      <Input id='bindUser' disabled={disabled} label='Bind User' />
+      <Password id='bindUserPassword' disabled={disabled} label='Bind User Password' />
+      <Select id='bindUserMethod'
+        label='Bind User Method'
+        disabled={disabled}
+        options={bindUserMethodOptions} />
+      {/* removed options: 'SASL', 'GSSAPI SASL' */}
+      {/* TODO GSSAPI SASL only */}
+      {/* <Input id='bindKdcAddress' disabled={disabled} label='KDC Address (for Kerberos authentication)' /> */}
+      {/* TODO GSSAPI and Digest MD5 SASL only */}
+      {/* Realm is needed for Kerberos and MD5 auth, currently only MD5 is supported by the wizard */}
+      {
+        (bindUserMethod === 'Digest MD5 SASL')
+          ? (<Input id='bindRealm' disabled={disabled} label='Realm (for Digest MD5 authentication)' />)
+          : null
+      }
+
+      <ActionGroup>
+        <Action
+          secondary
+          label='back'
+          onClick={prev}
+          disabled={disabled} />
+        <Action
+          primary
+          label='next'
+          onClick={test}
           disabled={disabled}
-          options={bindUserMethodOptions} />
-        {/* removed options: 'SASL', 'GSSAPI SASL' */}
-        {/* TODO GSSAPI SASL only */}
-        {/* <Input id='bindKdcAddress' disabled={disabled} label='KDC Address (for Kerberos authentication)' /> */}
-        {/* TODO GSSAPI and Digest MD5 SASL only */}
-        {/* Realm is needed for Kerberos and MD5 auth, currently only MD5 is supported by the wizard */}
-        {
-          (bindUserMethod === 'Digest MD5 SASL')
-            ? (<Input id='bindRealm' disabled={disabled} label='Realm (for Digest MD5 authentication)' />)
-            : null
-        }
+          nextStageId='directory-settings'
+          testId='bind' />
+      </ActionGroup>
 
-        <ActionGroup>
-          <Action
-            secondary
-            label='back'
-            onClick={prev}
-            disabled={disabled} />
-          <Action
-            primary
-            label='next'
-            onClick={test}
-            disabled={disabled}
-            nextStageId='directory-settings'
-            testId='bind' />
-        </ActionGroup>
-
-        {messages.map((msg, i) => <Message key={i} {...msg} />)}
-      </Spinner>
+      {messages.map((msg, i) => <Message key={i} {...msg} />)}
     </Stage>
   )
 }

--- a/ui/src/main/webapp/wizards/ldap/stages/configure-embedded-ldap.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/configure-embedded-ldap.js
@@ -8,7 +8,6 @@ import Description from 'components/Description'
 import Action from 'components/Action'
 import ActionGroup from 'components/ActionGroup'
 import Message from 'components/Message'
-import Spinner from 'components/Spinner'
 
 const useCaseDescription = (ldapUseCase) => {
   switch (ldapUseCase) {
@@ -36,46 +35,44 @@ const ConfigureEmbeddedLdap = (props) => {
   } = props
 
   return (
-    <Stage>
-      <Spinner submitting={submitting}>
-        <Mount on={setDefaults}
-          embeddedLdapPort={1389}
-          embeddedLdapsPort={1636}
-          embeddedLdapAdminPort={4444}
-          embeddedLdapStorageLocation='etc/org.codice.opendj/ldap'
-          ldifPath='etc/org.codice.opendj/ldap' />
-        <Title>Are You Sure You Want to Install Embedded LDAP?</Title>
-        <Description>
-          <div> { /* todo - add a 'warning-style' box around this <p/> */ }
-            <p>
-              The embedded LDAP server is used for testing purposes only and
-              should not be used in a production environment.
-            </p>
-          </div>
+    <Stage submitting={submitting}>
+      <Mount on={setDefaults}
+        embeddedLdapPort={1389}
+        embeddedLdapsPort={1636}
+        embeddedLdapAdminPort={4444}
+        embeddedLdapStorageLocation='etc/org.codice.opendj/ldap'
+        ldifPath='etc/org.codice.opendj/ldap' />
+      <Title>Are You Sure You Want to Install Embedded LDAP?</Title>
+      <Description>
+        <div> { /* todo - add a 'warning-style' box around this <p/> */ }
           <p>
-          Installing Embedded LDAP will start up the internal LDAP and
-            configure it as a {useCaseDescription(ldapUseCase)}.
+            The embedded LDAP server is used for testing purposes only and
+            should not be used in a production environment.
           </p>
-        </Description>
-        <ActionGroup>
-          <Action
-            secondary
-            label='back'
-            onClick={prev}
-            disabled={disabled} />
-          <Action
-            primary
-            label='save'
-            onClick={persist}
-            disabled={disabled}
-            nextStageId='final-stage'
-            configHandlerId='embedded-ldap'
-            configurationType='embedded-ldap'
-            persistId='defaults' />
-        </ActionGroup>
+        </div>
+        <p>
+        Installing Embedded LDAP will start up the internal LDAP and
+          configure it as a {useCaseDescription(ldapUseCase)}.
+        </p>
+      </Description>
+      <ActionGroup>
+        <Action
+          secondary
+          label='back'
+          onClick={prev}
+          disabled={disabled} />
+        <Action
+          primary
+          label='save'
+          onClick={persist}
+          disabled={disabled}
+          nextStageId='final-stage'
+          configHandlerId='embedded-ldap'
+          configurationType='embedded-ldap'
+          persistId='defaults' />
+      </ActionGroup>
 
-        {messages.map((msg, i) => <Message key={i} {...msg} />)}
-      </Spinner>
+      {messages.map((msg, i) => <Message key={i} {...msg} />)}
     </Stage>
   )
 }

--- a/ui/src/main/webapp/wizards/ldap/stages/confirm.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/confirm.js
@@ -8,7 +8,6 @@ import Description from 'components/Description'
 import Action from 'components/Action'
 import ActionGroup from 'components/ActionGroup'
 import Info from 'components/Information'
-import Spinner from 'components/Spinner'
 import Message from 'components/Message'
 import MapDisplay from 'components/MapDisplay'
 
@@ -21,60 +20,58 @@ const useCaseMapping = {
 }
 
 export default ({ disabled, prev, persist, submitting, messages = [], configs }) => (
-  <Stage>
-    <Spinner submitting={submitting}>
-      <Title>LDAP Settings Confirmation</Title>
+  <Stage submitting={submitting}>
+    <Title>LDAP Settings Confirmation</Title>
 
-      <Description>
-        All of the values have been successfully verified. Would you like to
-        save the LDAP configuration?
-      </Description>
+    <Description>
+      All of the values have been successfully verified. Would you like to
+      save the LDAP configuration?
+    </Description>
 
-      <Flexbox flexDirection='column'>
-        <Flexbox flexDirection='row' justifyContent='space-between'>
-          <Flexbox className={confirmationInfo} flexDirection='column'>
-            <Info label='LDAP Function' value={useCaseMapping[configs.ldapUseCase]} />
-            <Info label='Hostname' value={configs.hostName} />
-            <Info label='Port' value={configs.port} />
-            <Info label='Encryption Method' value={configs.encryptionMethod} />
-            <Info label='Base User DN' value={configs.baseUserDn} />
-            <Info label='User Name Attribute' value={configs.userNameAttribute} />
-          </Flexbox>
-          <Flexbox className={confirmationInfo} flexDirection='column'>
-            <Info label='Base Group DN' value={configs.baseGroupDn} />
-            <Info label='Bind User' value={configs.bindUser} />
-            <Info label='Bind User Password' value='*****' />
-            <Info label='Bind User Method' value={configs.bindUserMethod} />
-            <Info label='LDAP Group Object Class' value={configs.groupObjectClass} />
-            <Info label='Group Attribute Holding Member References'
-              value={configs.groupAttributeHoldingMember} />
-            <Info label='Member Attribute Referenced in Groups'
-              value={configs.memberAttributeReferencedInGroup} />
-          </Flexbox>
+    <Flexbox flexDirection='column'>
+      <Flexbox flexDirection='row' justifyContent='space-between'>
+        <Flexbox className={confirmationInfo} flexDirection='column'>
+          <Info label='LDAP Function' value={useCaseMapping[configs.ldapUseCase]} />
+          <Info label='Hostname' value={configs.hostName} />
+          <Info label='Port' value={configs.port} />
+          <Info label='Encryption Method' value={configs.encryptionMethod} />
+          <Info label='Base User DN' value={configs.baseUserDn} />
+          <Info label='User Name Attribute' value={configs.userNameAttribute} />
         </Flexbox>
-        { configs.ldapUseCase !== 'authentication'
-          ? (
-            <MapDisplay label='Attribute Mappings'
-              mapping={configs.attributeMappings} />
-          ) : null }
+        <Flexbox className={confirmationInfo} flexDirection='column'>
+          <Info label='Base Group DN' value={configs.baseGroupDn} />
+          <Info label='Bind User' value={configs.bindUser} />
+          <Info label='Bind User Password' value='*****' />
+          <Info label='Bind User Method' value={configs.bindUserMethod} />
+          <Info label='LDAP Group Object Class' value={configs.groupObjectClass} />
+          <Info label='Group Attribute Holding Member References'
+            value={configs.groupAttributeHoldingMember} />
+          <Info label='Member Attribute Referenced in Groups'
+            value={configs.memberAttributeReferencedInGroup} />
+        </Flexbox>
       </Flexbox>
+      { configs.ldapUseCase !== 'authentication'
+        ? (
+          <MapDisplay label='Attribute Mappings'
+            mapping={configs.attributeMappings} />
+        ) : null }
+    </Flexbox>
 
-      <ActionGroup>
-        <Action
-          secondary
-          label='back'
-          onClick={prev}
-          disabled={disabled} />
-        <Action
-          primary
-          label='save'
-          onClick={persist}
-          disabled={disabled}
-          persistId='create'
-          nextStageId='final-stage' />
-      </ActionGroup>
+    <ActionGroup>
+      <Action
+        secondary
+        label='back'
+        onClick={prev}
+        disabled={disabled} />
+      <Action
+        primary
+        label='save'
+        onClick={persist}
+        disabled={disabled}
+        persistId='create'
+        nextStageId='final-stage' />
+    </ActionGroup>
 
-      {messages.map((msg, i) => <Message key={i} {...msg} />)}
-    </Spinner>
+    {messages.map((msg, i) => <Message key={i} {...msg} />)}
   </Stage>
 )

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -15,7 +15,6 @@ import Title from 'components/Title'
 import Description from 'components/Description'
 import Action from 'components/Action'
 import ActionGroup from 'components/ActionGroup'
-import Spinner from 'components/Spinner'
 import Message from 'components/Message'
 
 import { InputAuto } from 'admin-wizard/inputs'
@@ -98,56 +97,54 @@ const DirectorySettings = (props) => {
   } = props
 
   return (
-    <Stage>
-      <Spinner submitting={submitting}>
-        <Mount on={probe} probeId='dir-struct' />
+    <Stage submitting={submitting}>
+      <Mount on={probe} probeId='dir-struct' />
 
-        <Title>LDAP Directory Structure</Title>
-        <Description>
-          Next we need to configure the directories for users/members and decide which attributes to use.
-          Default values have been filled out below and some other recommended values are available via each
-          field's drop-down menu. This page also has an LDAP Query Tool capable of executing queries
-          against the connected LDAP to assist in customizing these settings.
-        </Description>
-        <InputAuto id='baseUserDn' disabled={disabled} label='Base User DN'
-          tooltip='Distinguished name of the LDAP directory in which users can be found.' />
-        <InputAuto id='userNameAttribute' disabled={disabled} label='User Name Attribute'
-          tooltip='Attribute used to designate the user’s name in LDAP. Typically uid or cn.' />
-        <InputAuto id='baseGroupDn' disabled={disabled} label='Base Group DN'
-          tooltip='Distinguished name of the LDAP directory in which groups can be found.' />
-        {ldapUseCase === 'authenticationAndAttributeStore' || ldapUseCase === 'attributeStore'
-          ? <div>
-            <InputAuto id='groupObjectClass' disabled={disabled} label='LDAP Group ObjectClass'
-              tooltip='ObjectClass that defines the structure for group membership in LDAP. Typically groupOfNames.' />
-            <InputAuto id='groupAttributeHoldingMember' disabled={disabled}
-              label='Group Attribute Holding Member References'
-              tooltip='Multivalued-attribute on the group entry that holds references to users.' />
-            <InputAuto id='memberAttributeReferencedInGroup' disabled={disabled}
-              label='Member Attribute Referenced in Groups'
-              tooltip='The attribute of the user entry that, when combined with the Base User DN,
-              forms the reference value, e.g. XXX=jsmith,ou=users,dc=example,dc=com' />
-          </div>
-          : null}
+      <Title>LDAP Directory Structure</Title>
+      <Description>
+        Next we need to configure the directories for users/members and decide which attributes to use.
+        Default values have been filled out below and some other recommended values are available via each
+        field's drop-down menu. This page also has an LDAP Query Tool capable of executing queries
+        against the connected LDAP to assist in customizing these settings.
+      </Description>
+      <InputAuto id='baseUserDn' disabled={disabled} label='Base User DN'
+        tooltip='Distinguished name of the LDAP directory in which users can be found.' />
+      <InputAuto id='userNameAttribute' disabled={disabled} label='User Name Attribute'
+        tooltip='Attribute used to designate the user’s name in LDAP. Typically uid or cn.' />
+      <InputAuto id='baseGroupDn' disabled={disabled} label='Base Group DN'
+        tooltip='Distinguished name of the LDAP directory in which groups can be found.' />
+      {ldapUseCase === 'authenticationAndAttributeStore' || ldapUseCase === 'attributeStore'
+        ? <div>
+          <InputAuto id='groupObjectClass' disabled={disabled} label='LDAP Group ObjectClass'
+            tooltip='ObjectClass that defines the structure for group membership in LDAP. Typically groupOfNames.' />
+          <InputAuto id='groupAttributeHoldingMember' disabled={disabled}
+            label='Group Attribute Holding Member References'
+            tooltip='Multivalued-attribute on the group entry that holds references to users.' />
+          <InputAuto id='memberAttributeReferencedInGroup' disabled={disabled}
+            label='Member Attribute Referenced in Groups'
+            tooltip='The attribute of the user entry that, when combined with the Base User DN,
+            forms the reference value, e.g. XXX=jsmith,ou=users,dc=example,dc=com' />
+        </div>
+        : null}
 
-        <LdapQueryTool disabled={disabled} />
+      <LdapQueryTool disabled={disabled} />
 
-        <ActionGroup>
-          <Action
-            secondary
-            label='back'
-            onClick={prev}
-            disabled={disabled} />
-          <Action
-            primary
-            label='next'
-            onClick={test}
-            disabled={disabled}
-            testId='dir-struct'
-            nextStageId={ldapUseCase === 'authenticationAndAttributeStore' || ldapUseCase === 'attributeStore' ? 'attribute-mapping' : 'confirm'} />
-        </ActionGroup>
+      <ActionGroup>
+        <Action
+          secondary
+          label='back'
+          onClick={prev}
+          disabled={disabled} />
+        <Action
+          primary
+          label='next'
+          onClick={test}
+          disabled={disabled}
+          testId='dir-struct'
+          nextStageId={ldapUseCase === 'authenticationAndAttributeStore' || ldapUseCase === 'attributeStore' ? 'attribute-mapping' : 'confirm'} />
+      </ActionGroup>
 
-        {messages.map((msg, i) => <Message key={i} {...msg} />)}
-      </Spinner>
+      {messages.map((msg, i) => <Message key={i} {...msg} />)}
     </Stage>
   )
 }

--- a/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/network-settings.js
@@ -8,7 +8,6 @@ import Description from 'components/Description'
 import Action from 'components/Action'
 import ActionGroup from 'components/ActionGroup'
 import Message from 'components/Message'
-import Spinner from 'components/Spinner'
 
 import {
   Hostname,
@@ -27,44 +26,42 @@ const NetworkSettings = (props) => {
   } = props
 
   return (
-    <Stage>
+    <Stage submitting={submitting}>
       <Mount
         on={setDefaults}
         port={636}
         encryptionMethod='LDAPS' />
-      <Spinner submitting={submitting}>
-        <Title>LDAP Network Settings</Title>
-        <Description>
-          To establish a connection to the remote LDAP store, we need the hostname of the
-          LDAP machine, the port number that the LDAP service is running on, and the
-          encryption method. Typically, port 636 uses LDAPS encryption and port 389 uses
-          StartTLS.
-        </Description>
+      <Title>LDAP Network Settings</Title>
+      <Description>
+        To establish a connection to the remote LDAP store, we need the hostname of the
+        LDAP machine, the port number that the LDAP service is running on, and the
+        encryption method. Typically, port 636 uses LDAPS encryption and port 389 uses
+        StartTLS.
+      </Description>
 
-        <Hostname id='hostName' disabled={disabled} />
-        <Port id='port' disabled={disabled} options={[389, 636]} />
-        <Select id='encryptionMethod'
-          label='Encryption Method'
+      <Hostname id='hostName' disabled={disabled} />
+      <Port id='port' disabled={disabled} options={[389, 636]} />
+      <Select id='encryptionMethod'
+        label='Encryption Method'
+        disabled={disabled}
+        options={[ 'None', 'LDAPS', 'StartTLS' ]} />
+
+      <ActionGroup>
+        <Action
+          secondary
+          label='back'
+          onClick={prev}
+          disabled={disabled} />
+        <Action
+          primary
+          label='next'
+          onClick={test}
           disabled={disabled}
-          options={[ 'None', 'LDAPS', 'StartTLS' ]} />
+          nextStageId='bind-settings'
+          testId='connection' />
+      </ActionGroup>
 
-        <ActionGroup>
-          <Action
-            secondary
-            label='back'
-            onClick={prev}
-            disabled={disabled} />
-          <Action
-            primary
-            label='next'
-            onClick={test}
-            disabled={disabled}
-            nextStageId='bind-settings'
-            testId='connection' />
-        </ActionGroup>
-
-        {messages.map((msg, i) => <Message key={i} {...msg} />)}
-      </Spinner>
+      {messages.map((msg, i) => <Message key={i} {...msg} />)}
     </Stage>
   )
 }


### PR DESCRIPTION
 - Added a spinner to the config panels when a delete request is sent.
 - Moved actions & async calls to actions.js file and reducer logic to reducer.js file to match other directory structures
 - Some minor cleanup and refactoring

@djblue @tbatie @coyotesqrl 

Before:
![screen shot 2017-02-13 at 12 52 03](https://cloud.githubusercontent.com/assets/12499654/22901182/1b7b41d2-f1ee-11e6-95c8-efacc27ee767.png)

After clicking delete:
![screen shot 2017-02-13 at 12 52 10](https://cloud.githubusercontent.com/assets/12499654/22901214/2c7b3cbc-f1ee-11e6-90b7-f258905633a2.png)

After delete:
![screen shot 2017-02-13 at 12 52 18](https://cloud.githubusercontent.com/assets/12499654/22901222/31c0494c-f1ee-11e6-9111-01ba0f2dcb91.png)

Error message examples on Sources & LDAP tiles:
![screen shot 2017-02-16 at 12 03 07](https://cloud.githubusercontent.com/assets/12499654/23037968/88b69748-f445-11e6-9d66-ada47e5cdc15.png)


Testing:
Make create a source, delete it, and make sure the spinner appears while the request to delete is sent. Since the home page code was refactored, also keep an eye out for any functionality on that screen that might have been Affected. All links and config/ldap polling should be fine.

Testing error reporting is a bit trickier since an error needs to occur on delete in the backend. I've been using a proxy to modify the outgoing request so I could change the servicePid to be invalid, that way backend would return an error message to the frontend and the frontend would generate the message.