### PR TITLE
DDF-2773 In admin console, prevents root web context from being deleted

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -88,6 +88,8 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <version>3.0.2</version>
                 <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
@@ -111,6 +113,7 @@
             <plugin>
                 <groupId>org.apache.karaf.tooling</groupId>
                 <artifactId>karaf-maven-plugin</artifactId>
+                <version>4.1.0</version>
                 <executions>
                     <execution>
                         <id>kar</id>
@@ -129,6 +132,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.0.0</version>
                 <executions>
                     <execution>
                         <id>attach-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -309,7 +309,9 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -320,7 +322,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/ui/src/main/webapp/adminTools/webContextPolicyManager/reducer.js
+++ b/ui/src/main/webapp/adminTools/webContextPolicyManager/reducer.js
@@ -137,6 +137,15 @@ export const getBins = (state) => state.get('bins').toJS()
 export const getEditingBinNumber = (state) => state.get('editingBinNumber')
 export const getConfirmDelete = (state) => state.get('confirmDelete')
 export const getWcpmErrors = (state) => state.get('wcpmErrors').toJS()
+export const hasPath = (state, path, binNumber) => {
+  const allBins = state.get('bins')
+  const binCheck = (bin) => bin.get('contextPaths').some(path => path === '/')
+  if (binNumber) {
+    return binCheck(allBins.get(binNumber))
+  } else {
+    return allBins.some(bin => binCheck(bin))
+  }
+}
 
 export default combineReducers({ bins, options, editingBinNumber, confirmDelete, wcpmErrors })
 

--- a/ui/src/main/webapp/reducer/index.js
+++ b/ui/src/main/webapp/reducer/index.js
@@ -40,5 +40,6 @@ export const getOptions = (state) => webContext.getOptions(state.get('wcpm'))
 export const getEditingBinNumber = (state) => webContext.getEditingBinNumber(state.get('wcpm'))
 export const getConfirmDelete = (state) => webContext.getConfirmDelete(state.get('wcpm'))
 export const getWcpmErrors = (state) => webContext.getWcpmErrors(state.get('wcpm'))
+export const hasPath = (state, path, binNumber) => webContext.hasPath(state.get('wcpm'), path, binNumber)
 
 export default combineReducers({ fetch, wizard, backendError, sourceWizard, home, wcpm, polling, systemUsage })


### PR DESCRIPTION
#### What does this PR do?
Protects the root context (/) from being deleted either by editing a context definition or by deleting one.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @djblue 

#### How should this be tested? (List steps with links to updated documentation)
1. Confirm that no regressions have been introduced (contexts can be added/edited/removed still).
2. Attempt to delete the root context; an error should display preventing the deletion.
3. Add a second context path to the entry that contains the root context; this should succeed.
4. Attempt to delete this entry; an error should display preventing the deletion.
5. Edit this entry, attempting to remove the root path but leaving the second; an error should display preventing the deletion.
6. Edit this entry, attempting to remove the secondary path; this should succeed.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
<img width="792" alt="screen shot 2017-03-14 at 9 15 03 am" src="https://cloud.githubusercontent.com/assets/1469860/23910388/cbedc7b0-0896-11e7-817d-9213cba21c60.png">

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
