### PR TITLE
DDF-2773: Confirm on delete configs (dependency on PR #28)

### DIFF
--- a/ui/src/main/webapp/home/index.js
+++ b/ui/src/main/webapp/home/index.js
@@ -16,10 +16,13 @@ import { cyan500 } from 'material-ui/styles/colors'
 import RaisedButton from 'material-ui/RaisedButton'
 import MapDisplay from 'components/MapDisplay'
 import Spinner from 'components/Spinner'
+import confirmable from 'react-confirmable'
 
 import * as selectors from './reducer'
 import * as actions from './actions'
 import * as styles from './styles.less'
+
+const ConfirmableButton = confirmable(RaisedButton)
 
 const getSourceTypeFromFactoryPid = (factoryPid) => {
   return factoryPid.replace(/_/g, ' ')
@@ -45,7 +48,10 @@ const SourceTileView = (props) => {
           <ConfigField fieldName='Endpoint' value={endpointUrl} />
           <ConfigField fieldName='Username' value={sourceUserName || 'none'} />
           <ConfigField fieldName='Password' value={sourceUserName || '******'} />
-          <RaisedButton style={{marginTop: 20}} label='Delete' secondary onClick={onDeleteConfig} />
+          <div style={{ textAlign: 'center' }}>
+            <ConfirmableButton confirmableMessage='Confirm delete?' style={{ marginTop: 20 }}
+              label='Delete' secondary onClick={onDeleteConfig} />
+          </div>
           {messages.map((message, i) => (
             <Flexbox key={i} flexDirection='row' justifyContent='center' className={styles.error}>{message.message}</Flexbox>))}
         </div>
@@ -94,7 +100,10 @@ const LdapTileView = (props) => {
               <MapDisplay label='Attribute Mappings'
                 mapping={attributeMappings} />
           ) : null }
-          <RaisedButton style={{marginTop: 20}} label='Delete' secondary onClick={onDeleteConfig} />
+          <div style={{ textAlign: 'center' }}>
+            <ConfirmableButton confirmableMessage='Confirm delete?' style={{ marginTop: 20 }}
+              label='Delete' secondary onClick={onDeleteConfig} />
+          </div>
           {messages.map((message, i) => (
             <Flexbox key={i} flexDirection='row' justifyContent='center' className={styles.error}>{message.message}</Flexbox>))}
         </div>


### PR DESCRIPTION
**NOTE**: this PR directly utilizes a refactored component from PR #28 - please only review the most recent commit on this PR.

#### What does this PR do?
Adds a confirm dialog to the Sources and LDAP home screen configs. Also centers the delete buttons because they look a bit cleaner that way with the confirmation dialog.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue 

#### How should this be tested? (List steps with links to updated documentation)
Click the delete buttons and make sure that a confirmation dialog appears. Confirm that the "Yes" and "No" buttons delete and cancel the delete respectively.

#### Screenshots
![screen shot 2017-03-05 at 18 05 01](https://cloud.githubusercontent.com/assets/12499654/23593593/53b5309a-01ce-11e7-9ddf-b23eff92c352.png)
![screen shot 2017-03-05 at 18 05 11](https://cloud.githubusercontent.com/assets/12499654/23593595/55a6116c-01ce-11e7-82fc-4852f099042d.png)

Spinner is displayed after pressing "Yes".