### PR TITLE
DDF-2773: Fix error when creating LDAP Authentication Source

### DIFF
--- a/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
@@ -98,6 +98,11 @@ public class SourceValidationUtils {
      */
     public List<ConfigurationMessage> validateSourceName(@Nonnull String sourceName,
             @Nonnull List<String> factoryPids, Configurator configurator) {
+        List<ConfigurationMessage> errors = validateString(sourceName, SOURCE_NAME);
+        if(!errors.isEmpty()) {
+            return errors;
+        }
+
         if (configurator == null) {
             configurator = new Configurator();
         }

--- a/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
@@ -24,7 +24,7 @@ class SourceValidationUtilsTest extends Specification {
         sourceValidationUtils = new SourceValidationUtils()
     }
 
-    def 'test validateSourceName(String, String) with no existing config with source name'() {
+    def 'test validateSourceName(String, String, Configurator) with no existing config with source name'() {
         when:
         List<ConfigurationMessage> results = sourceValidationUtils.validateSourceName(NEW_SOURCE_NAME, FACTORY_IDS, configurator)
 
@@ -32,7 +32,18 @@ class SourceValidationUtilsTest extends Specification {
         results.isEmpty()
     }
 
-    def 'test validateSourceName(String, String) with duplicate source name'() {
+    def 'test validateSourceName(String, String, Configurator) failure with empty source name'() {
+        when:
+        List<ConfigurationMessage> results = sourceValidationUtils.validateSourceName("", FACTORY_IDS, configurator)
+
+        then:
+        results.size() == 1
+        results.get(0).type() == ConfigurationMessage.MessageType.FAILURE
+        results.get(0).configFieldId() == CONFIG_FIELD_ID
+        results.get(0).subtype() == ConfigurationMessage.MISSING_REQUIRED_FIELD
+    }
+
+    def 'test validateSourceName(String, String, Configurator) with duplicate source name'() {
         when:
         List<ConfigurationMessage> results = sourceValidationUtils.validateSourceName(EXISTING_SOURCE_NAME, FACTORY_IDS, configurator)
 
@@ -43,7 +54,7 @@ class SourceValidationUtilsTest extends Specification {
         results.get(0).subtype() == ConfigurationMessage.INVALID_FIELD
     }
 
-    def 'test validateSourceName(String, String) with invalid existing config id property'() {
+    def 'test validateSourceName(String, String, Configurator) with invalid existing config id property'() {
         when:
         configurator = mockConfigurator(true)
         sourceValidationUtils = new SourceValidationUtils()

--- a/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/persist/CreateLdapConfigMethod.java
+++ b/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/persist/CreateLdapConfigMethod.java
@@ -144,8 +144,15 @@ public class CreateLdapConfigMethod extends PersistMethod<LdapConfiguration> {
     public List<ConfigurationMessage> validateOptionalFields(LdapConfiguration configuration) {
         List<ConfigurationMessage> validationResults = validateBindRealm(configuration);
         if (configuration.ldapUseCase()
-                .equals(AUTHENTICATION) || configuration.ldapUseCase()
-                .equals(AUTHENTICATION_AND_ATTRIBUTE_STORE)) {
+                .equals(AUTHENTICATION)) {
+            validationResults.addAll(configuration.validate(ImmutableList.of(GROUP_OBJECT_CLASS,
+                    GROUP_ATTRIBUTE_HOLDING_MEMBER,
+                    MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP)));
+        }
+
+        if (configuration.ldapUseCase()
+                .equals(AUTHENTICATION_AND_ATTRIBUTE_STORE) || configuration.ldapUseCase()
+                .equals(ATTRIBUTE_STORE)) {
             validationResults.addAll(configuration.validate(ImmutableList.of(GROUP_OBJECT_CLASS,
                     GROUP_ATTRIBUTE_HOLDING_MEMBER,
                     MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP,


### PR DESCRIPTION
#### What does this PR do?
- Fixes empty attributeMappings check when only creating LDAP Authentication Source
- Fix empty string passing Source Name Exists test method.
- Add unit test for emptry string source name.


#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @adimka 

#### How should this be tested? (List steps with links to updated documentation)
Configure all available LDAP types. Authentication, Attribute Store, Authentication and Attribute Store.
Passing unit tests for SourceValidationUtils.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
