### PR TITLE
DDF-2773: LDAP directory page skippable warnings (dependency on PR #28)

### DIFF
--- a/ui/src/main/webapp/lib/admin-wizard/actions.js
+++ b/ui/src/main/webapp/lib/admin-wizard/actions.js
@@ -12,6 +12,8 @@ export const editConfig = (id, value) => ({ type: 'EDIT_CONFIG', id, value })
 export const editConfigs = (values) => ({ type: 'EDIT_CONFIGS', values })
 export const setDefaults = (values) => ({ type: 'SET_DEFAULTS', values })
 export const clearWizard = () => ({ type: 'CLEAR_WIZARD' })
+export const setSkippable = (stageId) => ({ type: 'ALLOW_SKIP', stageId })
+export const setNotSkippable = () => ({ type: 'DONT_ALLOW_SKIP' })
 
 export const probe = (options) => async (dispatch, getState) => {
   const { stageId, ...opts } = options
@@ -58,11 +60,21 @@ export const test = (options) => async (dispatch, getState) => {
 
   if (res.status === 400) {
     dispatch(setMessages(stageId, json.messages))
+    if (onlyHasWarnings(json.messages)) {
+      dispatch(setSkippable(stageId))
+    } else {
+      dispatch(setNotSkippable())
+    }
   } else if (res.status === 200) {
     dispatch(setMessages(stageId, json.messages))
     if (nextStageId !== undefined) {
       dispatch(nextStage({ nextStageId }))
     }
   }
+}
+
+const onlyHasWarnings = (messages) => {
+  messages.forEach((message) => { if (message.type !== 'WARNING') return false })
+  return true
 }
 

--- a/ui/src/main/webapp/lib/admin-wizard/index.js
+++ b/ui/src/main/webapp/lib/admin-wizard/index.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import Mount from 'react-mount'
 
-import { getDisplayedLdapStage, getAllConfig, isSubmitting, getMessages } from '../../reducer'
+import { getDisplayedLdapStage, getAllConfig, isSubmitting, getMessages, getAllowSkip } from '../../reducer'
 
 import {
   // sync
@@ -42,7 +42,8 @@ const mapStateToProps = (state, { wizardId }) => {
     stageId,
     configs: getAllConfig(state),
     submitting: isSubmitting(state, stageId),
-    messages: getMessages(state, stageId)
+    messages: getMessages(state, stageId),
+    allowSkip: getAllowSkip(state, stageId)
   }
 }
 

--- a/ui/src/main/webapp/lib/admin-wizard/reducer.js
+++ b/ui/src/main/webapp/lib/admin-wizard/reducer.js
@@ -6,6 +6,7 @@ export const getAllConfig = (state) => state.get('config').map((config) => confi
 export const getMessages = (state, id) => state.getIn(['messages', id], List()).toJS()
 export const getProbeValue = (state) => state.getIn(['probeValue'])
 export const getDisplayedLdapStage = (state) => state.getIn(['ldapDisplayedStages']).last()
+export const getAllowSkip = (state, stageId) => state.getIn(['allowSkip', stageId])
 
 // TODO: add reducer checks for the wizardClear action to reset the state to defaults
 const config = (state = Map(), { type, id, value, values, messages, options }) => {
@@ -75,10 +76,25 @@ const ldapDisplayedStages = (state = List.of('introduction-stage'), { type, stag
   }
 }
 
+const allowSkip = (state = Map(), { type, stageId }) => {
+  switch (type) {
+    case 'ALLOW_SKIP':
+      return state.set(stageId, true)
+    case 'DONT_ALLOW_SKIP':
+    case 'EDIT_CONFIG':
+    case 'LDAP_ADD_STAGE':
+    case 'LDAP_REMOVE_STAGE':
+      return Map()
+    default:
+      return state
+  }
+}
+
 export default combineReducers({
   config,
   probeValue,
   messages,
-  ldapDisplayedStages
+  ldapDisplayedStages,
+  allowSkip
 })
 

--- a/ui/src/main/webapp/lib/components/ActionMessage.js
+++ b/ui/src/main/webapp/lib/components/ActionMessage.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import Flexbox from 'flexbox-react'
+
+import FlatButton from 'material-ui/FlatButton'
+
+import Message from 'components/Message'
+
+export default ({ type, message, ...rest }) => {
+  return (
+    <Message type={type} >
+      <Flexbox flexDirection='row' alignItems='center' justifyContent='space-between'>
+        <div>{message}</div>
+        <FlatButton {...rest} />
+      </Flexbox>
+    </Message>
+  )
+}

--- a/ui/src/main/webapp/lib/components/Message.js
+++ b/ui/src/main/webapp/lib/components/Message.js
@@ -2,6 +2,16 @@ import React from 'react'
 
 import * as styles from './styles.less'
 
-export default ({ type, message }) => (
-  <div className={type === 'FAILURE' ? styles.error : styles.success}>{message}</div>
-)
+export default ({ type, message, children }) => {
+  const styleMap = {
+    FAILURE: styles.error,
+    WARNING: styles.warning,
+    SUCCESS: styles.success
+  }
+  return (
+    <div className={styleMap[type] || styleMap.SUCCESS}>
+      {message}
+      {children}
+    </div>
+  )
+}

--- a/ui/src/main/webapp/lib/components/styles.less
+++ b/ui/src/main/webapp/lib/components/styles.less
@@ -62,6 +62,18 @@
   font-weight: bold;
 }
 
+.warning {
+  margin-top: 20px;
+  color: white;
+  background: #FF9800;
+  padding: 10px;
+  box-sizing: border-box;
+  box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
+  border-radius: 2px;
+  font-size: 14px;
+  font-weight: bold;
+}
+
 .center {
   text-align: center;
 }

--- a/ui/src/main/webapp/reducer/index.js
+++ b/ui/src/main/webapp/reducer/index.js
@@ -33,6 +33,7 @@ export const getProbeValue = (state) => ldap.getProbeValue(state.get('wizard'))
 export const getStep = (state) => ldap.getStep(state.get('wizard'))
 export const getMessages = (state, id) => ldap.getMessages(state.get('wizard'), id)
 export const getDisplayedLdapStage = (state) => ldap.getDisplayedLdapStage(state.get('wizard'))
+export const getAllowSkip = (state, stageId) => ldap.getAllowSkip(state.get('wizard'), stageId)
 
 export const getBins = (state) => webContext.getBins(state.get('wcpm'))
 export const getOptions = (state) => webContext.getOptions(state.get('wcpm'))

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -7,6 +7,7 @@ import { getProbeValue } from '../../../reducer'
 import { List, ListItem } from 'material-ui/List'
 import { Card, CardActions, CardHeader } from 'material-ui/Card'
 import FlatButton from 'material-ui/FlatButton'
+import NextIcon from 'material-ui/svg-icons/image/navigate-next'
 
 import Mount from 'react-mount'
 
@@ -16,6 +17,8 @@ import Description from 'components/Description'
 import Action from 'components/Action'
 import ActionGroup from 'components/ActionGroup'
 import Message from 'components/Message'
+import ActionMessage from 'components/ActionMessage'
+import visible from 'react-visible'
 
 import { InputAuto } from 'admin-wizard/inputs'
 
@@ -24,6 +27,8 @@ import { probe } from './actions'
 import * as styles from './styles.less'
 
 import muiThemeable from 'material-ui/styles/muiThemeable'
+
+const VisibleActionMessage = visible(ActionMessage)
 
 const QueryResultView = (props) => {
   const { muiTheme: { palette }, ...rest } = props
@@ -92,11 +97,14 @@ const DirectorySettings = (props) => {
     messages = [],
 
     prev,
+    next,
     probe,
-    test
+    test,
+    allowSkip
   } = props
 
   const isAttrStore = ldapUseCase === 'authenticationAndAttributeStore' || ldapUseCase === 'attributeStore'
+  const nextStageId = isAttrStore ? 'attribute-mapping' : 'confirm'
 
   return (
     <Stage submitting={submitting}>
@@ -139,8 +147,16 @@ const DirectorySettings = (props) => {
           onClick={test}
           disabled={disabled}
           testId='dir-struct'
-          nextStageId={ldapUseCase === 'authenticationAndAttributeStore' || ldapUseCase === 'attributeStore' ? 'attribute-mapping' : 'confirm'} />
+          nextStageId={nextStageId} />
       </ActionGroup>
+
+      <VisibleActionMessage visible={allowSkip || false}
+        type='WARNING'
+        message='There are warnings, would you like to ignore warnings and continue anyway?'
+        label='Skip Warnings'
+        labelPosition='before'
+        icon={<NextIcon />}
+        onClick={() => next({ nextStageId })} />
 
       {messages.map((msg, i) => <Message key={i} {...msg} />)}
     </Stage>


### PR DESCRIPTION
**NOTE**: this PR builds off of changes from PR #28 - please only review the most recent commit on this PR.

#### What does this PR do?
Adds a message when ONLY warnings are returned from the backend on the directory structure page of the LDAP wizard that allows the user to ignore the warnings and continue to the next stage. The message will only remain visible so long as no other fields have been changed and the user has not navigated away from the page to ensure that the user does not accidentally modify a field and then be allowed to skip validation.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @djblue @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)
Make sure that if warnings ONLY are returned from the backend, the message appears and the user can continue anyways. Also test that if any fields are modified or if the stage changes, the message goes away and the user must re-validate the configuration before being shown the skip message.

#### Screenshot:
![screen shot 2017-03-05 at 17 53 28](https://cloud.githubusercontent.com/assets/12499654/23593568/d0eab9f0-01cd-11e7-9b83-1eb2f20d6518.png)

The "Skip Warnings >" is a Material UI FlatButton that highlights on hover.