### PR TITLE
DDF-2773 Ensures that an invalid PID (one with no known factory PID) will not incorrectly report success on deletion.

### DIFF
--- a/api/src/main/java/org/codice/ddf/admin/api/configurator/operations/ManagedServiceOperation.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/configurator/operations/ManagedServiceOperation.java
@@ -173,6 +173,11 @@ public abstract class ManagedServiceOperation
 
     protected void deleteByPid(String configPid) {
         try {
+            if (factoryPid == null) {
+                ManagedServiceOperation.LOGGER.debug("Error getting factory for pid {}",
+                        configPid);
+                throw new ConfiguratorException("Internal error");
+            }
             cfgAdmMbean.delete(configPid);
         } catch (IOException e) {
             LOGGER.debug("Error deleting managed service with pid {}", configPid, e);

--- a/api/src/test/groovy/org/codice/ddf/admin/api/ManagedServiceHandlerTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/ManagedServiceHandlerTest.groovy
@@ -1,5 +1,6 @@
 package org.codice.ddf.admin.api
 
+import org.codice.ddf.admin.api.configurator.ConfiguratorException
 import org.codice.ddf.admin.api.configurator.operations.ManagedServiceOperation
 import org.codice.ddf.ui.admin.api.ConfigurationAdmin
 import org.codice.ddf.ui.admin.api.ConfigurationAdminMBean
@@ -54,5 +55,19 @@ class ManagedServiceHandlerTest extends Specification {
         1 * configAdmin.createFactoryConfiguration('factoryPid') >> 'newPid'
         1 * cfgAdmMbean.update('newPid', configs)
         key == 'newPid'
+    }
+
+    def 'test delete of pid with unknown factory pid fails'() {
+        setup:
+        def configs = [k1: 'v1', k2: 'v2']
+        cfgAdmMbean.getFactoryPid('xxx') >> null
+        cfgAdmMbean.getProperties('xxx') >> configs
+        def handler = ManagedServiceOperation.forDelete('xxx', configAdmin, cfgAdmMbean)
+
+        when:
+        handler.commit()
+
+        then:
+        thrown ConfiguratorException
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Fixes the case where an invalid/unknown pid will result in a silent pass. Instead, will report a transaction failure.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @peterhuffer @adimka 

#### How should this be tested? (List steps with links to updated documentation)
Unit test should be sufficient. Otherwise, calling the `Configurator.deleteManagedService()` method with an unknown managed service pid (e.g. with a factory pid instead of the pid of a managed instance) and attempting to commit should result in a transaction failure.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [X] Update / Add Unit Tests
