### PR TITLE
DDF-2773 Makes validation of realms and authentication methods case-insensitive

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -151,17 +151,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.49</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.45</minimum>
+                                            <minimum>0.55</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.38</minimum>
+                                            <minimum>0.44</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/api/src/main/java/org/codice/ddf/admin/api/config/context/ContextPolicyBin.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/config/context/ContextPolicyBin.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
+import org.codice.ddf.admin.api.validation.SecurityValidationUtils;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
@@ -101,12 +102,16 @@ public class ContextPolicyBin {
 
     //Setters
     public ContextPolicyBin realm(String realm) {
-        this.realm = realm;
+        // Ensure that the realm has been converted to a correct, expected case
+        this.realm = SecurityValidationUtils.normalizeRealm(realm);
         return this;
     }
 
     public ContextPolicyBin authenticationTypes(Set<String> authenticationTypes) {
-        this.authenticationTypes = authenticationTypes;
+        // Ensure that the authentication type names have been converted to correct, expected case
+        this.authenticationTypes = authenticationTypes.stream()
+                .map(SecurityValidationUtils::normalizeAuthType)
+                .collect(Collectors.toSet());
         return this;
     }
 

--- a/api/src/test/groovy/org/codice/ddf/admin/api/validation/SecurityValidationUtilsTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/validation/SecurityValidationUtilsTest.groovy
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+
+package org.codice.ddf.admin.api.validation
+
+import spock.lang.Specification
+
+import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.*
+
+class SecurityValidationUtilsTest extends Specification {
+    def 'test authtype normalization no exceptions'() {
+        expect:
+        output == normalizeAuthType(input)
+
+        where:
+        input  | output
+        'saml' | SAML
+        'SAML' | SAML
+        'sAmL' | SAML
+        'idp'  | IDP_AUTH
+        'IDP'  | IDP_AUTH
+        'iDp'  | IDP_AUTH
+    }
+
+    def 'test authtype normalization with exceptions'() {
+        when:
+        normalizeAuthType(input)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        input << ['xyz', 'abc', 'def', 'unknown', 'samlx']
+    }
+
+    def 'test realm normalization no exceptions'() {
+        expect:
+        output == normalizeRealm(input)
+
+        where:
+        input   | output
+        'karaf' | KARAF
+        'KaRaF' | KARAF
+        'KARAF' | KARAF
+        'LdAp'  | LDAP
+        'idp'   | IDP_REALM
+        'IdP'   | IDP_REALM
+    }
+
+    def 'test realm normalization with exceptions'() {
+        when:
+        normalizeRealm(input)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        input << ['karafXXX', 'idpx', 'ldapppp', 'xyz']
+    }
+}

--- a/security/contextpolicy-config-handler/src/main/java/org/codice/ddf/admin/security/context/probe/AvailableOptionsProbeMethod.java
+++ b/security/contextpolicy-config-handler/src/main/java/org/codice/ddf/admin/security/context/probe/AvailableOptionsProbeMethod.java
@@ -25,7 +25,8 @@ import static org.codice.ddf.admin.api.validation.LdapValidationUtils.AUTHENTICA
 import static org.codice.ddf.admin.api.validation.LdapValidationUtils.AUTHENTICATION_AND_ATTRIBUTE_STORE;
 import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.BASIC;
 import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.GUEST;
-import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.IDP;
+import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.IDP_AUTH;
+import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.IDP_REALM;
 import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.KARAF;
 import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.LDAP;
 import static org.codice.ddf.admin.api.validation.SecurityValidationUtils.PKI;
@@ -110,7 +111,7 @@ public class AvailableOptionsProbeMethod extends ProbeMethod<ContextPolicyConfig
         List<String> authTypes = new ArrayList<>(Arrays.asList(BASIC, SAML, PKI, GUEST));
 
         if (configurator.isBundleStarted(IDP_CLIENT_BUNDLE_NAME)) {
-            authTypes.add(IDP);
+            authTypes.add(IDP_AUTH);
         }
 
         return authTypes;
@@ -120,7 +121,7 @@ public class AvailableOptionsProbeMethod extends ProbeMethod<ContextPolicyConfig
         List<String> realms = new ArrayList<>(Collections.singletonList(KARAF));
         // If an IdpConfigurationHandler exists replace this with a service reference
         if (configurator.isBundleStarted(IDP_SERVER_BUNDLE_NAME)) {
-            realms.add(IDP);
+            realms.add(IDP_REALM);
         }
 
         if (ldapConfigHandler == null


### PR DESCRIPTION
#### What does this PR do?
Uses case-insensitive comparisons to validate realms and authentication methods; passes correctly cased values to underlying configuration regardless of input.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @adimka 

#### How should this be tested? (List steps with links to updated documentation)
1. Ensure the WCPM correctly loads against DDF 2.11.0-SNAPSHOT (defaults are not set to IDP).
2. Ensure that the values persisted to the underlying configuration match the case expected.
3. Test a post, circumventing the UI, to ensure that incorrectly cased inputs for realm and authentication are accepted as valid but persisted correctly.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
