### PR TITLE
DDF-2773 Add unit tests to verify HttpClients and HttpResponses are always closed

### DIFF
--- a/commons/src/main/java/org/codice/ddf/admin/commons/requests/RequestUtils.java
+++ b/commons/src/main/java/org/codice/ddf/admin/commons/requests/RequestUtils.java
@@ -238,7 +238,7 @@ public class RequestUtils {
         return requestResults;
     }
 
-    private void closeClientAndResponse(CloseableHttpClient client, CloseableHttpResponse response) {
+    protected void closeClientAndResponse(CloseableHttpClient client, CloseableHttpResponse response) {
         try {
             if (client != null) {
                 client.close();


### PR DESCRIPTION
#### What does this PR do?
Adds unit tests ensuring we're closing all closable resources via all branches of logic.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @coyotesqrl @garrettfreibott 

#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?
These tests will ensure we don't make future changes that result in us not closing resources.

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/)

#### Screenshots (if appropriate)

#### Checklist:
- [] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
