### PR TITLE
DDF-2773 Sources wizard should support discovery by IP address

### DIFF
--- a/federation/commons/src/main/java/org/codice/ddf/admin/commons/sources/SourceHandlerCommons.java
+++ b/federation/commons/src/main/java/org/codice/ddf/admin/commons/sources/SourceHandlerCommons.java
@@ -51,11 +51,12 @@ public class SourceHandlerCommons {
 
     //Common failure types
     public static final String UNKNOWN_ENDPOINT = "UNKNOWN_ENDPOINT";
-    private static final Map<String, String> FAILURE_DESCRIPTIONS = ImmutableMap.<String, String>builder().putAll(
-            REQUEST_UTILS.getRequestSubtypeDescriptions(RequestUtils.CANNOT_CONNECT, RequestUtils.CERT_ERROR))
-                    .put(UNKNOWN_ENDPOINT, "The endpoint does not appear to have the specified capabilities.")
-                    .put(FAILED_CREATE, "Failed to create source configuration.")
-                    .put(FAILED_DELETE, "Failed to delete source configuration.")
+    public static final String BAD_IP = "BAD_IP";
+    private static final Map<String, String> FAILURE_DESCRIPTIONS = ImmutableMap.<String, String>builder()
+            .putAll(REQUEST_UTILS.getRequestSubtypeDescriptions(RequestUtils.CANNOT_CONNECT, RequestUtils.CERT_ERROR))
+            .put(UNKNOWN_ENDPOINT, "The endpoint does not appear to have the specified capabilities.")
+            .put(FAILED_CREATE, "Failed to create source configuration.")
+            .put(FAILED_DELETE, "Failed to delete source configuration.")
             .build();
 
     //Common warning types

--- a/ui/src/main/webapp/wizards/sources/stages/discovery.js
+++ b/ui/src/main/webapp/wizards/sources/stages/discovery.js
@@ -42,12 +42,12 @@ const DiscoveryStageView = ({ messages, testSources, setDefaults, configs }) => 
         Discover Available Sources
       </Title>
       <Description>
-        Enter connection information to scan for available sources on a host.
+        Enter connection information to scan for available sources.
       </Description>
       <div style={{ width: 400, position: 'relative', margin: '0px auto', padding: 0 }}>
         <Hostname
           id='sourceHostName'
-          label='Hostname'
+          label='Host'
           autoFocus />
         <Port
           id='sourcePort'


### PR DESCRIPTION
#### What does this PR do?
Adds IP address support to the hostname field for source discovery.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @coyotesqrl @garrettfreibott 

#### How should this be tested? (List steps with links to updated documentation)
Confirm discovery via IP address is possible, (ideally with loopback and a remote source)
#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
