### PR TITLE
DDF-2773 Fixes exception thrown by ServerGuesser

### DIFF
--- a/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/ServerGuesser.java
+++ b/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/ServerGuesser.java
@@ -94,9 +94,12 @@ public abstract class ServerGuesser {
 
             ArrayList<String> contexts = new ArrayList<>();
             while (reader.hasNext()) {
-                contexts.add(reader.readEntry()
-                        .getAttribute("namingContexts")
-                        .firstValueAsString());
+                SearchResultEntry entry = reader.readEntry();
+                if (entry.containsAttribute("namingContexts")) {
+                    contexts.add(entry
+                            .getAttribute("namingContexts")
+                            .firstValueAsString());
+                }
             }
 
             if (contexts.isEmpty()) {
@@ -233,9 +236,14 @@ public abstract class ServerGuesser {
                         "rootDomainNamingContext");
 
                 if (reader.hasNext()) {
-                    return Collections.singletonList(reader.readEntry()
-                            .getAttribute("rootDomainNamingContext")
-                            .firstValueAsString());
+                    SearchResultEntry entry = reader.readEntry();
+                    if (entry.containsAttribute("rootDomainNamingContext")) {
+                        return Collections.singletonList(entry.getAttribute(
+                                "rootDomainNamingContext")
+                                .firstValueAsString());
+                    } else {
+                        return Collections.singletonList("");
+                    }
                 } else {
                     return Collections.singletonList("");
                 }


### PR DESCRIPTION
Exception thrown by `ServerGuesser` when no rootDomainNamingContext attribute found in base object search.

This can occur if ActiveDirectory is misconfigured, or if the AD profile is chosen for a non-AD server.

#### What does this PR do?
Confirms first that the attribute exists before attempting to extract its value.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@garrettfreibott @adimka @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)
Select ActiveDirectory as the server type but point to a running Embedded LDAP (or other LDAP type externally if one is available) and step forward to the Directory Structure stage. If no exception is thrown, the stage should display correctly.

#### Any background context you want to provide?
N/A

#### Screenshots (if appropriate)
N/A