### PR TITLE
DDF-2773 Fixes javadoc errors and enables javadoc generation

### DIFF
--- a/api/src/main/java/org/codice/ddf/admin/api/configurator/Configurator.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/configurator/Configurator.java
@@ -317,6 +317,7 @@ public class Configurator {
      * any changes should be done through a commit
      *
      * @param serviceClass - Class of service to retrieve
+     * @param <S> type to be returned
      * @return first found service reference of serviceClass
      * @throws ConfiguratorException if any errors occur
      */

--- a/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
@@ -84,15 +84,15 @@ public class SourceValidationUtils {
     }
 
     /**
-     * Validates the {@param sourceName} against the existing source names of the configuration's for
-     * the given {@param factoryPids} using the {@param configurator}. An empty {@link List} will be returned
-     * if there are no existing source names with with name {@param sourceName}, or a {@link List} containing
-     * {@link ConfigurationMessage}s if there are errors. If the {@param configurator} is {@code null}, one will
+     * Validates the {@code sourceName} against the existing source names of the configuration's for
+     * the given {@code factoryPids} using the {@code configurator}. An empty {@link List} will be returned
+     * if there are no existing source names with with name {@code sourceName}, or a {@link List} containing
+     * {@link ConfigurationMessage}s if there are errors. If the {@code configurator} is {@code null}, one will
      * be created.
      *
      * @param sourceName   a non null name to validate
      * @param factoryPids  a list of non null factory pids of the configuration to validate names against
-     * @param configurator configurator to fetch configurations for the given {@param factoryPids}
+     * @param configurator configurator to fetch configurations for the given {@code factoryPids}
      * @return a {@link List} of {@link ConfigurationMessage}s containing failure messages, or empty {@link List}
      * if there are no duplicate source names found
      */

--- a/pom.xml
+++ b/pom.xml
@@ -72,40 +72,6 @@
             <url>${reports.repository.url}</url>
         </site>
     </distributionManagement>
-    <profiles>
-        <profile>
-            <id>release</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 
     <dependencies>
         <!--Spock dependencies-->
@@ -341,6 +307,28 @@
                 <configuration>
                     <argLine>${argLine} -Djava.awt.headless=true -noverify</argLine>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
#### What does this PR do?
Javadocs will be generated for all builds. Docs and sources attached to all releases.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @tbatie 

#### How should this be tested? (List steps with links to updated documentation)
Run a build and ensure docs are generated.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
