### PR TITLE
DDF-2773: Skippable LDAP Config Warnings (Dependency on PR #30)

### DIFF
--- a/ui/src/main/webapp/wizards/ldap/stages/confirm.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/confirm.js
@@ -2,6 +2,8 @@ import React from 'react'
 
 import Flexbox from 'flexbox-react'
 
+import NextIcon from 'material-ui/svg-icons/image/navigate-next'
+
 import Stage from 'components/Stage'
 import Title from 'components/Title'
 import Description from 'components/Description'
@@ -10,8 +12,12 @@ import ActionGroup from 'components/ActionGroup'
 import Info from 'components/Information'
 import Message from 'components/Message'
 import MapDisplay from 'components/MapDisplay'
+import ActionMessage from 'components/ActionMessage'
+import visible from 'react-visible'
 
 import { confirmationInfo } from './styles.less'
+
+const VisibleActionMessage = visible(ActionMessage)
 
 const useCaseMapping = {
   authentication: 'Authentication source',
@@ -19,57 +25,83 @@ const useCaseMapping = {
   authenticationAndAttributeStore: 'Authentication and attribute store'
 }
 
-export default ({ disabled, prev, persist, submitting, messages = [], configs }) => (
-  <Stage submitting={submitting}>
-    <Title>LDAP Settings Confirmation</Title>
+export default (props) => {
+  const {
+    disabled,
+    prev,
+    persist,
+    submitting,
+    messages = [],
+    configs,
+    allowSkip
+  } = props
 
-    <Description>
-      All of the values have been successfully verified. Would you like to
-      save the LDAP configuration?
-    </Description>
+  return (
+    <Stage submitting={submitting}>
+      <Title>LDAP Settings Confirmation</Title>
 
-    <Flexbox flexDirection='column'>
-      <Flexbox flexDirection='row' justifyContent='space-between'>
-        <Flexbox className={confirmationInfo} flexDirection='column'>
-          <Info label='LDAP Function' value={useCaseMapping[configs.ldapUseCase]} />
-          <Info label='Hostname' value={configs.hostName} />
-          <Info label='Port' value={configs.port} />
-          <Info label='Encryption Method' value={configs.encryptionMethod} />
-          <Info label='Base User DN' value={configs.baseUserDn} />
-          <Info label='User Name Attribute' value={configs.userNameAttribute} />
+      <Description>
+        All of the values have been successfully verified. Would you like to
+        save the LDAP configuration?
+      </Description>
+
+      <Flexbox flexDirection='column'>
+        <Flexbox flexDirection='row' justifyContent='space-between'>
+          <Flexbox className={confirmationInfo} flexDirection='column'>
+            <Info label='LDAP Function' value={useCaseMapping[configs.ldapUseCase]} />
+            <Info label='Hostname' value={configs.hostName} />
+            <Info label='Port' value={configs.port} />
+            <Info label='Encryption Method' value={configs.encryptionMethod} />
+            <Info label='Base User DN' value={configs.baseUserDn} />
+            <Info label='User Name Attribute' value={configs.userNameAttribute} />
+          </Flexbox>
+          <Flexbox className={confirmationInfo} flexDirection='column'>
+            <Info label='Base Group DN' value={configs.baseGroupDn} />
+            <Info label='Bind User' value={configs.bindUser} />
+            <Info label='Bind User Password' value='*****' />
+            <Info label='Bind User Method' value={configs.bindUserMethod} />
+            <Info label='LDAP Group Object Class' value={configs.groupObjectClass} />
+            <Info label='Group Attribute Holding Member References'
+              value={configs.groupAttributeHoldingMember} />
+            <Info label='Member Attribute Referenced in Groups'
+              value={configs.memberAttributeReferencedInGroup} />
+          </Flexbox>
         </Flexbox>
-        <Flexbox className={confirmationInfo} flexDirection='column'>
-          <Info label='Base Group DN' value={configs.baseGroupDn} />
-          <Info label='Bind User' value={configs.bindUser} />
-          <Info label='Bind User Password' value='*****' />
-          <Info label='Bind User Method' value={configs.bindUserMethod} />
-          <Info label='LDAP Group Object Class' value={configs.groupObjectClass} />
-          <Info label='Group Attribute Holding Member References'
-            value={configs.groupAttributeHoldingMember} />
-          <Info label='Member Attribute Referenced in Groups'
-            value={configs.memberAttributeReferencedInGroup} />
-        </Flexbox>
+        <MapDisplay visible={configs.ldapUseCase !== 'authentication'}
+          label='Attribute Mappings'
+          mapping={configs.attributeMappings} />
       </Flexbox>
-      <MapDisplay visible={configs.ldapUseCase !== 'authentication'}
-        label='Attribute Mappings'
-        mapping={configs.attributeMappings} />
-    </Flexbox>
 
-    <ActionGroup>
-      <Action
-        secondary
-        label='back'
-        onClick={prev}
-        disabled={disabled} />
-      <Action
-        primary
-        label='save'
-        onClick={persist}
-        disabled={disabled}
-        persistId='create'
-        nextStageId='final-stage' />
-    </ActionGroup>
+      <ActionGroup>
+        <Action
+          secondary
+          label='back'
+          onClick={prev}
+          disabled={disabled} />
+        <Action
+          primary
+          label='save'
+          onClick={persist}
+          ignoreWarnings={false}
+          disabled={disabled}
+          persistId='create'
+          nextStageId='final-stage' />
+      </ActionGroup>
 
-    {messages.map((msg, i) => <Message key={i} {...msg} />)}
-  </Stage>
-)
+      {messages.map((msg, i) => <Message key={i} {...msg} />)}
+
+      <VisibleActionMessage visible={allowSkip || false}
+        type='WARNING'
+        message='There are warnings, would you like to ignore warnings and persist?'
+        label='Ignore and Save'
+        labelPosition='before'
+        icon={<NextIcon />}
+        onClick={() => persist({
+          ignoreWarnings: true,
+          persistId: 'create',
+          nextStageId: 'final-stage'
+        })} />
+
+    </Stage>
+  )
+}


### PR DESCRIPTION
NOTE: this PR directly utilizes a component created in PR #30 - please only review the most recent commit on this PR.

#### What does this PR do?
If an identical LDAP configuration already exists, a warning message will be displayed and the user has the option to ignore errors and force a persist

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @adimka 

#### How should this be tested? (List steps with links to updated documentation)
Add 2 identical LDAP configs and ensure that a skippable error is displayed when the second config tries to persist. Ensure that pressing the "Ignore and Save >" button will continue to the finished screen and the configuration is saved.