### PR TITLE
DDF-2773 Switches out non-standard 'subordinates' LDAP search scope

### DIFF
--- a/api/src/main/java/org/codice/ddf/admin/api/handler/report/Report.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/handler/report/Report.java
@@ -18,8 +18,10 @@ import static org.codice.ddf.admin.api.handler.ConfigurationMessage.buildMessage
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
@@ -52,21 +54,18 @@ public class Report {
 
     public boolean containsUnsuccessfulMessages() {
         return messages.stream()
-                .filter(msg -> msg.type() != ConfigurationMessage.MessageType.SUCCESS)
-                .findFirst()
-                .isPresent();
+                .anyMatch(msg -> msg.type() != ConfigurationMessage.MessageType.SUCCESS);
     }
 
     public boolean containsFailureMessages() {
         return messages.stream()
-                .filter(msg -> msg.type() == ConfigurationMessage.MessageType.FAILURE)
-                .findFirst()
-                .isPresent();
+                .anyMatch(msg -> msg.type() == ConfigurationMessage.MessageType.FAILURE);
     }
 
     public static Report createReport(Map<String, String> successTypes,
             Map<String, String> failureTypes, Map<String, String> warningTypes, String result) {
-        return createReport(successTypes, failureTypes, warningTypes, Arrays.asList(result));
+        return createReport(successTypes, failureTypes, warningTypes,
+                Collections.singletonList(result));
     }
 
     public static Report createReport(Map<String, String> successTypes,
@@ -106,7 +105,7 @@ public class Report {
     public Report addMessages(List<ConfigurationMessage> messages) {
         if (messages != null && !messages.isEmpty()) {
             messages.stream()
-                    .filter(msg -> msg != null)
+                    .filter(Objects::nonNull)
                     .forEach(msg -> this.messages.add(msg));
         }
         return this;

--- a/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/test/AttributeMappingTestMethod.java
+++ b/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/test/AttributeMappingTestMethod.java
@@ -141,7 +141,7 @@ public class AttributeMappingTestMethod extends TestMethod<LdapConfiguration> {
                 configuration.baseUserDn(),
                 Filter.and(Filter.present(configuration.userNameAttribute()), Filter.present(attr))
                         .toString(),
-                SearchScope.SUBORDINATES,
+                SearchScope.WHOLE_SUBTREE,
                 1);
         return !userWithAttrResults.isEmpty();
     }

--- a/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/test/DirectoryStructTestMethod.java
+++ b/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/test/DirectoryStructTestMethod.java
@@ -173,7 +173,7 @@ public class DirectoryStructTestMethod extends TestMethod<LdapConfiguration> {
                 configuration.baseUserDn(),
                 Filter.present(configuration.userNameAttribute())
                         .toString(),
-                SearchScope.SUBORDINATES,
+                SearchScope.WHOLE_SUBTREE,
                 1);
         if (baseUsersResults.isEmpty()) {
             resultsWithConfigIds.put(NO_USERS_IN_BASE_USER_DN.name(), BASE_USER_DN);
@@ -198,7 +198,7 @@ public class DirectoryStructTestMethod extends TestMethod<LdapConfiguration> {
                 configuration.baseGroupDn(),
                 Filter.equality("objectClass", configuration.groupObjectClass())
                         .toString(),
-                SearchScope.SUBORDINATES,
+                SearchScope.WHOLE_SUBTREE,
                 1);
         if (baseGroupResults.isEmpty()) {
             resultsWithConfigIds.put(NO_GROUPS_IN_BASE_GROUP_DN.name(), BASE_GROUP_DN);
@@ -213,7 +213,7 @@ public class DirectoryStructTestMethod extends TestMethod<LdapConfiguration> {
                 Filter.and(Filter.equality("objectClass", configuration.groupObjectClass()),
                         Filter.present(configuration.groupAttributeHoldingMember()))
                         .toString(),
-                SearchScope.SUBORDINATES,
+                SearchScope.WHOLE_SUBTREE,
                 1);
         if (groups.isEmpty()) {
             resultsWithConfigIds.put(NO_GROUPS_WITH_MEMBERS.name(), GROUP_ATTRIBUTE_HOLDING_MEMBER);
@@ -246,7 +246,7 @@ public class DirectoryStructTestMethod extends TestMethod<LdapConfiguration> {
         List<SearchResultEntry> foundMember = ldapTestingCommons.getLdapQueryResults(ldapConnection,
                 configuration.baseUserDn(),
                 userFilter,
-                SearchScope.SUBORDINATES,
+                SearchScope.WHOLE_SUBTREE,
                 1);
         if (foundMember.isEmpty()) {
             resultsWithConfigIds.put(NO_REFERENCED_MEMBER.name(),


### PR DESCRIPTION
#### What does this PR do?
Switch is for whole subtree.
Also cleans up a little unrelated, inefficient code.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@garrettfreibott @adimka 

#### How should this be tested? (List steps with links to updated documentation)
Ensure that creating LDAP auth & attribute store works. Specifically that the directory struct stage works correctly.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
