### PR TITLE
DDF-2773 Creates new AdminModule to plug the Beta Console into AdminUI

### DIFF
--- a/admin-module/pom.xml
+++ b/admin-module/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.codice.ddf.admin.beta</groupId>
+        <artifactId>admin</artifactId>
+        <version>0.1.2-SNAPSHOT</version>
+    </parent>
+
+    <name>DDF :: Admin (Beta) :: Modules :: Setup</name>
+    <artifactId>admin-module</artifactId>
+    <packaging>bundle</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>ddf.admin.core</groupId>
+            <artifactId>admin-core-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Export-Package/>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.00</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>.00</minimum>
+                                        </limit>
+
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/admin-module/src/main/java/org/codice/admin/module/AdminConfModule.java
+++ b/admin-module/src/main/java/org/codice/admin/module/AdminConfModule.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.admin.module;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.codice.ddf.ui.admin.api.module.AdminModule;
+
+public class AdminConfModule implements AdminModule {
+    private final String name;
+    private final String id;
+    private final String iFrameLocation;
+
+    public AdminConfModule(String name, String id, String iFrameLocation) {
+        this.name = name;
+        this.id = id;
+        this.iFrameLocation = iFrameLocation;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public URI getJSLocation() {
+        return null;
+    }
+
+    @Override
+    public URI getCSSLocation() {
+        return null;
+    }
+
+    @Override
+    public URI getIframeLocation() {
+        try {
+            return new URI(iFrameLocation);
+        } catch (URISyntaxException e) {
+            return null;
+        }
+    }
+}

--- a/admin-module/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/admin-module/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -1,0 +1,22 @@
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <bean id="confModule" class="org.codice.admin.module.AdminConfModule">
+        <argument value="Setup-Beta"/>
+        <argument value="confwizards"/>
+        <argument value="./beta"/>
+    </bean>
+
+    <service interface="org.codice.ddf.ui.admin.api.module.AdminModule" ref="confModule"/>
+</blueprint>

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -77,6 +77,11 @@
             <artifactId>embedded-ldap-config-handler</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.codice.ddf.admin.beta</groupId>
+            <artifactId>admin-module</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/app/src/main/resources/features.xml
+++ b/app/src/main/resources/features.xml
@@ -73,5 +73,6 @@
              description="DDF Admin UI (Beta)">
         <feature prerequisite="true">admin-beta-core</feature>
         <bundle>mvn:org.codice.ddf.admin.beta/admin-ui/${project.version}</bundle>
+        <bundle>mvn:org.codice.ddf.admin.beta/admin-module/${project.version}</bundle>
     </feature>
 </features>

--- a/config-handler-router/pom.xml
+++ b/config-handler-router/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.5</version>
+            <version>${spark.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
         <node.version>v7.1.0</node.version>
         <yarn.version>v0.21.2</yarn.version>
         <junit.version>4.12</junit.version>
+        <spark.version>2.5.5</spark.version>
 
         <ddf.scm.connection.url />
         <snapshots.repository.url />
@@ -382,5 +383,6 @@
         <module>ui</module>
         <module>app</module>
         <module>commons</module>
+        <module>admin-module</module>
     </modules>
 </project>

--- a/ui/src/main/resources/index.html
+++ b/ui/src/main/resources/index.html
@@ -52,5 +52,6 @@
       <!-- }}} -->
     </div>
     <script type="text/javascript" src="bundle.js"></script>
+    <script type="text/javascript" src="/admin/iframe-resizer/2.6.2/js/iframeResizer.contentWindow.min.js"></script>
   </body>
 </html>

--- a/ui/src/main/webapp/app.js
+++ b/ui/src/main/webapp/app.js
@@ -13,7 +13,6 @@ import HomeIcon from 'material-ui/svg-icons/action/home'
 import IconButton from 'material-ui/IconButton'
 import { Link } from 'react-router'
 import AppBar from 'material-ui/AppBar'
-import Flexbox from 'flexbox-react'
 
 import Banners from 'system-usage/Banners'
 import Modal from 'system-usage/Modal'
@@ -28,14 +27,6 @@ if (process.env.NODE_ENV !== 'production') {
   DevTools = require('./containers/dev-tools').default
 }
 
-const fixed = {
-  position: 'relative',
-  top: 0,
-  left: 0,
-  bottom: 0,
-  right: 0
-}
-
 const LinkHomeIcon = (props) => (
   <Link to='/'>
     <HomeIcon {...props} />
@@ -47,19 +38,14 @@ const App = ({ children }) => (
     <Provider store={store}>
       <Banners>
         <Modal />
-        <Flexbox flexDirection='column' height='100vh' style={fixed}>
-          <AppBar
-            title='Admin Console (BETA)'
-            iconElementLeft={
-              <IconButton>
-                <LinkHomeIcon />
-              </IconButton>
-            } />
-          <Flexbox flex='1' style={{ overflowY: 'scroll', width: '100%' }}>
-            <div style={{ maxWidth: 960, margin: '0 auto' }}>{children}</div>
-          </Flexbox>
-          <Exception />
-        </Flexbox>
+        <AppBar
+          iconElementLeft={
+            <IconButton>
+              <LinkHomeIcon />
+            </IconButton>
+          } />
+        <div style={{ maxWidth: 960, padding: 20, margin: '0 auto' }}>{children}</div>
+        <Exception />
         <DevTools />
       </Banners>
     </Provider>

--- a/ui/src/main/webapp/lib/components/styles.less
+++ b/ui/src/main/webapp/lib/components/styles.less
@@ -17,7 +17,6 @@
 .main {
   margin: 20px;
   padding: 0px;
-  width: 800px;
   position: relative;
   box-sizing: border-box;
 }

--- a/ui/src/main/webapp/wizards/sources/styles.less
+++ b/ui/src/main/webapp/wizards/sources/styles.less
@@ -62,7 +62,6 @@
 .main {
   margin: 20px;
   padding: 40px;
-  max-width: 800px;
   position: relative;
 }
 


### PR DESCRIPTION
#### What does this PR do?

- Now pluggable Admin Console (iframed into AdminUI). 
- Title removed from header bar
- Also updates Spark to latest version (2.5.5).

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie 
@garrettfreibott 

#### How should this be tested? (List steps with links to updated documentation)
Build and deploy into a DDF instance. Ensure that a new link appears in the sidebar nav and that it opens up an iframe with the console inside it. Confirm that the console's functionality is unaffected.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
<img width="1249" alt="screen shot 2017-03-21 at 9 50 47 am" src="https://cloud.githubusercontent.com/assets/1469860/24159273/f0d4e4a2-0e1b-11e7-85e4-6b852a0ae760.png">


#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
