### PR TITLE
DDF-2773: Fix duplicate source names being allowed

### DIFF
--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/CswSourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/CswSourceConfiguration.java
@@ -36,18 +36,16 @@ public class CswSourceConfiguration extends SourceConfiguration {
 
     public static final String FORCE_SPATIAL_FILTER = "forceSpatialFilter";
 
-    private SourceValidationUtils sourceValidationUtils;
-
     private String outputSchema;
 
     private String forceSpatialFilter;
 
-    private final Map<String, Function<CswSourceConfiguration, List<ConfigurationMessage>>>
+    private static final Map<String, Function<CswSourceConfiguration, List<ConfigurationMessage>>>
             FIELDS_TO_VALIDATION_FUNC =
             new ImmutableMap.Builder<String, Function<CswSourceConfiguration, List<ConfigurationMessage>>>().putAll(
                     getBaseFieldValidationMap())
                     .put(FACTORY_PID,
-                            config -> sourceValidationUtils.validateCswFactoryPid(config.factoryPid(),
+                            config -> new SourceValidationUtils().validateCswFactoryPid(config.factoryPid(),
                                     FACTORY_PID))
                     .put(OUTPUT_SCHEMA,
                             config -> validateStringNoWhiteSpace(config.outputSchema(),
@@ -55,7 +53,6 @@ public class CswSourceConfiguration extends SourceConfiguration {
                     .build();
 
     public CswSourceConfiguration() {
-        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public CswSourceConfiguration(SourceConfiguration baseConfig) {

--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/CswSourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/CswSourceConfiguration.java
@@ -14,7 +14,6 @@
 
 package org.codice.ddf.admin.api.config.sources;
 
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateCswFactoryPid;
 import static org.codice.ddf.admin.api.validation.ValidationUtils.validateStringNoWhiteSpace;
 
 import java.util.List;
@@ -23,6 +22,7 @@ import java.util.function.Function;
 
 import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.api.validation.ValidationUtils;
 
 import com.google.common.base.MoreObjects;
@@ -36,22 +36,26 @@ public class CswSourceConfiguration extends SourceConfiguration {
 
     public static final String FORCE_SPATIAL_FILTER = "forceSpatialFilter";
 
-    private static final Map<String, Function<CswSourceConfiguration, List<ConfigurationMessage>>>
-            FIELDS_TO_VALIDATION_FUNC =
-            new ImmutableMap.Builder<String, Function<CswSourceConfiguration, List<ConfigurationMessage>>>().putAll(
-                    getBaseFieldValidationMap())
-                    .put(FACTORY_PID,
-                            config -> validateCswFactoryPid(config.factoryPid(), FACTORY_PID))
-                    .put(OUTPUT_SCHEMA,
-                            config -> validateStringNoWhiteSpace(config.outputSchema(),
-                                    OUTPUT_SCHEMA))
-                    .build();
+    private SourceValidationUtils sourceValidationUtils;
 
     private String outputSchema;
 
     private String forceSpatialFilter;
 
+    private final Map<String, Function<CswSourceConfiguration, List<ConfigurationMessage>>>
+            FIELDS_TO_VALIDATION_FUNC =
+            new ImmutableMap.Builder<String, Function<CswSourceConfiguration, List<ConfigurationMessage>>>().putAll(
+                    getBaseFieldValidationMap())
+                    .put(FACTORY_PID,
+                            config -> sourceValidationUtils.validateCswFactoryPid(config.factoryPid(),
+                                    FACTORY_PID))
+                    .put(OUTPUT_SCHEMA,
+                            config -> validateStringNoWhiteSpace(config.outputSchema(),
+                                    OUTPUT_SCHEMA))
+                    .build();
+
     public CswSourceConfiguration() {
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public CswSourceConfiguration(SourceConfiguration baseConfig) {

--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/OpenSearchSourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/OpenSearchSourceConfiguration.java
@@ -14,14 +14,13 @@
 
 package org.codice.ddf.admin.api.config.sources;
 
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOpensearchFactoryPid;
-
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.api.validation.ValidationUtils;
 
 import com.google.common.collect.ImmutableMap;
@@ -30,16 +29,19 @@ public class OpenSearchSourceConfiguration extends SourceConfiguration {
 
     public static final String CONFIGURATION_TYPE = "opensearch-source";
 
-    private static final Map<String, Function<OpenSearchSourceConfiguration, List<ConfigurationMessage>>>
+    private SourceValidationUtils sourceValidationUtils;
+
+    private final Map<String, Function<OpenSearchSourceConfiguration, List<ConfigurationMessage>>>
             FIELDS_TO_VALIDATION_FUNC =
             new ImmutableMap.Builder<String, Function<OpenSearchSourceConfiguration, List<ConfigurationMessage>>>().putAll(
                     getBaseFieldValidationMap())
                     .put(FACTORY_PID,
-                            config -> validateOpensearchFactoryPid(config.factoryPid(),
+                            config -> sourceValidationUtils.validateOpensearchFactoryPid(config.factoryPid(),
                                     FACTORY_PID))
                     .build();
 
     public OpenSearchSourceConfiguration() {
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public OpenSearchSourceConfiguration(SourceConfiguration baseConfig) {

--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/OpenSearchSourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/OpenSearchSourceConfiguration.java
@@ -29,19 +29,17 @@ public class OpenSearchSourceConfiguration extends SourceConfiguration {
 
     public static final String CONFIGURATION_TYPE = "opensearch-source";
 
-    private SourceValidationUtils sourceValidationUtils;
-
-    private final Map<String, Function<OpenSearchSourceConfiguration, List<ConfigurationMessage>>>
+    private static final Map<String, Function<OpenSearchSourceConfiguration, List<ConfigurationMessage>>>
             FIELDS_TO_VALIDATION_FUNC =
             new ImmutableMap.Builder<String, Function<OpenSearchSourceConfiguration, List<ConfigurationMessage>>>().putAll(
                     getBaseFieldValidationMap())
                     .put(FACTORY_PID,
-                            config -> sourceValidationUtils.validateOpensearchFactoryPid(config.factoryPid(),
+                            config -> new SourceValidationUtils().validateOpensearchFactoryPid(
+                                    config.factoryPid(),
                                     FACTORY_PID))
                     .build();
 
     public OpenSearchSourceConfiguration() {
-        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public OpenSearchSourceConfiguration(SourceConfiguration baseConfig) {

--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/SourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/SourceConfiguration.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 import org.codice.ddf.admin.api.config.Configuration;
 import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
-import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.api.validation.ValidationUtils;
 
 import com.google.common.base.MoreObjects;
@@ -60,10 +59,7 @@ public class SourceConfiguration extends Configuration {
 
     private String sourceUserPassword;
 
-    private SourceValidationUtils sourceValidationUtils;
-
     public SourceConfiguration() {
-        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public SourceConfiguration(SourceConfiguration sourceConfiguration) {
@@ -76,11 +72,10 @@ public class SourceConfiguration extends Configuration {
         this.endpointUrl = sourceConfiguration.endpointUrl;
     }
 
-    public <T extends SourceConfiguration> Map<String, Function<T, List<ConfigurationMessage>>> getBaseFieldValidationMap() {
+    public static <T extends SourceConfiguration> Map<String, Function<T, List<ConfigurationMessage>>> getBaseFieldValidationMap() {
         return new ImmutableMap.Builder<String, Function<T, List<ConfigurationMessage>>>().put(
                 SOURCE_NAME,
-                config -> sourceValidationUtils.validateNonDuplicateSourceName(config.sourceName(),
-                        SOURCE_NAME))
+                config -> validateString(config.sourceName(), SOURCE_NAME))
                 .put(SOURCE_HOSTNAME,
                         config -> validateHostName(config.sourceHostName(), SOURCE_HOSTNAME))
                 .put(PORT, config -> validatePort(config.sourcePort(), PORT))

--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/SourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/SourceConfiguration.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 import org.codice.ddf.admin.api.config.Configuration;
 import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.api.validation.ValidationUtils;
 
 import com.google.common.base.MoreObjects;
@@ -59,8 +60,10 @@ public class SourceConfiguration extends Configuration {
 
     private String sourceUserPassword;
 
-    public SourceConfiguration() {
+    private SourceValidationUtils sourceValidationUtils;
 
+    public SourceConfiguration() {
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public SourceConfiguration(SourceConfiguration sourceConfiguration) {
@@ -73,10 +76,11 @@ public class SourceConfiguration extends Configuration {
         this.endpointUrl = sourceConfiguration.endpointUrl;
     }
 
-    public static <T extends SourceConfiguration> Map<String, Function<T, List<ConfigurationMessage>>> getBaseFieldValidationMap() {
+    public <T extends SourceConfiguration> Map<String, Function<T, List<ConfigurationMessage>>> getBaseFieldValidationMap() {
         return new ImmutableMap.Builder<String, Function<T, List<ConfigurationMessage>>>().put(
                 SOURCE_NAME,
-                config -> validateString(config.sourceName(), SOURCE_NAME))
+                config -> sourceValidationUtils.validateNonDuplicateSourceName(config.sourceName(),
+                        SOURCE_NAME))
                 .put(SOURCE_HOSTNAME,
                         config -> validateHostName(config.sourceHostName(), SOURCE_HOSTNAME))
                 .put(PORT, config -> validatePort(config.sourcePort(), PORT))

--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/WfsSourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/WfsSourceConfiguration.java
@@ -29,19 +29,16 @@ public class WfsSourceConfiguration extends SourceConfiguration {
 
     public static final String CONFIGURATION_TYPE = "wfs-source";
 
-    private SourceValidationUtils sourceValidationUtils;
-
-    private final Map<String, Function<SourceConfiguration, List<ConfigurationMessage>>>
+    private static final Map<String, Function<SourceConfiguration, List<ConfigurationMessage>>>
             FIELDS_TO_VALIDATION_FUNC =
             new ImmutableMap.Builder<String, Function<SourceConfiguration, List<ConfigurationMessage>>>().putAll(
                     getBaseFieldValidationMap())
                     .put(FACTORY_PID,
-                            config -> sourceValidationUtils.validateWfsFactoryPid(config.factoryPid(),
+                            config -> new SourceValidationUtils().validateWfsFactoryPid(config.factoryPid(),
                                     FACTORY_PID))
                     .build();
 
     public WfsSourceConfiguration() {
-        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public WfsSourceConfiguration(SourceConfiguration baseConfig) {

--- a/api/src/main/java/org/codice/ddf/admin/api/config/sources/WfsSourceConfiguration.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/sources/WfsSourceConfiguration.java
@@ -14,14 +14,13 @@
 
 package org.codice.ddf.admin.api.config.sources;
 
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateWfsFactoryPid;
-
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
 import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.api.validation.ValidationUtils;
 
 import com.google.common.collect.ImmutableMap;
@@ -30,16 +29,19 @@ public class WfsSourceConfiguration extends SourceConfiguration {
 
     public static final String CONFIGURATION_TYPE = "wfs-source";
 
-    private static final Map<String, Function<SourceConfiguration, List<ConfigurationMessage>>>
+    private SourceValidationUtils sourceValidationUtils;
+
+    private final Map<String, Function<SourceConfiguration, List<ConfigurationMessage>>>
             FIELDS_TO_VALIDATION_FUNC =
             new ImmutableMap.Builder<String, Function<SourceConfiguration, List<ConfigurationMessage>>>().putAll(
                     getBaseFieldValidationMap())
                     .put(FACTORY_PID,
-                            config -> validateWfsFactoryPid(config.factoryPid(), FACTORY_PID))
+                            config -> sourceValidationUtils.validateWfsFactoryPid(config.factoryPid(),
+                                    FACTORY_PID))
                     .build();
 
     public WfsSourceConfiguration() {
-
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     public WfsSourceConfiguration(SourceConfiguration baseConfig) {

--- a/api/src/main/java/org/codice/ddf/admin/api/handler/commons/SourceHandlerCommons.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/handler/commons/SourceHandlerCommons.java
@@ -34,6 +34,8 @@ public class SourceHandlerCommons {
 
     public static final String VALID_URL_TEST_ID = "valid-url";
 
+    public static final String SOURCE_NAME_EXISTS_TEST_ID = "source-name-exists";
+
     //Common success types
     public static final String CONFIG_CREATED = "CONFIG_CREATED";
 

--- a/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
@@ -13,7 +13,6 @@
  */
 package org.codice.ddf.admin.api.validation;
 
-import static org.apache.commons.lang.Validate.notNull;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_NAME;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_USERNAME;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_USER_PASSWORD;

--- a/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
@@ -13,24 +13,24 @@
  */
 package org.codice.ddf.admin.api.validation;
 
+import static org.apache.commons.lang.Validate.notNull;
+import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_NAME;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_USERNAME;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_USER_PASSWORD;
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.createInvalidFieldMsg;
 import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_FACTORY_PIDS;
-import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_GMD_FACTORY_PID;
-import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_PROFILE_FACTORY_PID;
-import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_SPEC_FACTORY_PID;
 import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.OPENSEARCH_FACTORY_PID;
-import static org.codice.ddf.admin.api.services.WfsServiceProperties.WFS1_FACTORY_PID;
-import static org.codice.ddf.admin.api.services.WfsServiceProperties.WFS2_FACTORY_PID;
 import static org.codice.ddf.admin.api.services.WfsServiceProperties.WFS_FACTORY_PIDS;
 import static org.codice.ddf.admin.api.validation.ValidationUtils.validateString;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
 
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
@@ -39,31 +39,9 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableList;
-
 public class SourceValidationUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SourceValidationUtils.class);
-
-    private static final List<String> FACTORY_PIDS = ImmutableList.of(CSW_GMD_FACTORY_PID,
-            CSW_PROFILE_FACTORY_PID,
-            CSW_SPEC_FACTORY_PID,
-            OPENSEARCH_FACTORY_PID,
-            WFS1_FACTORY_PID,
-            WFS2_FACTORY_PID);
-
-    private Configurator configurator;
-
-    public SourceValidationUtils() {
-        configurator = new Configurator();
-    }
-
-    /*
-        For testing purposes only.
-     */
-    protected SourceValidationUtils(Configurator configurator) {
-        this.configurator = configurator;
-    }
 
     public List<ConfigurationMessage> validateWfsFactoryPid(String factoryPid, String configId) {
         List<ConfigurationMessage> errors = validateString(factoryPid, configId);
@@ -105,41 +83,53 @@ public class SourceValidationUtils {
         return validationResults;
     }
 
-    public List<ConfigurationMessage> validateNonDuplicateSourceName(String sourceName,
-            String configFieldId) {
-        List<ConfigurationMessage> validationResults = validateString(sourceName, configFieldId);
-        if (validationResults.isEmpty()) {
-            List<Map<String, Map<String, Object>>> configurations = FACTORY_PIDS.stream()
-                    .map(configurator::getManagedServiceConfigs)
-                    .filter(config -> !config.isEmpty())
-                    .collect(Collectors.toList());
+    /**
+     * Validates the {@param sourceName} against the existing source names of the configuration's for
+     * the given {@param factoryPids} using the {@param configurator}. An empty {@link List} will be returned
+     * if there are no existing source names with with name {@param sourceName}, or a {@link List} containing
+     * {@link ConfigurationMessage}s if there are errors.
+     *
+     * @param  sourceName a non null name to validate
+     * @param  factoryPids a list of non null factory pids of the configuration to validate names against
+     * @param  configurator configurator to fetch configurations for the given {@param factoryPids}
+     * @return a {@link List} of {@link ConfigurationMessage}s containing failure messages, or empty {@link List}
+     *         if there are no duplicate source names found
+     */
+    public List<ConfigurationMessage> validateSourceName(@Nonnull String sourceName,
+            @Nonnull List<String> factoryPids, Configurator configurator) {
+        if(configurator == null) {
+            configurator = new Configurator();
+        }
 
-            for (Map<String, Map<String, Object>> config : configurations) {
-                for (Map<String, Object> entry : config.values()) {
-                    Object id = entry.get("id");
-                    if (id instanceof String) {
-                        String name = (String) id;
-                        if (StringUtils.isNotEmpty(name) && sourceName.equals(name)) {
-                            LOGGER.debug(
-                                    "Found duplicate existing source name when creating source with name \"{}\"",
-                                    sourceName);
-                            validationResults.add(createInvalidFieldMsg(String.format(
-                                    "A source with the name \"%s\" is already in use. Please choose another name.",
-                                    sourceName), configFieldId));
-                            break;
-                        }
-                    } else {
+        List<Map<String, Map<String, Object>>> configurations = factoryPids.stream()
+                .map(configurator::getManagedServiceConfigs)
+                .filter(config -> !config.isEmpty())
+                .collect(Collectors.toList());
+
+        for (Map<String, Map<String, Object>> config : configurations) {
+            for (Map<String, Object> entry : config.values()) {
+                Object id = entry.get("id");
+                if (id instanceof String) {
+                    String name = (String) id;
+                    if (StringUtils.isNotEmpty(name) && sourceName.equals(name)) {
                         LOGGER.debug(
-                                "Unable to validate duplicity of the incoming configuration's source name \"{}\"",
+                                "Found duplicate existing source name when creating source with name \"{}\"",
                                 sourceName);
-                        validationResults.add(createInvalidFieldMsg(String.format(String.format(
-                                "Error validating \"%s\" against existing source names.",
-                                sourceName), sourceName), configFieldId));
+                        return Collections.singletonList(createInvalidFieldMsg(String.format(
+                                "A source with the name \"%s\" is already in use. Please choose another name.",
+                                sourceName), SOURCE_NAME));
                     }
+                } else {
+                    LOGGER.debug(
+                            "Unable to validate duplicity of the incoming configuration's source name \"{}\"",
+                            sourceName);
+                    return Collections.singletonList(createInvalidFieldMsg(String.format(String.format(
+                            "Error validating \"%s\" against existing source names.",
+                            sourceName), sourceName), SOURCE_NAME));
                 }
             }
         }
 
-        return validationResults;
+        return Collections.emptyList();
     }
 }

--- a/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
@@ -16,6 +16,7 @@ package org.codice.ddf.admin.api.validation;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_NAME;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_USERNAME;
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_USER_PASSWORD;
+import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.createInvalidFieldMsg;
 import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_FACTORY_PIDS;
 import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.OPENSEARCH_FACTORY_PID;
@@ -86,17 +87,18 @@ public class SourceValidationUtils {
      * Validates the {@param sourceName} against the existing source names of the configuration's for
      * the given {@param factoryPids} using the {@param configurator}. An empty {@link List} will be returned
      * if there are no existing source names with with name {@param sourceName}, or a {@link List} containing
-     * {@link ConfigurationMessage}s if there are errors.
+     * {@link ConfigurationMessage}s if there are errors. If the {@param configurator} is {@code null}, one will
+     * be created.
      *
-     * @param  sourceName a non null name to validate
-     * @param  factoryPids a list of non null factory pids of the configuration to validate names against
-     * @param  configurator configurator to fetch configurations for the given {@param factoryPids}
+     * @param sourceName   a non null name to validate
+     * @param factoryPids  a list of non null factory pids of the configuration to validate names against
+     * @param configurator configurator to fetch configurations for the given {@param factoryPids}
      * @return a {@link List} of {@link ConfigurationMessage}s containing failure messages, or empty {@link List}
-     *         if there are no duplicate source names found
+     * if there are no duplicate source names found
      */
     public List<ConfigurationMessage> validateSourceName(@Nonnull String sourceName,
             @Nonnull List<String> factoryPids, Configurator configurator) {
-        if(configurator == null) {
+        if (configurator == null) {
             configurator = new Configurator();
         }
 
@@ -114,6 +116,7 @@ public class SourceValidationUtils {
                         LOGGER.debug(
                                 "Found duplicate existing source name when creating source with name \"{}\"",
                                 sourceName);
+
                         return Collections.singletonList(createInvalidFieldMsg(String.format(
                                 "A source with the name \"%s\" is already in use. Please choose another name.",
                                 sourceName), SOURCE_NAME));
@@ -122,9 +125,10 @@ public class SourceValidationUtils {
                     LOGGER.debug(
                             "Unable to validate duplicity of the incoming configuration's source name \"{}\"",
                             sourceName);
-                    return Collections.singletonList(createInvalidFieldMsg(String.format(String.format(
-                            "Error validating \"%s\" against existing source names.",
-                            sourceName), sourceName), SOURCE_NAME));
+                    return Collections.singletonList(buildMessage(ConfigurationMessage.MessageType.FAILURE,
+                            ConfigurationMessage.INTERNAL_ERROR,
+                            String.format("Error validating \"%s\" against existing source names.",
+                                    sourceName)));
                 }
             }
         }

--- a/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
@@ -1,16 +1,19 @@
 package org.codice.ddf.admin.api.validation
 
+import org.codice.ddf.admin.api.config.sources.SourceConfiguration
 import org.codice.ddf.admin.api.configurator.Configurator
 import org.codice.ddf.admin.api.handler.ConfigurationMessage
 import spock.lang.Specification
 
 class SourceValidationUtilsTest extends Specification {
 
-    static final CONFIG_FIELD_ID = "testFieldId"
+    static final CONFIG_FIELD_ID = SourceConfiguration.SOURCE_NAME
 
     static final EXISTING_SOURCE_NAME = "existingSourceName"
 
     static final NEW_SOURCE_NAME = "newSourceName"
+
+    static final FACTORY_IDS = Collections.singletonList("fid")
 
     def configurator
 
@@ -18,20 +21,20 @@ class SourceValidationUtilsTest extends Specification {
 
     def setup() {
         configurator = mockConfigurator(EXISTING_SOURCE_NAME)
-        sourceValidationUtils = new SourceValidationUtils(configurator)
+        sourceValidationUtils = new SourceValidationUtils()
     }
 
-    def 'test validateNonDuplicateSourceName(String, String) with no existing config with source name'() {
+    def 'test validateSourceName(String, String) with no existing config with source name'() {
         when:
-        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(NEW_SOURCE_NAME, CONFIG_FIELD_ID)
+        List<ConfigurationMessage> results = sourceValidationUtils.validateSourceName(NEW_SOURCE_NAME, FACTORY_IDS, configurator)
 
         then:
         results.isEmpty()
     }
 
-    def 'test validateNonDuplicateSourceName(String, String) with duplicate source name'() {
+    def 'test validateSourceName(String, String) with duplicate source name'() {
         when:
-        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(EXISTING_SOURCE_NAME, CONFIG_FIELD_ID)
+        List<ConfigurationMessage> results = sourceValidationUtils.validateSourceName(EXISTING_SOURCE_NAME, FACTORY_IDS, configurator)
 
         then:
         results.size() == 1
@@ -40,31 +43,17 @@ class SourceValidationUtilsTest extends Specification {
         results.get(0).subtype() == ConfigurationMessage.INVALID_FIELD
     }
 
-    def 'test validateNonDuplicateSourceName(String, String) with invalid existing config id property'() {
+    def 'test validateSourceName(String, String) with invalid existing config id property'() {
         when:
         configurator = mockConfigurator(true)
-        sourceValidationUtils = new SourceValidationUtils(configurator)
-        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(NEW_SOURCE_NAME, CONFIG_FIELD_ID)
+        sourceValidationUtils = new SourceValidationUtils()
+        List<ConfigurationMessage> results = sourceValidationUtils.validateSourceName(NEW_SOURCE_NAME, FACTORY_IDS, configurator)
 
         then:
         results.size() == 1
         results.get(0).type() == ConfigurationMessage.MessageType.FAILURE
         results.get(0).configFieldId() == CONFIG_FIELD_ID
         results.get(0).subtype() == ConfigurationMessage.INVALID_FIELD
-    }
-
-    def 'test validateNonDuplicateSourceName(String, String) with null or empty sourceName'() {
-        when:
-        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(sourceName, CONFIG_FIELD_ID)
-
-        then:
-        results.size() == 1
-        results.get(0).type() == ConfigurationMessage.MessageType.FAILURE
-        results.get(0).configFieldId() == CONFIG_FIELD_ID
-        results.get(0).subtype() == ConfigurationMessage.MISSING_REQUIRED_FIELD
-
-        where:
-        sourceName << [null, ""]
     }
 
     def mockConfigurator(Object sourceName) {

--- a/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
@@ -1,0 +1,75 @@
+package org.codice.ddf.admin.api.validation
+
+import org.codice.ddf.admin.api.configurator.Configurator
+import org.codice.ddf.admin.api.handler.ConfigurationMessage
+import spock.lang.Specification
+
+class SourceValidationUtilsTest extends Specification {
+
+    static final CONFIG_FIELD_ID = "testFieldId"
+
+    static final EXISTING_SOURCE_NAME = "existingSourceName"
+
+    static final NEW_SOURCE_NAME = "newSourceName"
+
+    def configurator
+
+    def sourceValidationUtils
+
+    def setup() {
+        configurator = mockConfigurator(EXISTING_SOURCE_NAME)
+        sourceValidationUtils = new SourceValidationUtils(configurator)
+    }
+
+    def 'test validateNonDuplicateSourceName(String, String) with no existing config with source name'() {
+        when:
+        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(NEW_SOURCE_NAME, CONFIG_FIELD_ID)
+
+        then:
+        results.isEmpty()
+    }
+
+    def 'test validateNonDuplicateSourceName(String, String) with duplicate source name'() {
+        when:
+        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(EXISTING_SOURCE_NAME, CONFIG_FIELD_ID)
+
+        then:
+        results.size() == 1
+        results.get(0).type() == ConfigurationMessage.MessageType.FAILURE
+        results.get(0).configFieldId() == CONFIG_FIELD_ID
+        results.get(0).subtype() == ConfigurationMessage.INVALID_FIELD
+    }
+
+    def 'test validateNonDuplicateSourceName(String, String) with invalid existing config id property'() {
+        when:
+        configurator = mockConfigurator(true)
+        sourceValidationUtils = new SourceValidationUtils(configurator)
+        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(NEW_SOURCE_NAME, CONFIG_FIELD_ID)
+
+        then:
+        results.size() == 1
+        results.get(0).type() == ConfigurationMessage.MessageType.FAILURE
+        results.get(0).configFieldId() == CONFIG_FIELD_ID
+        results.get(0).subtype() == ConfigurationMessage.INVALID_FIELD
+    }
+
+    def 'test validateNonDuplicateSourceName(String, String) with null or empty sourceName'() {
+        when:
+        List<ConfigurationMessage> results = sourceValidationUtils.validateNonDuplicateSourceName(sourceName, CONFIG_FIELD_ID)
+
+        then:
+        results.size() == 1
+        results.get(0).type() == ConfigurationMessage.MessageType.FAILURE
+        results.get(0).configFieldId() == CONFIG_FIELD_ID
+        results.get(0).subtype() == ConfigurationMessage.MISSING_REQUIRED_FIELD
+
+        where:
+        sourceName << [null, ""]
+    }
+
+    def mockConfigurator(Object sourceName) {
+        return Mock(Configurator) {
+            getManagedServiceConfigs(_ as String) >> ["fid": ["id": sourceName]] >> [:]
+        }
+    }
+}

--- a/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
@@ -52,8 +52,7 @@ class SourceValidationUtilsTest extends Specification {
         then:
         results.size() == 1
         results.get(0).type() == ConfigurationMessage.MessageType.FAILURE
-        results.get(0).configFieldId() == CONFIG_FIELD_ID
-        results.get(0).subtype() == ConfigurationMessage.INVALID_FIELD
+        results.get(0).subtype() == ConfigurationMessage.INTERNAL_ERROR
     }
 
     def mockConfigurator(Object sourceName) {

--- a/federation/source-config-handlers/pom.xml
+++ b/federation/source-config-handlers/pom.xml
@@ -45,6 +45,11 @@
             <artifactId>httpclient</artifactId>
             <version>4.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/federation/source-config-handlers/pom.xml
+++ b/federation/source-config-handlers/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
+            <version>${commons-lang.version}</version>
         </dependency>
     </dependencies>
 

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceConfigurationHandler.java
@@ -11,12 +11,12 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  */
-
 package org.codice.ddf.admin.sources.csw;
 
 import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_FACTORY_PIDS;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +36,7 @@ import org.codice.ddf.admin.sources.csw.persist.CreateCswSourcePersistMethod;
 import org.codice.ddf.admin.sources.csw.persist.DeleteCswSourcePersistMethod;
 import org.codice.ddf.admin.sources.csw.probe.CswConfigFromUrlProbeMethod;
 import org.codice.ddf.admin.sources.csw.probe.DiscoverCswSourceProbeMethod;
+import org.codice.ddf.admin.sources.csw.test.SourceNameExistsCswTestMethod;
 
 public class CswSourceConfigurationHandler extends DefaultConfigurationHandler<SourceConfiguration>
         implements SourceConfigurationHandler<SourceConfiguration> {
@@ -50,7 +51,7 @@ public class CswSourceConfigurationHandler extends DefaultConfigurationHandler<S
 
     @Override
     public List<TestMethod> getTestMethods() {
-        return null;
+        return Collections.singletonList(new SourceNameExistsCswTestMethod(new Configurator()));
     }
 
     @Override

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceConfigurationHandler.java
@@ -24,6 +24,7 @@ import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.config.sources.CswSourceConfiguration;
 import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
 import org.codice.ddf.admin.api.configurator.Configurator;
+import org.codice.ddf.admin.api.handler.ConfigurationHandler;
 import org.codice.ddf.admin.api.handler.DefaultConfigurationHandler;
 import org.codice.ddf.admin.api.handler.SourceConfigurationHandler;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
@@ -44,6 +45,12 @@ public class CswSourceConfigurationHandler extends DefaultConfigurationHandler<S
     public static final String CSW_SOURCE_CONFIGURATION_HANDLER_ID =
             CswSourceConfiguration.CONFIGURATION_TYPE;
 
+    private final ConfigurationHandler handler;
+
+    public CswSourceConfigurationHandler(ConfigurationHandler handler) {
+        this.handler = handler;
+    }
+
     @Override
     public List<ProbeMethod> getProbeMethods() {
         return Arrays.asList(new DiscoverCswSourceProbeMethod(), new CswConfigFromUrlProbeMethod());
@@ -56,7 +63,7 @@ public class CswSourceConfigurationHandler extends DefaultConfigurationHandler<S
 
     @Override
     public List<PersistMethod> getPersistMethods() {
-        return Arrays.asList(new CreateCswSourcePersistMethod(),
+        return Arrays.asList(new CreateCswSourcePersistMethod(handler),
                 new DeleteCswSourcePersistMethod());
     }
 

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
@@ -24,7 +24,6 @@ import static org.codice.ddf.admin.api.handler.ConfigurationMessage.FAILED_PERSI
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.CREATE;
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_PERSIST;
 import static org.codice.ddf.admin.api.services.CswServiceProperties.cswConfigToServiceProps;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 
 import java.util.Arrays;
 import java.util.List;
@@ -36,6 +35,7 @@ import org.codice.ddf.admin.api.configurator.OperationReport;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
 import org.codice.ddf.admin.api.handler.report.Report;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -62,6 +62,8 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
     private static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(FAILED_PERSIST,
             "Failed to create CSW Source.");
 
+    private SourceValidationUtils sourceValidationUtils;
+
     public CreateCswSourcePersistMethod() {
         super(CREATE_CSW_SOURCE_ID,
                 DESCRIPTION,
@@ -70,6 +72,8 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
                 SUCCESS_TYPES,
                 FAILURE_TYPES,
                 null);
+
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -87,8 +91,8 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
 
     @Override
     public List<ConfigurationMessage> validateOptionalFields(CswSourceConfiguration configuration) {
-        List<ConfigurationMessage> validationResults = validateOptionalUsernameAndPassword(
-                configuration);
+        List<ConfigurationMessage> validationResults =
+                sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
         if (configuration.outputSchema() != null) {
             validationResults.addAll(configuration.validate(Arrays.asList(OUTPUT_SCHEMA)));
         }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
@@ -111,10 +111,7 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
     public List<ConfigurationMessage> validateRequiredFields(
             CswSourceConfiguration configuration) {
         Report report = handler.test(SOURCE_NAME_EXISTS_TEST_ID, configuration);
-        if(report.containsFailureMessages()) {
-            return report.messages();
-        }
-
-        return super.validateRequiredFields(configuration);
+        report.addMessages(super.validateRequiredFields(configuration));
+        return report.messages();
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
@@ -62,7 +62,7 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
     private static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(FAILED_PERSIST,
             "Failed to create CSW Source.");
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public CreateCswSourcePersistMethod() {
         super(CREATE_CSW_SOURCE_ID,

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswSourcePersistMethod.java
@@ -23,6 +23,7 @@ import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.FAILED_PERSIST;
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.CREATE;
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_PERSIST;
+import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.api.services.CswServiceProperties.cswConfigToServiceProps;
 
 import java.util.Arrays;
@@ -32,6 +33,7 @@ import java.util.Map;
 import org.codice.ddf.admin.api.config.sources.CswSourceConfiguration;
 import org.codice.ddf.admin.api.configurator.Configurator;
 import org.codice.ddf.admin.api.configurator.OperationReport;
+import org.codice.ddf.admin.api.handler.ConfigurationHandler;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
 import org.codice.ddf.admin.api.handler.report.Report;
@@ -64,7 +66,9 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
 
     private final SourceValidationUtils sourceValidationUtils;
 
-    public CreateCswSourcePersistMethod() {
+    private final ConfigurationHandler handler;
+
+    public CreateCswSourcePersistMethod(ConfigurationHandler handler) {
         super(CREATE_CSW_SOURCE_ID,
                 DESCRIPTION,
                 REQUIRED_FIELDS,
@@ -74,6 +78,7 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
                 null);
 
         sourceValidationUtils = new SourceValidationUtils();
+        this.handler = handler;
     }
 
     @Override
@@ -100,5 +105,16 @@ public class CreateCswSourcePersistMethod extends PersistMethod<CswSourceConfigu
             validationResults.addAll(configuration.validate(Arrays.asList(FORCE_SPATIAL_FILTER)));
         }
         return validationResults;
+    }
+
+    @Override
+    public List<ConfigurationMessage> validateRequiredFields(
+            CswSourceConfiguration configuration) {
+        Report report = handler.test(SOURCE_NAME_EXISTS_TEST_ID, configuration);
+        if(report.containsFailureMessages()) {
+            return report.messages();
+        }
+
+        return super.validateRequiredFields(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/CswConfigFromUrlProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/CswConfigFromUrlProbeMethod.java
@@ -79,9 +79,9 @@ public class CswConfigFromUrlProbeMethod extends ProbeMethod<CswSourceConfigurat
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private CswSourceUtils cswSourceUtils;
+    private final CswSourceUtils cswSourceUtils;
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public CswConfigFromUrlProbeMethod() {
         super(CSW_CONFIG_FROM_URL_ID,
@@ -92,6 +92,7 @@ public class CswConfigFromUrlProbeMethod extends ProbeMethod<CswSourceConfigurat
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
+
         cswSourceUtils = new CswSourceUtils();
         sourceValidationUtils = new SourceValidationUtils();
     }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/CswConfigFromUrlProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/CswConfigFromUrlProbeMethod.java
@@ -28,7 +28,6 @@ import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNKN
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNTRUSTED_CA;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.VERIFIED_URL;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.endpointIsReachable;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 import static org.codice.ddf.admin.sources.csw.CswSourceConfigurationHandler.CSW_SOURCE_CONFIGURATION_HANDLER_ID;
 
 import java.util.HashMap;
@@ -41,6 +40,7 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.commons.UrlAvailability;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.sources.csw.CswSourceUtils;
 
 import com.google.common.collect.ImmutableList;
@@ -79,7 +79,9 @@ public class CswConfigFromUrlProbeMethod extends ProbeMethod<CswSourceConfigurat
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private CswSourceUtils utils;
+    private CswSourceUtils cswSourceUtils;
+
+    private SourceValidationUtils sourceValidationUtils;
 
     public CswConfigFromUrlProbeMethod() {
         super(CSW_CONFIG_FROM_URL_ID,
@@ -90,7 +92,8 @@ public class CswConfigFromUrlProbeMethod extends ProbeMethod<CswSourceConfigurat
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
-        utils = new CswSourceUtils();
+        cswSourceUtils = new CswSourceUtils();
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -103,10 +106,10 @@ public class CswConfigFromUrlProbeMethod extends ProbeMethod<CswSourceConfigurat
             return report;
         }
 
-        UrlAvailability availability = utils.getUrlAvailability(
-                configuration.endpointUrl(),
-                configuration.sourceUserName(),
-                configuration.sourceUserPassword());
+        UrlAvailability availability =
+                cswSourceUtils.getUrlAvailability(configuration.endpointUrl(),
+                        configuration.sourceUserName(),
+                        configuration.sourceUserPassword());
         if (availability == null) {
             return report.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -122,7 +125,8 @@ public class CswConfigFromUrlProbeMethod extends ProbeMethod<CswSourceConfigurat
             return report;
         }
 
-        Optional<CswSourceConfiguration> createdConfig = utils.getPreferredConfig(configuration);
+        Optional<CswSourceConfiguration> createdConfig = cswSourceUtils.getPreferredConfig(
+                configuration);
         if (!createdConfig.isPresent()) {
             return report.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -144,6 +148,6 @@ public class CswConfigFromUrlProbeMethod extends ProbeMethod<CswSourceConfigurat
 
     @Override
     public List<ConfigurationMessage> validateOptionalFields(CswSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/DiscoverCswSourceProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/DiscoverCswSourceProbeMethod.java
@@ -75,9 +75,9 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private CswSourceUtils cswSourceUtils;
+    private final CswSourceUtils cswSourceUtils;
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public DiscoverCswSourceProbeMethod() {
         super(CSW_DISCOVER_SOURCES_ID,
@@ -88,6 +88,7 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
+
         cswSourceUtils = new CswSourceUtils();
         sourceValidationUtils = new SourceValidationUtils();
     }
@@ -119,7 +120,9 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
             return probeReport;
         }
 
-        Optional<CswSourceConfiguration> createdConfig = cswSourceUtils.getPreferredConfig((CswSourceConfiguration) config.endpointUrl(availability.getUrl()));
+        Optional<CswSourceConfiguration> createdConfig =
+                cswSourceUtils.getPreferredConfig((CswSourceConfiguration) config.endpointUrl(
+                        availability.getUrl()));
         if (!createdConfig.isPresent()) {
             return probeReport.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/DiscoverCswSourceProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/probe/DiscoverCswSourceProbeMethod.java
@@ -28,7 +28,6 @@ import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNKN
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNTRUSTED_CA;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.endpointIsReachable;
 import static org.codice.ddf.admin.api.handler.report.ProbeReport.createProbeReport;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 import static org.codice.ddf.admin.sources.csw.CswSourceConfigurationHandler.CSW_SOURCE_CONFIGURATION_HANDLER_ID;
 
 import java.util.HashMap;
@@ -41,6 +40,7 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.commons.UrlAvailability;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.sources.csw.CswSourceUtils;
 
 import com.google.common.collect.ImmutableList;
@@ -75,7 +75,9 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private CswSourceUtils utils;
+    private CswSourceUtils cswSourceUtils;
+
+    private SourceValidationUtils sourceValidationUtils;
 
     public DiscoverCswSourceProbeMethod() {
         super(CSW_DISCOVER_SOURCES_ID,
@@ -86,7 +88,8 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
-        utils = new CswSourceUtils();
+        cswSourceUtils = new CswSourceUtils();
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -101,7 +104,7 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
             return probeReport;
         }
 
-        UrlAvailability availability = utils.confirmEndpointUrl(config);
+        UrlAvailability availability = cswSourceUtils.confirmEndpointUrl(config);
         if (availability == null) {
             return probeReport.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -116,7 +119,7 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
             return probeReport;
         }
 
-        Optional<CswSourceConfiguration> createdConfig = utils.getPreferredConfig((CswSourceConfiguration) config.endpointUrl(availability.getUrl()));
+        Optional<CswSourceConfiguration> createdConfig = cswSourceUtils.getPreferredConfig((CswSourceConfiguration) config.endpointUrl(availability.getUrl()));
         if (!createdConfig.isPresent()) {
             return probeReport.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -138,6 +141,6 @@ public class DiscoverCswSourceProbeMethod extends ProbeMethod<CswSourceConfigura
 
     @Override
     public List<ConfigurationMessage> validateOptionalFields(CswSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
@@ -14,12 +14,12 @@
 package org.codice.ddf.admin.sources.csw.test;
 
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
+import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_TEST;
+import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_FACTORY_PIDS;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.DESCRIPTION;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.FAILURE_TYPES;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.REQUIRED_FIELDS;
-import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_SUCCESS;
-import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SUCCESS_TYPES;
 
 import java.util.List;
@@ -71,10 +71,7 @@ public class SourceNameExistsCswTestMethod extends TestMethod<SourceConfiguratio
                         configurator);
 
         if (results.isEmpty()) {
-            return new Report(buildMessage(SUCCESS_TYPES,
-                    FAILURE_TYPES,
-                    null,
-                    SOURCE_NAME_EXISTS_SUCCESS));
+            return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));
         }
 
         Report report = new Report();

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.sources.csw.test;
+
+import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
+import static org.codice.ddf.admin.api.services.CswServiceProperties.CSW_FACTORY_PIDS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.DESCRIPTION;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.FAILURE_TYPES;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.REQUIRED_FIELDS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_SUCCESS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_TEST_ID;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SUCCESS_TYPES;
+
+import java.util.List;
+
+import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
+import org.codice.ddf.admin.api.configurator.Configurator;
+import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.handler.method.TestMethod;
+import org.codice.ddf.admin.api.handler.report.Report;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
+import org.codice.ddf.admin.sources.opensearch.test.SourceNameExistsOpenSearchTestMethod;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SourceNameExistsCswTestMethod extends TestMethod<SourceConfiguration> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(
+            SourceNameExistsOpenSearchTestMethod.class);
+
+    public static final String CSW_SOURCE_EXISTS_ID = SOURCE_NAME_EXISTS_TEST_ID;
+
+    private final Configurator configurator;
+
+    private final SourceValidationUtils sourceValidationUtils;
+
+    public SourceNameExistsCswTestMethod(Configurator configurator) {
+        super(CSW_SOURCE_EXISTS_ID,
+                DESCRIPTION,
+                REQUIRED_FIELDS,
+                null,
+                SUCCESS_TYPES,
+                FAILURE_TYPES,
+                null);
+
+        sourceValidationUtils = new SourceValidationUtils();
+
+        if (configurator == null) {
+            this.configurator = new Configurator();
+        } else {
+            this.configurator = configurator;
+        }
+    }
+
+    @Override
+    public Report test(SourceConfiguration configuration) {
+        List<ConfigurationMessage> results =
+                sourceValidationUtils.validateSourceName(configuration.sourceName(),
+                        CSW_FACTORY_PIDS,
+                        configurator);
+
+        if (results.isEmpty()) {
+            return new Report(buildMessage(SUCCESS_TYPES,
+                    FAILURE_TYPES,
+                    null,
+                    SOURCE_NAME_EXISTS_SUCCESS));
+        }
+
+        Report report = new Report();
+        results.forEach(report::addMessage);
+        return report;
+    }
+}

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
@@ -74,8 +74,6 @@ public class SourceNameExistsCswTestMethod extends TestMethod<SourceConfiguratio
             return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));
         }
 
-        Report report = new Report();
-        results.forEach(report::addMessage);
-        return report;
+        return new Report(results);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/SourceConfigurationHandlerImpl.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/SourceConfigurationHandlerImpl.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.method.TestMethod;
 import org.codice.ddf.admin.sources.impl.probe.DiscoverSourcesProbeMethod;
 import org.codice.ddf.admin.sources.impl.probe.GetConfigHandlersProbeMethod;
+import org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod;
 import org.codice.ddf.admin.sources.impl.test.ValidUrlTestMethod;
 
 import com.google.common.collect.ImmutableList;
@@ -46,7 +47,8 @@ public class SourceConfigurationHandlerImpl
 
     @Override
     public List<TestMethod> getTestMethods() {
-        return ImmutableList.of(new ValidUrlTestMethod());
+        return ImmutableList.of(new ValidUrlTestMethod(),
+                new SourceNameExistsTestMethod(srcHandlers));
     }
 
     @Override

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/probe/DiscoverSourcesProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/probe/DiscoverSourcesProbeMethod.java
@@ -21,7 +21,6 @@ import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.DISCOVERED_SOURCES;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.DISCOVER_SOURCES_ID;
 import static org.codice.ddf.admin.api.handler.report.ProbeReport.createProbeReport;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 
 import java.util.List;
 import java.util.Map;
@@ -32,6 +31,7 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.SourceConfigurationHandler;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -59,6 +59,8 @@ public class DiscoverSourcesProbeMethod extends ProbeMethod<SourceConfiguration>
 
     private List<SourceConfigurationHandler> handlers;
 
+    private SourceValidationUtils sourceValidationUtils;
+
     // TODO: tbatie - 2/1/17 - (Ticket) We can't return a failure type here because the frontend can't handle the error properly
     public DiscoverSourcesProbeMethod(List<SourceConfigurationHandler> handlers) {
         super(DISCOVER_SOURCES_ID,
@@ -70,6 +72,7 @@ public class DiscoverSourcesProbeMethod extends ProbeMethod<SourceConfiguration>
                 null,
                 RETURN_TYPES);
         this.handlers = handlers;
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -94,6 +97,6 @@ public class DiscoverSourcesProbeMethod extends ProbeMethod<SourceConfiguration>
 
     @Override
     public List<ConfigurationMessage> validateOptionalFields(SourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/probe/DiscoverSourcesProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/probe/DiscoverSourcesProbeMethod.java
@@ -59,7 +59,7 @@ public class DiscoverSourcesProbeMethod extends ProbeMethod<SourceConfiguration>
 
     private List<SourceConfigurationHandler> handlers;
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     // TODO: tbatie - 2/1/17 - (Ticket) We can't return a failure type here because the frontend can't handle the error properly
     public DiscoverSourcesProbeMethod(List<SourceConfigurationHandler> handlers) {
@@ -71,6 +71,7 @@ public class DiscoverSourcesProbeMethod extends ProbeMethod<SourceConfiguration>
                 null,
                 null,
                 RETURN_TYPES);
+
         this.handlers = handlers;
         sourceValidationUtils = new SourceValidationUtils();
     }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/test/SourceNameExistsTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/test/SourceNameExistsTestMethod.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.sources.impl.test;
+
+import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_NAME;
+import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
+import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_TEST;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
+import org.codice.ddf.admin.api.handler.SourceConfigurationHandler;
+import org.codice.ddf.admin.api.handler.method.TestMethod;
+import org.codice.ddf.admin.api.handler.report.Report;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+public class SourceNameExistsTestMethod extends TestMethod<SourceConfiguration> {
+
+    public static final String SOURCE_NAME_EXISTS_TEST_ID = "source-name-exists";
+
+    public static final String SOURCE_NAME_EXISTS_SUCCESS = "SOURCE_NAME_EXISTS_SUCCESS";
+
+    public static final String SOURCE_NAME_EXISTS_FAIL = "SOURCE_NAME_EXISTS_FAIL";
+
+    public static final String DESCRIPTION =
+            "Verifies incoming configuration's source name against all existing configuration's source names.";
+
+    public static final List<String> REQUIRED_FIELDS = ImmutableList.of(SOURCE_NAME);
+
+    public static final Map<String, String> SUCCESS_TYPES = ImmutableMap.of(
+            SOURCE_NAME_EXISTS_SUCCESS,
+            "Source name does not exist.");
+
+    public static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(SOURCE_NAME_EXISTS_FAIL,
+            "Source name already exists.");
+
+    private List<SourceConfigurationHandler> handlers;
+
+    public SourceNameExistsTestMethod(List<SourceConfigurationHandler> handlers) {
+        super(SOURCE_NAME_EXISTS_TEST_ID,
+                DESCRIPTION,
+                REQUIRED_FIELDS,
+                null,
+                SUCCESS_TYPES,
+                FAILURE_TYPES,
+                null);
+
+        this.handlers = handlers;
+    }
+
+    @Override
+    public Report test(SourceConfiguration configuration) {
+        List<Report> sourceReport = handlers.stream()
+                .map(handler -> handler.test(SOURCE_NAME_EXISTS_TEST_ID, configuration))
+                .collect(Collectors.toList());
+
+        List<Report> duplicateSourceNameReports = sourceReport.stream()
+                .filter(Report::containsFailureMessages)
+                .collect(Collectors.toList());
+
+        if (!duplicateSourceNameReports.isEmpty()) {
+            Report report = new Report();
+            duplicateSourceNameReports.forEach(sourceNameReport -> report.addMessages(
+                    sourceNameReport.messages()));
+            return report;
+        }
+
+        return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));
+    }
+}

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/test/SourceNameExistsTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/impl/test/SourceNameExistsTestMethod.java
@@ -14,8 +14,10 @@
 package org.codice.ddf.admin.sources.impl.test;
 
 import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE_NAME;
+import static org.codice.ddf.admin.api.handler.ConfigurationMessage.INVALID_FIELD;
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_TEST;
+import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.SOURCE_NAME_EXISTS_TEST_ID;
 
 import java.util.List;
 import java.util.Map;
@@ -31,22 +33,15 @@ import com.google.common.collect.ImmutableMap;
 
 public class SourceNameExistsTestMethod extends TestMethod<SourceConfiguration> {
 
-    public static final String SOURCE_NAME_EXISTS_TEST_ID = "source-name-exists";
-
-    public static final String SOURCE_NAME_EXISTS_SUCCESS = "SOURCE_NAME_EXISTS_SUCCESS";
-
-    public static final String SOURCE_NAME_EXISTS_FAIL = "SOURCE_NAME_EXISTS_FAIL";
-
     public static final String DESCRIPTION =
-            "Verifies incoming configuration's source name against all existing configuration's source names.";
+            "Checks for duplicated source names and fails if there is an existing configuration with the incoming source name exists.";
 
     public static final List<String> REQUIRED_FIELDS = ImmutableList.of(SOURCE_NAME);
 
-    public static final Map<String, String> SUCCESS_TYPES = ImmutableMap.of(
-            SOURCE_NAME_EXISTS_SUCCESS,
+    public static final Map<String, String> SUCCESS_TYPES = ImmutableMap.of(SUCCESSFUL_TEST,
             "Source name does not exist.");
 
-    public static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(SOURCE_NAME_EXISTS_FAIL,
+    public static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(INVALID_FIELD,
             "Source name already exists.");
 
     private List<SourceConfigurationHandler> handlers;

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceConfigurationHandler.java
@@ -17,6 +17,7 @@ package org.codice.ddf.admin.sources.opensearch;
 import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.OPENSEARCH_FACTORY_PID;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +37,7 @@ import org.codice.ddf.admin.sources.opensearch.persist.CreateOpenSearchSourcePer
 import org.codice.ddf.admin.sources.opensearch.persist.DeleteOpenSearchSourcePersistMethod;
 import org.codice.ddf.admin.sources.opensearch.probe.DiscoverOpenSearchSourceProbeMethod;
 import org.codice.ddf.admin.sources.opensearch.probe.OpenSearchConfigFromUrlProbeMethod;
+import org.codice.ddf.admin.sources.opensearch.test.SourceNameExistsOpenSearchTestMethod;
 
 public class OpenSearchSourceConfigurationHandler
         extends DefaultConfigurationHandler<SourceConfiguration>
@@ -52,7 +54,7 @@ public class OpenSearchSourceConfigurationHandler
 
     @Override
     public List<TestMethod> getTestMethods() {
-        return null;
+        return Collections.singletonList(new SourceNameExistsOpenSearchTestMethod(new Configurator()));
     }
 
     @Override

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceConfigurationHandler.java
@@ -25,6 +25,7 @@ import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.config.sources.OpenSearchSourceConfiguration;
 import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
 import org.codice.ddf.admin.api.configurator.Configurator;
+import org.codice.ddf.admin.api.handler.ConfigurationHandler;
 import org.codice.ddf.admin.api.handler.DefaultConfigurationHandler;
 import org.codice.ddf.admin.api.handler.SourceConfigurationHandler;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
@@ -46,6 +47,12 @@ public class OpenSearchSourceConfigurationHandler
     public static final String OPENSEARCH_SOURCE_CONFIGURATION_HANDLER_ID =
             OpenSearchSourceConfiguration.CONFIGURATION_TYPE;
 
+    private final ConfigurationHandler handler;
+
+    public OpenSearchSourceConfigurationHandler(ConfigurationHandler handler) {
+        this.handler = handler;
+    }
+
     @Override
     public List<ProbeMethod> getProbeMethods() {
         return Arrays.asList(new DiscoverOpenSearchSourceProbeMethod(),
@@ -59,7 +66,7 @@ public class OpenSearchSourceConfigurationHandler
 
     @Override
     public List<PersistMethod> getPersistMethods() {
-        return Arrays.asList(new CreateOpenSearchSourcePersistMethod(),
+        return Arrays.asList(new CreateOpenSearchSourcePersistMethod(handler),
                 new DeleteOpenSearchSourcePersistMethod());
     }
 

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchSourcePersistMethod.java
@@ -22,7 +22,6 @@ import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.FAILED_PER
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_PERSIST;
 import static org.codice.ddf.admin.api.handler.report.Report.createReport;
 import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.openSearchConfigToServiceProps;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 
 import java.util.List;
 import java.util.Map;
@@ -33,6 +32,7 @@ import org.codice.ddf.admin.api.configurator.OperationReport;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
 import org.codice.ddf.admin.api.handler.report.Report;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -55,6 +55,8 @@ public class CreateOpenSearchSourcePersistMethod
     private static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(FAILED_PERSIST,
             "Failed to create OpenSearch Source.");
 
+    private SourceValidationUtils sourceValidationUtils;
+
     public CreateOpenSearchSourcePersistMethod() {
         super(CREATE_OPENSEARCH_SOURCE_ID,
                 DESCRIPTION,
@@ -63,6 +65,8 @@ public class CreateOpenSearchSourcePersistMethod
                 SUCCESS_TYPES,
                 FAILURE_TYPES,
                 null);
+
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -83,6 +87,6 @@ public class CreateOpenSearchSourcePersistMethod
     @Override
     public List<ConfigurationMessage> validateOptionalFields(
             OpenSearchSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchSourcePersistMethod.java
@@ -99,10 +99,7 @@ public class CreateOpenSearchSourcePersistMethod
     public List<ConfigurationMessage> validateRequiredFields(
             OpenSearchSourceConfiguration configuration) {
         Report report = handler.test(SOURCE_NAME_EXISTS_TEST_ID, configuration);
-        if(report.containsFailureMessages()) {
-            return report.messages();
-        }
-
-        return super.validateRequiredFields(configuration);
+        report.addMessages(super.validateRequiredFields(configuration));
+        return report.messages();
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchSourcePersistMethod.java
@@ -55,7 +55,7 @@ public class CreateOpenSearchSourcePersistMethod
     private static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(FAILED_PERSIST,
             "Failed to create OpenSearch Source.");
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public CreateOpenSearchSourcePersistMethod() {
         super(CREATE_OPENSEARCH_SOURCE_ID,

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/DiscoverOpenSearchSourceProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/DiscoverOpenSearchSourceProbeMethod.java
@@ -27,7 +27,6 @@ import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNKN
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNTRUSTED_CA;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.endpointIsReachable;
 import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.OPENSEARCH_FACTORY_PID;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 import static org.codice.ddf.admin.sources.opensearch.OpenSearchSourceConfigurationHandler.OPENSEARCH_SOURCE_CONFIGURATION_HANDLER_ID;
 
 import java.util.HashMap;
@@ -39,6 +38,7 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.commons.UrlAvailability;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.sources.opensearch.OpenSearchSourceUtils;
 
 import com.google.common.collect.ImmutableList;
@@ -72,7 +72,9 @@ public class DiscoverOpenSearchSourceProbeMethod
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private OpenSearchSourceUtils utils;
+    private OpenSearchSourceUtils openSearchSourceUtils;
+
+    private SourceValidationUtils sourceValidationUtils;
 
     public DiscoverOpenSearchSourceProbeMethod() {
         super(OPENSEARCH_DISCOVER_SOURCES_ID,
@@ -83,7 +85,8 @@ public class DiscoverOpenSearchSourceProbeMethod
                 FAILURE_TYPES,
                 null,
                 RETURN_TYPES);
-        utils = new OpenSearchSourceUtils();
+        openSearchSourceUtils = new OpenSearchSourceUtils();
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -96,7 +99,7 @@ public class DiscoverOpenSearchSourceProbeMethod
             return probeReport;
         }
 
-        UrlAvailability availability = utils.confirmEndpointUrl(configuration);
+        UrlAvailability availability = openSearchSourceUtils.confirmEndpointUrl(configuration);
         if (availability == null) {
             return probeReport.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -130,6 +133,6 @@ public class DiscoverOpenSearchSourceProbeMethod
     @Override
     public List<ConfigurationMessage> validateOptionalFields(
             OpenSearchSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/DiscoverOpenSearchSourceProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/DiscoverOpenSearchSourceProbeMethod.java
@@ -72,9 +72,9 @@ public class DiscoverOpenSearchSourceProbeMethod
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private OpenSearchSourceUtils openSearchSourceUtils;
+    private final OpenSearchSourceUtils openSearchSourceUtils;
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public DiscoverOpenSearchSourceProbeMethod() {
         super(OPENSEARCH_DISCOVER_SOURCES_ID,
@@ -85,6 +85,7 @@ public class DiscoverOpenSearchSourceProbeMethod
                 FAILURE_TYPES,
                 null,
                 RETURN_TYPES);
+
         openSearchSourceUtils = new OpenSearchSourceUtils();
         sourceValidationUtils = new SourceValidationUtils();
     }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/OpenSearchConfigFromUrlProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/OpenSearchConfigFromUrlProbeMethod.java
@@ -28,7 +28,6 @@ import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNTR
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.endpointIsReachable;
 import static org.codice.ddf.admin.api.handler.report.ProbeReport.createProbeReport;
 import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.OPENSEARCH_FACTORY_PID;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 import static org.codice.ddf.admin.sources.opensearch.OpenSearchSourceConfigurationHandler.OPENSEARCH_SOURCE_CONFIGURATION_HANDLER_ID;
 
 import java.util.HashMap;
@@ -40,6 +39,7 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.commons.UrlAvailability;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.sources.opensearch.OpenSearchSourceUtils;
 
 import com.google.common.collect.ImmutableList;
@@ -72,7 +72,9 @@ public class OpenSearchConfigFromUrlProbeMethod extends ProbeMethod<OpenSearchSo
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private OpenSearchSourceUtils utils;
+    private OpenSearchSourceUtils openSearchSourceUtils;
+
+    private SourceValidationUtils sourceValidationUtils;
 
     public OpenSearchConfigFromUrlProbeMethod() {
         super(OPENSEARCH_CONFIG_FROM_URL_ID,
@@ -83,7 +85,8 @@ public class OpenSearchConfigFromUrlProbeMethod extends ProbeMethod<OpenSearchSo
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
-        utils = new OpenSearchSourceUtils();
+        openSearchSourceUtils = new OpenSearchSourceUtils();
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -97,10 +100,10 @@ public class OpenSearchConfigFromUrlProbeMethod extends ProbeMethod<OpenSearchSo
             return report;
         }
 
-        UrlAvailability availability = utils.getUrlAvailability(
-                configuration.endpointUrl(),
-                configuration.sourceUserName(),
-                configuration.sourceUserPassword());
+        UrlAvailability availability =
+                openSearchSourceUtils.getUrlAvailability(configuration.endpointUrl(),
+                        configuration.sourceUserName(),
+                        configuration.sourceUserPassword());
         if (availability == null) {
             return report.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -128,6 +131,6 @@ public class OpenSearchConfigFromUrlProbeMethod extends ProbeMethod<OpenSearchSo
     @Override
     public List<ConfigurationMessage> validateOptionalFields(
             OpenSearchSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/OpenSearchConfigFromUrlProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/probe/OpenSearchConfigFromUrlProbeMethod.java
@@ -72,9 +72,9 @@ public class OpenSearchConfigFromUrlProbeMethod extends ProbeMethod<OpenSearchSo
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private OpenSearchSourceUtils openSearchSourceUtils;
+    private final OpenSearchSourceUtils openSearchSourceUtils;
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public OpenSearchConfigFromUrlProbeMethod() {
         super(OPENSEARCH_CONFIG_FROM_URL_ID,
@@ -85,6 +85,7 @@ public class OpenSearchConfigFromUrlProbeMethod extends ProbeMethod<OpenSearchSo
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
+
         openSearchSourceUtils = new OpenSearchSourceUtils();
         sourceValidationUtils = new SourceValidationUtils();
     }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
@@ -14,12 +14,12 @@
 package org.codice.ddf.admin.sources.opensearch.test;
 
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
+import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_TEST;
+import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.OPENSEARCH_FACTORY_PID;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.DESCRIPTION;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.FAILURE_TYPES;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.REQUIRED_FIELDS;
-import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_SUCCESS;
-import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SUCCESS_TYPES;
 
 import java.util.Collections;
@@ -66,10 +66,7 @@ public class SourceNameExistsOpenSearchTestMethod extends TestMethod<SourceConfi
                         configurator);
 
         if (results.isEmpty()) {
-            return new Report(buildMessage(SUCCESS_TYPES,
-                    FAILURE_TYPES,
-                    null,
-                    SOURCE_NAME_EXISTS_SUCCESS));
+            return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));
         }
 
         Report report = new Report();

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.sources.opensearch.test;
+
+import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
+import static org.codice.ddf.admin.api.services.OpenSearchServiceProperties.OPENSEARCH_FACTORY_PID;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.DESCRIPTION;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.FAILURE_TYPES;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.REQUIRED_FIELDS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_SUCCESS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_TEST_ID;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SUCCESS_TYPES;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
+import org.codice.ddf.admin.api.configurator.Configurator;
+import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.handler.method.TestMethod;
+import org.codice.ddf.admin.api.handler.report.Report;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
+
+public class SourceNameExistsOpenSearchTestMethod extends TestMethod<SourceConfiguration> {
+
+    public static final String OPENSEARCH_SOURCE_EXISTS_ID = SOURCE_NAME_EXISTS_TEST_ID;
+
+    private final Configurator configurator;
+
+    private final SourceValidationUtils sourceValidationUtils;
+
+    public SourceNameExistsOpenSearchTestMethod(Configurator configurator) {
+        super(OPENSEARCH_SOURCE_EXISTS_ID,
+                DESCRIPTION,
+                REQUIRED_FIELDS,
+                null,
+                SUCCESS_TYPES,
+                FAILURE_TYPES,
+                null);
+
+        sourceValidationUtils = new SourceValidationUtils();
+
+        if (configurator == null) {
+            this.configurator = new Configurator();
+        } else {
+            this.configurator = configurator;
+        }
+    }
+
+    @Override
+    public Report test(SourceConfiguration configuration) {
+        List<ConfigurationMessage> results =
+                sourceValidationUtils.validateSourceName(configuration.sourceName(),
+                        Collections.singletonList(OPENSEARCH_FACTORY_PID),
+                        configurator);
+
+        if (results.isEmpty()) {
+            return new Report(buildMessage(SUCCESS_TYPES,
+                    FAILURE_TYPES,
+                    null,
+                    SOURCE_NAME_EXISTS_SUCCESS));
+        }
+
+        Report report = new Report();
+        results.forEach(report::addMessage);
+        return report;
+    }
+}

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
@@ -69,8 +69,6 @@ public class SourceNameExistsOpenSearchTestMethod extends TestMethod<SourceConfi
             return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));
         }
 
-        Report report = new Report();
-        results.forEach(report::addMessage);
-        return report;
+        return new Report(results);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceConfigurationHandler.java
@@ -17,6 +17,7 @@ package org.codice.ddf.admin.sources.wfs;
 import static org.codice.ddf.admin.api.services.WfsServiceProperties.WFS_FACTORY_PIDS;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -36,6 +37,7 @@ import org.codice.ddf.admin.sources.wfs.persist.CreateWfsSourcePersistMethod;
 import org.codice.ddf.admin.sources.wfs.persist.DeleteWfsSourcePersistMethod;
 import org.codice.ddf.admin.sources.wfs.probe.DiscoverWfsSourceProbeMethod;
 import org.codice.ddf.admin.sources.wfs.probe.WfsConfigFromUrlProbeMethod;
+import org.codice.ddf.admin.sources.wfs.test.SourceNameExistsWfsTestMethod;
 
 public class WfsSourceConfigurationHandler extends DefaultConfigurationHandler<SourceConfiguration>
         implements SourceConfigurationHandler<SourceConfiguration> {
@@ -50,7 +52,7 @@ public class WfsSourceConfigurationHandler extends DefaultConfigurationHandler<S
 
     @Override
     public List<TestMethod> getTestMethods() {
-        return null;
+        return Collections.singletonList(new SourceNameExistsWfsTestMethod(new Configurator()));
     }
 
     @Override

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceConfigurationHandler.java
@@ -25,6 +25,7 @@ import org.codice.ddf.admin.api.config.ConfigurationType;
 import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
 import org.codice.ddf.admin.api.config.sources.WfsSourceConfiguration;
 import org.codice.ddf.admin.api.configurator.Configurator;
+import org.codice.ddf.admin.api.handler.ConfigurationHandler;
 import org.codice.ddf.admin.api.handler.DefaultConfigurationHandler;
 import org.codice.ddf.admin.api.handler.SourceConfigurationHandler;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
@@ -45,6 +46,12 @@ public class WfsSourceConfigurationHandler extends DefaultConfigurationHandler<S
     public static final String WFS_SOURCE_CONFIGURATION_HANDLER_ID =
             WfsSourceConfiguration.CONFIGURATION_TYPE;
 
+    private final ConfigurationHandler handler;
+
+    public WfsSourceConfigurationHandler(ConfigurationHandler handler) {
+        this.handler = handler;
+    }
+
     @Override
     public List<ProbeMethod> getProbeMethods() {
         return Arrays.asList(new DiscoverWfsSourceProbeMethod(), new WfsConfigFromUrlProbeMethod());
@@ -57,7 +64,7 @@ public class WfsSourceConfigurationHandler extends DefaultConfigurationHandler<S
 
     @Override
     public List<PersistMethod> getPersistMethods() {
-        return Arrays.asList(new CreateWfsSourcePersistMethod(),
+        return Arrays.asList(new CreateWfsSourcePersistMethod(handler),
                 new DeleteWfsSourcePersistMethod());
     }
 

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
@@ -21,6 +21,7 @@ import static org.codice.ddf.admin.api.config.sources.SourceConfiguration.SOURCE
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.FAILED_PERSIST;
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.CREATE;
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_PERSIST;
+import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.api.handler.report.Report.createReport;
 import static org.codice.ddf.admin.api.services.WfsServiceProperties.wfsConfigToServiceProps;
 
@@ -30,6 +31,7 @@ import java.util.Map;
 import org.codice.ddf.admin.api.config.sources.WfsSourceConfiguration;
 import org.codice.ddf.admin.api.configurator.Configurator;
 import org.codice.ddf.admin.api.configurator.OperationReport;
+import org.codice.ddf.admin.api.handler.ConfigurationHandler;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
 import org.codice.ddf.admin.api.handler.report.Report;
@@ -60,7 +62,9 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
 
     private final SourceValidationUtils sourceValidationUtils;
 
-    public CreateWfsSourcePersistMethod() {
+    private final ConfigurationHandler handler;
+
+    public CreateWfsSourcePersistMethod(ConfigurationHandler handler) {
         super(CREATE_WFS_SOURCE_ID,
                 DESCRIPTION,
                 REQUIRED_FIELDS,
@@ -69,6 +73,7 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
                 FAILURE_TYPES,
                 null);
 
+        this.handler = handler;
         sourceValidationUtils = new SourceValidationUtils();
     }
 
@@ -88,5 +93,15 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
     @Override
     public List<ConfigurationMessage> validateOptionalFields(WfsSourceConfiguration configuration) {
         return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
+    }
+
+    @Override
+    public List<ConfigurationMessage> validateRequiredFields(WfsSourceConfiguration configuration) {
+        Report report = handler.test(SOURCE_NAME_EXISTS_TEST_ID, configuration);
+        if (report.containsFailureMessages()) {
+            return report.messages();
+        }
+
+        return super.validateRequiredFields(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
@@ -23,7 +23,6 @@ import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.CREATE;
 import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_PERSIST;
 import static org.codice.ddf.admin.api.handler.report.Report.createReport;
 import static org.codice.ddf.admin.api.services.WfsServiceProperties.wfsConfigToServiceProps;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 
 import java.util.List;
 import java.util.Map;
@@ -34,6 +33,7 @@ import org.codice.ddf.admin.api.configurator.OperationReport;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.method.PersistMethod;
 import org.codice.ddf.admin.api.handler.report.Report;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -58,6 +58,8 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
     private static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(FAILED_PERSIST,
             "Failed to create WFS Source.");
 
+    private SourceValidationUtils sourceValidationUtils;
+
     public CreateWfsSourcePersistMethod() {
         super(CREATE_WFS_SOURCE_ID,
                 DESCRIPTION,
@@ -66,6 +68,8 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
                 SUCCESS_TYPES,
                 FAILURE_TYPES,
                 null);
+
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -83,6 +87,6 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
 
     @Override
     public List<ConfigurationMessage> validateOptionalFields(WfsSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
@@ -98,10 +98,7 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
     @Override
     public List<ConfigurationMessage> validateRequiredFields(WfsSourceConfiguration configuration) {
         Report report = handler.test(SOURCE_NAME_EXISTS_TEST_ID, configuration);
-        if (report.containsFailureMessages()) {
-            return report.messages();
-        }
-
-        return super.validateRequiredFields(configuration);
+        report.addMessages(super.validateRequiredFields(configuration));
+        return report.messages();
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsSourcePersistMethod.java
@@ -58,7 +58,7 @@ public class CreateWfsSourcePersistMethod extends PersistMethod<WfsSourceConfigu
     private static final Map<String, String> FAILURE_TYPES = ImmutableMap.of(FAILED_PERSIST,
             "Failed to create WFS Source.");
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public CreateWfsSourcePersistMethod() {
         super(CREATE_WFS_SOURCE_ID,

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/DiscoverWfsSourceProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/DiscoverWfsSourceProbeMethod.java
@@ -28,7 +28,6 @@ import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNKN
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNTRUSTED_CA;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.endpointIsReachable;
 import static org.codice.ddf.admin.api.handler.report.ProbeReport.createProbeReport;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 import static org.codice.ddf.admin.sources.wfs.WfsSourceConfigurationHandler.WFS_SOURCE_CONFIGURATION_HANDLER_ID;
 
 import java.util.HashMap;
@@ -41,6 +40,7 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.commons.UrlAvailability;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.sources.wfs.WfsSourceUtils;
 
 import com.google.common.collect.ImmutableList;
@@ -75,7 +75,9 @@ public class DiscoverWfsSourceProbeMethod extends ProbeMethod<WfsSourceConfigura
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private WfsSourceUtils utils;
+    private WfsSourceUtils wfsSourceUtils;
+
+    private SourceValidationUtils sourceValidationUtils;
 
     public DiscoverWfsSourceProbeMethod() {
         super(WFS_DISCOVER_SOURCES_ID,
@@ -86,7 +88,8 @@ public class DiscoverWfsSourceProbeMethod extends ProbeMethod<WfsSourceConfigura
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
-        utils = new WfsSourceUtils();
+        wfsSourceUtils = new WfsSourceUtils();
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -100,7 +103,7 @@ public class DiscoverWfsSourceProbeMethod extends ProbeMethod<WfsSourceConfigura
             return probeReport;
         }
 
-        UrlAvailability availability = utils.confirmEndpointUrl(config);
+        UrlAvailability availability = wfsSourceUtils.confirmEndpointUrl(config);
         if (availability == null) {
             return probeReport.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -115,7 +118,7 @@ public class DiscoverWfsSourceProbeMethod extends ProbeMethod<WfsSourceConfigura
             return probeReport;
         }
 
-        Optional<WfsSourceConfiguration> createdConfig = utils.getPreferredConfig(config);
+        Optional<WfsSourceConfiguration> createdConfig = wfsSourceUtils.getPreferredConfig(config);
         if (!createdConfig.isPresent()) {
             return probeReport.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -137,7 +140,7 @@ public class DiscoverWfsSourceProbeMethod extends ProbeMethod<WfsSourceConfigura
 
     @Override
     public List<ConfigurationMessage> validateOptionalFields(WfsSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }
 

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/DiscoverWfsSourceProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/DiscoverWfsSourceProbeMethod.java
@@ -88,6 +88,7 @@ public class DiscoverWfsSourceProbeMethod extends ProbeMethod<WfsSourceConfigura
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
+
         wfsSourceUtils = new WfsSourceUtils();
         sourceValidationUtils = new SourceValidationUtils();
     }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/WfsConfigFromUrlProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/WfsConfigFromUrlProbeMethod.java
@@ -79,9 +79,9 @@ public class WfsConfigFromUrlProbeMethod extends ProbeMethod<WfsSourceConfigurat
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private WfsSourceUtils wfsSourceUtils;
+    private final WfsSourceUtils wfsSourceUtils;
 
-    private SourceValidationUtils sourceValidationUtils;
+    private final SourceValidationUtils sourceValidationUtils;
 
     public WfsConfigFromUrlProbeMethod() {
         super(WFS_CONFIG_FROM_URL_ID,

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/WfsConfigFromUrlProbeMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/probe/WfsConfigFromUrlProbeMethod.java
@@ -28,7 +28,6 @@ import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNKN
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.UNTRUSTED_CA;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.VERIFIED_URL;
 import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.endpointIsReachable;
-import static org.codice.ddf.admin.api.validation.SourceValidationUtils.validateOptionalUsernameAndPassword;
 import static org.codice.ddf.admin.sources.wfs.WfsSourceConfigurationHandler.WFS_SOURCE_CONFIGURATION_HANDLER_ID;
 
 import java.util.HashMap;
@@ -41,6 +40,7 @@ import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.commons.UrlAvailability;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
 import org.codice.ddf.admin.sources.wfs.WfsSourceUtils;
 
 import com.google.common.collect.ImmutableList;
@@ -79,7 +79,9 @@ public class WfsConfigFromUrlProbeMethod extends ProbeMethod<WfsSourceConfigurat
 
     public static final List<String> RETURN_TYPES = ImmutableList.of(DISCOVERED_SOURCES);
 
-    private WfsSourceUtils utils;
+    private WfsSourceUtils wfsSourceUtils;
+
+    private SourceValidationUtils sourceValidationUtils;
 
     public WfsConfigFromUrlProbeMethod() {
         super(WFS_CONFIG_FROM_URL_ID,
@@ -90,7 +92,9 @@ public class WfsConfigFromUrlProbeMethod extends ProbeMethod<WfsSourceConfigurat
                 FAILURE_TYPES,
                 WARNING_TYPES,
                 RETURN_TYPES);
-        utils = new WfsSourceUtils();
+
+        wfsSourceUtils = new WfsSourceUtils();
+        sourceValidationUtils = new SourceValidationUtils();
     }
 
     @Override
@@ -103,10 +107,10 @@ public class WfsConfigFromUrlProbeMethod extends ProbeMethod<WfsSourceConfigurat
             return report;
         }
 
-        UrlAvailability availability = utils.getUrlAvailability(
-                configuration.endpointUrl(),
-                configuration.sourceUserName(),
-                configuration.sourceUserPassword());
+        UrlAvailability availability =
+                wfsSourceUtils.getUrlAvailability(configuration.endpointUrl(),
+                        configuration.sourceUserName(),
+                        configuration.sourceUserPassword());
         if (availability == null) {
             return report.addMessage(buildMessage(SUCCESS_TYPES,
                     FAILURE_TYPES,
@@ -122,7 +126,7 @@ public class WfsConfigFromUrlProbeMethod extends ProbeMethod<WfsSourceConfigurat
             return report;
         }
 
-        Optional<WfsSourceConfiguration> createdConfig = utils.getPreferredConfig(
+        Optional<WfsSourceConfiguration> createdConfig = wfsSourceUtils.getPreferredConfig(
                 configuration);
         if (!createdConfig.isPresent()) {
             return report.addMessage(buildMessage(SUCCESS_TYPES,
@@ -145,6 +149,6 @@ public class WfsConfigFromUrlProbeMethod extends ProbeMethod<WfsSourceConfigurat
 
     @Override
     public List<ConfigurationMessage> validateOptionalFields(WfsSourceConfiguration configuration) {
-        return validateOptionalUsernameAndPassword(configuration);
+        return sourceValidationUtils.validateOptionalUsernameAndPassword(configuration);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
@@ -68,8 +68,6 @@ public class SourceNameExistsWfsTestMethod extends TestMethod<SourceConfiguratio
             return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));
         }
 
-        Report report = new Report();
-        results.forEach(report::addMessage);
-        return report;
+        return new Report(results);
     }
 }

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.sources.wfs.test;
+
+import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
+import static org.codice.ddf.admin.api.services.WfsServiceProperties.WFS_FACTORY_PIDS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.DESCRIPTION;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.FAILURE_TYPES;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.REQUIRED_FIELDS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_SUCCESS;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_TEST_ID;
+import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SUCCESS_TYPES;
+
+import java.util.List;
+
+import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
+import org.codice.ddf.admin.api.configurator.Configurator;
+import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.handler.method.TestMethod;
+import org.codice.ddf.admin.api.handler.report.Report;
+import org.codice.ddf.admin.api.validation.SourceValidationUtils;
+
+public class SourceNameExistsWfsTestMethod extends TestMethod<SourceConfiguration> {
+
+    public static final String WFS_SOURCE_EXISTS_ID = SOURCE_NAME_EXISTS_TEST_ID;
+
+    private final Configurator configurator;
+
+    private final SourceValidationUtils sourceValidationUtils;
+
+    public SourceNameExistsWfsTestMethod(Configurator configurator) {
+        super(WFS_SOURCE_EXISTS_ID,
+                DESCRIPTION,
+                REQUIRED_FIELDS,
+                null,
+                SUCCESS_TYPES,
+                FAILURE_TYPES,
+                null);
+
+        this.sourceValidationUtils = new SourceValidationUtils();
+
+        if (configurator == null) {
+            this.configurator = new Configurator();
+        } else {
+            this.configurator = configurator;
+        }
+    }
+
+    @Override
+    public Report test(SourceConfiguration configuration) {
+        List<ConfigurationMessage> results =
+                sourceValidationUtils.validateSourceName(configuration.sourceName(),
+                        WFS_FACTORY_PIDS,
+                        configurator);
+
+        if (results.isEmpty()) {
+            return new Report(buildMessage(SUCCESS_TYPES,
+                    FAILURE_TYPES,
+                    null,
+                    SOURCE_NAME_EXISTS_SUCCESS));
+        }
+
+        Report report = new Report();
+        results.forEach(report::addMessage);
+        return report;
+    }
+}

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
@@ -14,12 +14,12 @@
 package org.codice.ddf.admin.sources.wfs.test;
 
 import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage;
+import static org.codice.ddf.admin.api.handler.commons.HandlerCommons.SUCCESSFUL_TEST;
+import static org.codice.ddf.admin.api.handler.commons.SourceHandlerCommons.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.api.services.WfsServiceProperties.WFS_FACTORY_PIDS;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.DESCRIPTION;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.FAILURE_TYPES;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.REQUIRED_FIELDS;
-import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_SUCCESS;
-import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SOURCE_NAME_EXISTS_TEST_ID;
 import static org.codice.ddf.admin.sources.impl.test.SourceNameExistsTestMethod.SUCCESS_TYPES;
 
 import java.util.List;
@@ -65,10 +65,7 @@ public class SourceNameExistsWfsTestMethod extends TestMethod<SourceConfiguratio
                         configurator);
 
         if (results.isEmpty()) {
-            return new Report(buildMessage(SUCCESS_TYPES,
-                    FAILURE_TYPES,
-                    null,
-                    SOURCE_NAME_EXISTS_SUCCESS));
+            return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));
         }
 
         Report report = new Report();

--- a/federation/source-config-handlers/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/federation/source-config-handlers/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -19,10 +19,15 @@
         </bean>
     <service ref="sourceConfigurationHandler"
              interface="org.codice.ddf.admin.api.handler.ConfigurationHandler">
+        <service-properties>
+            <entry key="id" value="SourceConfigurationHandler"/>
+        </service-properties>
     </service>
 
     <bean id="cswConfigurationHandler"
-          class="org.codice.ddf.admin.sources.csw.CswSourceConfigurationHandler"/>
+          class="org.codice.ddf.admin.sources.csw.CswSourceConfigurationHandler">
+        <argument ref="sourceConfigurationHandler"/>
+    </bean>
     <service ref="cswConfigurationHandler">
         <interfaces>
             <value>org.codice.ddf.admin.api.handler.SourceConfigurationHandler</value>
@@ -31,7 +36,9 @@
     </service>
 
     <bean id="wfsConfigurationHandler"
-          class="org.codice.ddf.admin.sources.wfs.WfsSourceConfigurationHandler"/>
+          class="org.codice.ddf.admin.sources.wfs.WfsSourceConfigurationHandler">
+        <argument ref="sourceConfigurationHandler"/>
+    </bean>
     <service ref="wfsConfigurationHandler">
         <interfaces>
             <value>org.codice.ddf.admin.api.handler.SourceConfigurationHandler</value>
@@ -40,7 +47,9 @@
     </service>
 
     <bean id="openSearchConfigurationHandler"
-          class="org.codice.ddf.admin.sources.opensearch.OpenSearchSourceConfigurationHandler"/>
+          class="org.codice.ddf.admin.sources.opensearch.OpenSearchSourceConfigurationHandler">
+        <argument ref="sourceConfigurationHandler"/>
+    </bean>
     <service ref="openSearchConfigurationHandler">
         <interfaces>
             <value>org.codice.ddf.admin.api.handler.SourceConfigurationHandler</value>

--- a/ui/src/main/webapp/wizards/sources/actions.js
+++ b/ui/src/main/webapp/wizards/sources/actions.js
@@ -97,17 +97,8 @@ export const persistConfig = (url, config, nextStageId, configType, id = 'genera
     }
     const body = JSON.stringify(configuration)
 
-    let res = await dispatch(post('/admin/beta/config/test/sources/source-name-exists', { body }))
+    let res = await dispatch(post(url, { body }))
     let json = await res.json()
-
-    if (containsErrors(json)) {
-      dispatch(clearMessages(id))
-      dispatch(setMessages(id, filterErrors(json.messages)))
-      return
-    }
-
-    res = await dispatch(post(url, { body }))
-    json = await res.json()
 
     if (containsErrors(json)) {
       dispatch(clearMessages(id))

--- a/ui/src/main/webapp/wizards/sources/actions.js
+++ b/ui/src/main/webapp/wizards/sources/actions.js
@@ -97,8 +97,17 @@ export const persistConfig = (url, config, nextStageId, configType, id = 'genera
     }
     const body = JSON.stringify(configuration)
 
-    let res = await dispatch(post(url, { body }))
+    let res = await dispatch(post('/admin/beta/config/test/sources/source-name-exists', { body }))
     let json = await res.json()
+
+    if (containsErrors(json)) {
+      dispatch(clearMessages(id))
+      dispatch(setMessages(id, filterErrors(json.messages)))
+      return
+    }
+
+    res = await dispatch(post(url, { body }))
+    json = await res.json()
 
     if (containsErrors(json)) {
       dispatch(clearMessages(id))


### PR DESCRIPTION
- Cannot have duplicate source names anymore
- Error will appear if attempting to create a duplicate source name
- Unit tests
- The SourceNameExists TestMethod will be called during a Persist for a specific Source Configuration Handler.

@tbatie @adimka @coyotesqrl 

Manual test:
Create a source.
Attempt to create another source with same name. Observe error message.
Test this for CSW, WFS, and OpenSearch.