### PR TITLE
DDF-2773: Added conditional snapshot deploy for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ env:
     - secure: "kFHe2uFDq7toVyjZFxypZ5r9OZvaYWXEm2qPULkVms1DgSQqBncEKuSy9Y0Ab9UXlLkG0b9uUq8EEbXXcYX+OEnWIqOKleh+q/p912P/Xhmx2WFvs++743xzNa7gpBH5apZLlvLZst+UKfggvdMUqDSoSTZic1Pm+/RtMRbybMgnrdMvxXPaDqmjXGkKCoYE2OaUxQd+MtSUzgX76cXkCIADTrZKnGEKrfSzm52W0Lr90CQChJc9HOLtOiZYjYByLMRPLOZMEbG/fGjz2CSLP3BqCXuGwCW/4QcIaSk+DFxPu33HzKjYTztQYtGYksl1aY4WKlWw/BYfmZ4tzWIuyCSOVJcrxHZiXO3qj2fJDmK9QL/5yKVT+a7ly3ObiAdjtM5PF8h1qRP9Y++gLTUdBca5jaBvgqXTfdRvtwOo7vnD/VxDLy7+cd7f8qOo3fAacSedeQfYn5g0F0xaMB2tb2izdSBA1nb/nFGYdYffHIobmJplVwshi5GiGo8t1bYhel+HfT1SS8DyhAZXa5473UAQ8Lu/SErCqKsuFJMfiUa6TuS6Su3E2jJB3sjPYQP1Dhvp/vKCcY7z+Z0d6BoSQFYbkAgDNSqeZC/hjnzk+Di3Q1Q9KAT9x8RCH7cwmuDnLxGIzFnK3ECJIzz/ofoaPokrV9AYcPXa0HEuAr9vr7M="
 
 after_success:
-  - mvn clean deploy --settings ./travis_settings.xml
+  - ./snapshot-deploy.sh

--- a/snapshot-deploy.sh
+++ b/snapshot-deploy.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+if [ ! -z "$CODICE_PASSWORD" ]; then
+  echo "The codice password was available in the environment, deploying snapshots to nexus."
+  mvn clean deploy --settings ./travis_settings.xml
+else
+  echo "The codice password was not available in the environment, skipping deploy to nexus."
+fi


### PR DESCRIPTION
#### What does this PR do?

Conditionally deploy to nexus if the codice credentials are available.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@coyotesqrl 
@tbatie 

#### How should this be tested? (List steps with links to updated documentation)

The PR build should not try to deploy snapshot artifacts to nexus.

#### Any background context you want to provide?

Currently, travis will always try to deploy to nexus after a successful build, this adds a condition that to deploy, the `$CODICE_PASSWORD` environment variable should be available, which is not available for PR builds.

#### What are the relevant tickets?

[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
