### PR TITLE
DDF-2773: Added Material UI Theming

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -32,11 +32,14 @@
     "redux": "^3.5.2"
   },
   "dependencies": {
+    "color": "^1.0.3",
     "es6-promise": "^4.0.5",
     "flexbox-react": "^4.2.1",
     "immutable": "^3.8.1",
     "material-ui": "^0.16.7",
     "react": "^15.1.0",
+    "react-color": "^2.11.4",
+    "react-deep-force-update": "^2.0.1",
     "react-dom": "^15.1.0",
     "react-redux": "^5.0.2",
     "react-router": "^3.0.2",

--- a/ui/src/main/resources/index.html
+++ b/ui/src/main/resources/index.html
@@ -11,7 +11,7 @@
         font-size: 18px;
         margin: 0;
         color: #333333;
-        background: #eeeeee;  
+        background: #ffffff;
       }
       a {
         text-decoration: none;

--- a/ui/src/main/webapp/actions.js
+++ b/ui/src/main/webapp/actions.js
@@ -21,3 +21,6 @@ export const editConfig = (id, value) => ({ type: 'EDIT_CONFIG', id, value })
 export const editConfigs = (values) => ({ type: 'EDIT_CONFIGS', values })
 export const setDefaults = (values) => ({ type: 'SET_DEFAULTS', values })
 
+export const updateThemeColor = (path, value) => ({ type: 'THEME/SET_COLOR', path, value })
+export const setThemePreset = (themeName) => ({ type: 'THEME/SET_PRESET', themeName })
+

--- a/ui/src/main/webapp/actions.js
+++ b/ui/src/main/webapp/actions.js
@@ -20,7 +20,3 @@ export const clearBackendError = () => ({ type: 'CLEAR_BACKEND_ERRORS' })
 export const editConfig = (id, value) => ({ type: 'EDIT_CONFIG', id, value })
 export const editConfigs = (values) => ({ type: 'EDIT_CONFIGS', values })
 export const setDefaults = (values) => ({ type: 'SET_DEFAULTS', values })
-
-export const updateThemeColor = (path, value) => ({ type: 'THEME/SET_COLOR', path, value })
-export const setThemePreset = (themeName) => ({ type: 'THEME/SET_PRESET', themeName })
-

--- a/ui/src/main/webapp/adminTools/webContextPolicyManager/index.js
+++ b/ui/src/main/webapp/adminTools/webContextPolicyManager/index.js
@@ -1,8 +1,9 @@
 import React from 'react'
 import Paper from 'material-ui/Paper'
-import {connect} from 'react-redux'
+import { connect } from 'react-redux'
 import Mount from 'react-mount'
 import { isSubmitting } from 'redux-fetch'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 import {
   getBins,
   getOptions,
@@ -43,7 +44,6 @@ import {
   TableRow,
   TableRowColumn
 } from 'material-ui/Table'
-import {cyanA700} from 'material-ui/styles/colors'
 import CancelIcon from 'material-ui/svg-icons/content/remove-circle-outline'
 import DeleteIcon from 'material-ui/svg-icons/action/delete'
 import AddIcon from 'material-ui/svg-icons/content/add-circle-outline'
@@ -90,12 +90,12 @@ let ContextPathItem = ({ contextPath, binNumber, pathNumber, removePath, editing
 )
 ContextPathItem = connect(null, (dispatch, { binNumber, pathNumber, attribute }) => ({ removePath: () => dispatch(removeAttribute(attribute)(binNumber, pathNumber)) }))(ContextPathItem)
 
-let NewContextPathItem = ({ binNumber, addPath, onEdit, newPath, attribute, addButtonVisible = true, error }) => (
+let NewContextPathItem = ({ binNumber, addPath, onEdit, newPath, attribute, addButtonVisible = true, error, muiTheme }) => (
   <div>
     <Divider />
     <Flexbox style={{ position: 'relative' }} flexDirection='row' justifyContent='space-between'>
       <TextField hintStyle={{ padding: '0px 10px' }} inputStyle={{ padding: '0px 10px' }} style={{ width: '100%' }} id='name' hintText='Add New Path' onChange={(event, value) => onEdit(value)} value={newPath || ''} errorText={error} />
-      {(addButtonVisible) ? (<IconButton style={{ position: 'absolute', right: '0px' }} tooltip={'Add'} tooltipPosition='top-center' onClick={addPath}><AddIcon color={cyanA700} /></IconButton>) : null }
+      {(addButtonVisible) ? (<IconButton style={{ position: 'absolute', right: '0px' }} tooltip={'Add'} tooltipPosition='top-center' onClick={addPath}><AddIcon color={muiTheme.palette.primary1Color} /></IconButton>) : null }
       {(newPath && newPath.trim() !== '')
         ? <IconButton style={{ position: 'absolute', left: '-10px', width: '10px', height: '10px' }} iconStyle={{ width: '10px', height: '10px' }} onClick={() => onEdit('')}><ClearIcon /></IconButton>
         : null
@@ -108,17 +108,18 @@ NewContextPathItem = connect((state) => ({
 }), (dispatch, { binNumber, attribute }) => ({
   addPath: () => dispatch(addContextPath(attribute, binNumber)),
   onEdit: (value) => dispatch(editAttribute(attribute)(binNumber, value))
-}))(NewContextPathItem)
+}))(muiThemeable()(NewContextPathItem))
 
-let ContextPathGroup = ({ bin, binNumber, editing }) => (
+let ContextPathGroup = ({ bin, binNumber, editing, muiTheme }) => (
   <div className={(bin.name === 'WHITELIST') ? whitelistContextPathGroupStyle : contextPathGroupStyle}>
-    <p className={infoSubtitleLeft}>Context Paths</p>
+    <p className={infoSubtitleLeft} style={{ color: muiTheme.palette.primary1Color }}>Context Paths</p>
     {bin.contextPaths.map((contextPath, pathNumber) => (<ContextPathItem attribute='contextPaths' contextPath={contextPath} key={pathNumber} binNumber={binNumber} pathNumber={pathNumber} editing={editing} />))}
     {editing ? <NewContextPathItem binNumber={binNumber} attribute='contextPaths' newPath={bin['newcontextPaths']} /> : null}
   </div>
 )
+ContextPathGroup = muiThemeable()(ContextPathGroup)
 
-let NewSelectItem = ({ binNumber, addPath, onEdit, newPath, attribute, options, addButtonVisible = true, error }) => (
+let NewSelectItem = ({ binNumber, addPath, onEdit, newPath, attribute, options, addButtonVisible = true, error, muiTheme }) => (
   <div>
     <Divider />
     <Flexbox style={{ position: 'relative' }} flexDirection='row' justifyContent='space-between'>
@@ -135,7 +136,7 @@ let NewSelectItem = ({ binNumber, addPath, onEdit, newPath, attribute, options, 
         <IconButton style={{ position: 'absolute', right: '0px' }}
           tooltip={'Add'} tooltipPosition='top-center'
           onClick={addPath}>
-          <AddIcon color={cyanA700} />
+          <AddIcon color={muiTheme.palette.primary1Color} />
         </IconButton>
       ) : null }
       {(newPath && newPath.trim() !== '') ? (
@@ -151,7 +152,7 @@ let NewSelectItem = ({ binNumber, addPath, onEdit, newPath, attribute, options, 
 NewSelectItem = connect(null, (dispatch, { binNumber, attribute }) => ({
   addPath: () => dispatch(addAttribute(attribute)(binNumber)),
   onEdit: (value) => dispatch(editAttribute(attribute)(binNumber, value))
-}))(NewSelectItem)
+}))(muiThemeable()(NewSelectItem))
 
 let Realm = ({ bin, binNumber, policyOptions, editRealm, editing }) => {
   return editing ? (
@@ -217,7 +218,7 @@ AuthTypesGroup = connect(
     policyOptions: getOptions(state)
   }))(AuthTypesGroup)
 
-let AttributeTableGroup = ({ bin, binNumber, policyOptions, editAttribute, removeAttributeMapping, addAttributeMapping, editing, claimError, attrError }) => (
+let AttributeTableGroup = ({ bin, binNumber, policyOptions, editAttribute, removeAttributeMapping, addAttributeMapping, editing, claimError, attrError, muiTheme }) => (
   <Table selectable={false}>
     <TableHeader displaySelectAll={false} adjustForCheckbox={false}>
       <TableRow>
@@ -251,7 +252,7 @@ let AttributeTableGroup = ({ bin, binNumber, policyOptions, editAttribute, remov
           </TableRowColumn>
           <TableRowColumn style={{ width: 120, position: 'relative' }}>
             <TextField fullWidth style={{ margin: '0px', fontSize: '14px' }} id='attributes' value={bin.newrequiredAttribute || ''} onChange={(event, value) => editAttribute('requiredAttribute', value)} hintText='Claim Value' errorText={attrError} />
-            <IconButton style={{ position: 'absolute', right: 0, top: 0 }} tooltip={'Add'} tooltipPosition='top-center' onClick={addAttributeMapping}><AddIcon color={cyanA700} /></IconButton>
+            <IconButton style={{ position: 'absolute', right: 0, top: 0 }} tooltip={'Add'} tooltipPosition='top-center' onClick={addAttributeMapping}><AddIcon color={muiTheme.palette.primary1Color} /></IconButton>
             {(bin.newrequiredAttribute && bin.newrequiredAttribute.trim() !== '')
               ? <IconButton style={{ position: 'absolute', left: '-5px', width: '10px', height: '10px' }} iconStyle={{ width: '10px', height: '10px' }} onClick={() => editAttribute('requiredAttribute', '')}><ClearIcon /></IconButton>
               : null
@@ -272,7 +273,7 @@ AttributeTableGroup = connect(
     addAttributeMapping: () => dispatch(addAttributeMapping(binNumber)),
     removeAttributeMapping: (claim) => dispatch(removeAttributeMapping(binNumber, claim)),
     editAttribute: (attribute, value) => dispatch(editAttribute(attribute)(binNumber, value))
-  }))(AttributeTableGroup)
+  }))(muiThemeable()(AttributeTableGroup))
 
 const DisabledPanel = () => (
   <div className={disabledPanelStyle} />
@@ -312,19 +313,19 @@ ErrorBanner = connect(
     messages: getWcpmErrors(state).general
   }))(ErrorBanner)
 
-const PolicyBin = ({ policyBin, binNumber, editing, editingBinNumber }) => (
+let PolicyBin = ({ policyBin, binNumber, editing, editingBinNumber, muiTheme }) => (
   <Paper className={policyBinOuterStyle} >
     <Flexbox flexDirection='row'>
       <ContextPathGroup binNumber={binNumber} bin={policyBin} editing={editing} />
       <div style={{ width: '20%', padding: '5px', boxSizing: 'border-box' }}>
-        <p className={infoSubtitleLeft}>Realm</p>
+        <p className={infoSubtitleLeft} style={{ color: muiTheme.palette.primary1Color }}>Realm</p>
         <Divider />
         <Realm bin={policyBin} binNumber={binNumber} editing={editing} />
-        <p className={infoSubtitleLeft}>Authentication Types</p>
+        <p className={infoSubtitleLeft} style={{ color: muiTheme.palette.primary1Color }}>Authentication Types</p>
         <AuthTypesGroup bin={policyBin} binNumber={binNumber} editing={editing} />
       </div>
       <div style={{ width: '60%', padding: '5px', boxSizing: 'border-box' }}>
-        <p className={infoSubtitleLeft}>{(editing) ? 'Required Subject Claims (Optional)' : 'Required Subject Claims'}</p>
+        <p className={infoSubtitleLeft} style={{ color: muiTheme.palette.primary1Color }}>{(editing) ? 'Required Subject Claims (Optional)' : 'Required Subject Claims'}</p>
         <Divider />
         <div>
           <AttributeTableGroup bin={policyBin} binNumber={binNumber} editing={editing} />
@@ -337,6 +338,7 @@ const PolicyBin = ({ policyBin, binNumber, editing, editingBinNumber }) => (
     { (!editing && editingBinNumber !== null) ? <DisabledPanel /> : null }
   </Paper>
 )
+PolicyBin = muiThemeable()(PolicyBin)
 
 let PolicyBins = ({ policies, editingBinNumber }) => (
   <div>
@@ -353,20 +355,21 @@ PolicyBins = connect((state) => ({
   editingBinNumber: getEditingBinNumber(state)
 }))(PolicyBins)
 
-let NewBin = ({ policies, addNewBin, nextBinNumber, editing }) => {
+let NewBin = ({ policies, addNewBin, nextBinNumber, editing, muiTheme }) => {
   if (editing) {
     return (
-      <Paper style={{ position: 'relative', width: '100%', height: '100px', margin: '5px 0px', textAlign: 'center', backgroundColor: '#EEE' }} >
+      <Paper style={{ position: 'relative', width: '100%', height: '100px', margin: '5px 0px', textAlign: 'center', backgroundColor: muiTheme.palette.canvasColor }} >
         <Flexbox className={newBinDisabledStyle} flexDirection='column' justifyContent='center' alignItems='center'>
           <FloatingActionButton disabled>
             <ContentAdd />
           </FloatingActionButton>
         </Flexbox>
+        <DisabledPanel />
       </Paper>
     )
   } else {
     return (
-      <Paper style={{ position: 'relative', width: '100%', height: '100px', margin: '5px 0px', textAlign: 'center', backgroundColor: '#EEE' }} onClick={() => addNewBin(nextBinNumber)}>
+      <Paper style={{ position: 'relative', width: '100%', height: '100px', margin: '5px 0px', textAlign: 'center', backgroundColor: muiTheme.palette.canvasColor }} onClick={() => addNewBin(nextBinNumber)}>
         <Flexbox className={newBinStyle} flexDirection='column' justifyContent='center' alignItems='center'>
           <FloatingActionButton>
             <ContentAdd />
@@ -376,20 +379,20 @@ let NewBin = ({ policies, addNewBin, nextBinNumber, editing }) => {
     )
   }
 }
-NewBin = connect((state) => ({ nextBinNumber: getBins(state).length }), { addNewBin })(NewBin)
+NewBin = connect((state) => ({ nextBinNumber: getBins(state).length }), { addNewBin })(muiThemeable()(NewBin))
 
-let wcpm = ({ updatePolicyBins, isSubmitting }) => (
+let wcpm = ({ updatePolicyBins, isSubmitting, muiTheme }) => (
   <Mount on={() => updatePolicyBins('/admin/beta/config/configurations/context-policy-manager')}>
     <div>
       <div style={{ padding: 20 }}>
-        <p className={infoTitle}>Web Context Policy Manager</p>
-        <p className={infoSubtitle}>
+        <p className={infoTitle} style={{ color: muiTheme.palette.textColor }}>Web Context Policy Manager</p>
+        <p className={infoSubtitle} style={{ color: muiTheme.palette.textColor }}>
           The Web Context Policy Manager defines security policies for all subpaths of this web server.
           It defines the realms a path should be authenticated against, the type of authentication that
           a path requires, and any user attributes that are required for authorization.
         </p>
 
-        <p className={infoSubtitle}>
+        <p className={infoSubtitle} style={{ color: muiTheme.palette.textColor }}>
           Any subpaths of a configured path will inherit its parent's policy. For example, in a system
           where a policy is configured for '/a', its policy applies to '/a/b' and '/a/b/c' unless otherwise
           specified.
@@ -412,4 +415,4 @@ export default connect(
     isSubmitting: isSubmitting(state, 'wcpm')
   }), {
     updatePolicyBins
-  })(wcpm)
+  })(muiThemeable()(wcpm))

--- a/ui/src/main/webapp/adminTools/webContextPolicyManager/reducer.js
+++ b/ui/src/main/webapp/adminTools/webContextPolicyManager/reducer.js
@@ -31,7 +31,11 @@ const bins = (state = List(), { type, bin, bins, whitelistContexts, path, binNum
         return state.delete(binNumber)
       }
     case 'WCPM/EDIT_MODE_SAVE':
-      return state.update(binNumber, (bin) => bin.delete('beforeEdit')).update(binNumber, (bin) => bin.delete('name'))
+      if (state.getIn([binNumber, 'name']) === 'NewBin') {
+        return state.update(binNumber, (bin) => bin.delete('name'))
+      } else {
+        return state.update(binNumber, (bin) => bin.delete('beforeEdit'))
+      }
 
     // Realm
     case 'WCPM/EDIT_REALM':

--- a/ui/src/main/webapp/adminTools/webContextPolicyManager/styles.less
+++ b/ui/src/main/webapp/adminTools/webContextPolicyManager/styles.less
@@ -2,7 +2,6 @@
   font-size: 16px;
   position: relative;
   text-align: left;
-  color: rgba(0, 0, 0, 0.70);
   padding: 14px 10px;
   overflow-x: hidden;
   text-overflow: ellipsis;
@@ -12,7 +11,6 @@
   font-size: 18px;
   position: relative;
   text-align: center;
-  color: rgba(0, 0, 0, 0.70);
   margin: 10px 40px;
 }
 
@@ -20,7 +18,6 @@
   font-size: 14px;
   position: relative;
   text-align: center;
-  color: rgba(0, 0, 0, 0.541176);
   margin: 10px 10px;
 }
 
@@ -28,7 +25,6 @@
   font-size: 14px;
   position: relative;
   text-align: left;
-  color: rgb(0, 184, 212);
   margin: 10px 10px;
 }
 
@@ -36,18 +32,9 @@
   font-size: 16px;
   position: relative;
   text-align: left;
-  color: rgba(0, 0, 0, 0.70);
   padding: 0px 10px;
   overflow-x: hidden;
   text-overflow: ellipsis;
-}
-
-.infoContextPaths {
-  font-size: 14px;
-  position: relative;
-  text-align: center;
-  color: rgba(0, 0, 0, 0.70);
-  margin: 10px 0px;
 }
 
 .policyBinOuterStyle {
@@ -73,14 +60,12 @@ div:hover > .editPaneStyle {
   position: relative;
   height: 100%;
   text-align: center;
-  background-color: #EEE;
   border-radius: 5px;
   cursor: pointer;
   transition: background-color 0.5s ease;
 }
 
 .newBinStyle:hover {
-  background-color: #FFF;
   transition: background-color 0.5s ease;
 }
 
@@ -88,13 +73,12 @@ div:hover > .editPaneStyle {
   position: relative;
   height: 100%;
   text-align: center;
-  background-color: #EEE;
   border-radius: 5px;
   transition: background-color 0.5s ease;
 }
 
 .disabledPanelStyle {
-  background-color: rgba(0, 0, 0, 0.1);
+  background-color: rgba(125, 125, 125, 0.25);
   position: absolute;
   left: 0;
   right: 0;

--- a/ui/src/main/webapp/app.js
+++ b/ui/src/main/webapp/app.js
@@ -1,6 +1,5 @@
-import React, { Component } from 'react'
+import React from 'react'
 import { Provider, connect } from 'react-redux'
-import muiThemeable from 'material-ui/styles/muiThemeable'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 
 import store from './store'
@@ -11,22 +10,12 @@ import Sources from './wizards/sources'
 import { Home } from './home'
 import Wcpm from './adminTools/webContextPolicyManager'
 
-import { Link } from 'react-router'
-
-import AppBar from 'material-ui/AppBar'
-
-import IconButton from 'material-ui/IconButton'
-import HomeIcon from 'material-ui/svg-icons/action/home'
-import PaletteIcon from 'material-ui/svg-icons/image/palette'
-import CloseIcon from 'material-ui/svg-icons/navigation/close'
-
 import Banners from 'system-usage/Banners'
 import Modal from 'system-usage/Modal'
-import Drawer from 'material-ui/Drawer'
-import AdminPalette from 'react-swatch/admin-palette'
+import Backdrop from 'components/Backdrop'
+import AdminAppBar from 'admin-app-bar'
 
-import { getTheme } from './reducer'
-import { updateThemeColor, setThemePreset } from './actions'
+import { getTheme } from 'admin-app-bar/reducer'
 
 import getMuiTheme from 'material-ui/styles/getMuiTheme'
 
@@ -40,129 +29,29 @@ if (process.env.NODE_ENV !== 'production') {
   DevTools = require('./containers/dev-tools').default
 }
 
-const LinkHomeIcon = (props) => (
-  <Link to='/'>
-    <HomeIcon {...props} />
-  </Link>
-)
-
-const isInIframe = () => {
-  return window !== window.top
-}
-
-let BackdropView = ({ muiTheme, children, ...rest }) => {
-  let fixed = {
-    backgroundColor: muiTheme.palette.backdropColor,
-    minHeight: '100vh',
-    top: 0,
-    left: 0,
-    bottom: 0,
-    right: 0
-  }
-
-  if (isInIframe()) {
-    fixed.borderRadius = '4px'
-  }
-
-  return (
-    <div style={fixed} {...rest}>
-      {children}
-    </div>
-  )
-}
-
-const Backdrop = muiThemeable()(BackdropView)
-
 const ConnectedMuiThemeProvider = connect((state) => ({
   muiTheme: getMuiTheme(getTheme(state))
 }))(MuiThemeProvider)
 
-const getAppBarStyle = () => (
-  isInIframe() ? { borderRadius: '4px 4px 0px 0px' } : {}
-)
-
-class AppView extends Component {
-  constructor (props) {
-    super(props)
-    this.state = { isArtDrawerOpen: false }
-  }
-
-  openArtDrawer () {
-    this.setState({ isArtDrawerOpen: true })
-  }
-
-  closeArtDrawer () {
-    this.setState({ isArtDrawerOpen: false })
-  }
-
-  render () {
-    const {
-      children,
-      theme,
-      updateColor,
-      setThemePreset
-    } = this.props
-    const {
-      isArtDrawerOpen
-    } = this.state
-
-    return (
+const App = ({ children }) => (
+  <Provider store={store}>
+    <ConnectedMuiThemeProvider>
       <Banners>
         <Modal />
         <Backdrop>
-          <AppBar
-            style={getAppBarStyle()}
-            iconElementLeft={
-              <IconButton>
-                <LinkHomeIcon />
-              </IconButton>
-            }
-            iconElementRight={
-              !isInIframe() ? (
-                <IconButton onTouchTap={() => this.openArtDrawer()}>
-                  <PaletteIcon />
-                </IconButton>
-              ) : null
-            }
-          />
-          <Drawer width={281} openSecondary open={isArtDrawerOpen}>
-            <IconButton onTouchTap={() => this.closeArtDrawer()}>
-              <CloseIcon />
-            </IconButton>
-            <AdminPalette theme={theme} updateColor={updateColor} setThemePreset={setThemePreset} />
-          </Drawer>
+          <AdminAppBar />
           <div style={{maxWidth: 960, margin: '0 auto'}}>{children}</div>
           <Exception />
         </Backdrop>
         <DevTools />
       </Banners>
-    )
-  }
-}
-const App = connect((state) => ({
-  theme: getTheme(state)
-}), (dispatch) => ({
-  updateColor: (path) => (color) => {
-    dispatch(updateThemeColor(path, color))
-    window.forceUpdateThemeing()
-  },
-  setThemePreset: (themeName) => {
-    dispatch(setThemePreset(themeName))
-    window.forceUpdateThemeing()
-  }
-}))(AppView)
-
-const ConnectedApp = (props) => (
-  <Provider store={store}>
-    <ConnectedMuiThemeProvider>
-      <App {...props} />
     </ConnectedMuiThemeProvider>
   </Provider>
 )
 
 export const routes = {
   path: '/',
-  component: ConnectedApp,
+  component: App,
   indexRoute: { component: Home },
   childRoutes: [
     { path: 'ldap', component: Ldap },

--- a/ui/src/main/webapp/app.js
+++ b/ui/src/main/webapp/app.js
@@ -1,5 +1,8 @@
-import React from 'react'
-import { Provider } from 'react-redux'
+import React, { Component } from 'react'
+import { Provider, connect } from 'react-redux'
+import muiThemeable from 'material-ui/styles/muiThemeable'
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+
 import store from './store'
 
 import Exception from './containers/exceptions'
@@ -8,14 +11,24 @@ import Sources from './wizards/sources'
 import { Home } from './home'
 import Wcpm from './adminTools/webContextPolicyManager'
 
-import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
-import HomeIcon from 'material-ui/svg-icons/action/home'
-import IconButton from 'material-ui/IconButton'
 import { Link } from 'react-router'
+
 import AppBar from 'material-ui/AppBar'
+
+import IconButton from 'material-ui/IconButton'
+import HomeIcon from 'material-ui/svg-icons/action/home'
+import PaletteIcon from 'material-ui/svg-icons/image/palette'
+import CloseIcon from 'material-ui/svg-icons/navigation/close'
 
 import Banners from 'system-usage/Banners'
 import Modal from 'system-usage/Modal'
+import Drawer from 'material-ui/Drawer'
+import AdminPalette from 'react-swatch/admin-palette'
+
+import { getTheme } from './reducer'
+import { updateThemeColor, setThemePreset } from './actions'
+
+import getMuiTheme from 'material-ui/styles/getMuiTheme'
 
 var DevTools
 
@@ -33,28 +46,123 @@ const LinkHomeIcon = (props) => (
   </Link>
 )
 
-const App = ({ children }) => (
-  <MuiThemeProvider>
-    <Provider store={store}>
+const isInIframe = () => {
+  return window !== window.top
+}
+
+let BackdropView = ({ muiTheme, children, ...rest }) => {
+  let fixed = {
+    backgroundColor: muiTheme.palette.backdropColor,
+    minHeight: '100vh',
+    top: 0,
+    left: 0,
+    bottom: 0,
+    right: 0
+  }
+
+  if (isInIframe()) {
+    fixed.borderRadius = '4px'
+  }
+
+  return (
+    <div style={fixed} {...rest}>
+      {children}
+    </div>
+  )
+}
+
+const Backdrop = muiThemeable()(BackdropView)
+
+const ConnectedMuiThemeProvider = connect((state) => ({
+  muiTheme: getMuiTheme(getTheme(state))
+}))(MuiThemeProvider)
+
+const getAppBarStyle = () => (
+  isInIframe() ? { borderRadius: '4px 4px 0px 0px' } : {}
+)
+
+class AppView extends Component {
+  constructor (props) {
+    super(props)
+    this.state = { isArtDrawerOpen: false }
+  }
+
+  openArtDrawer () {
+    this.setState({ isArtDrawerOpen: true })
+  }
+
+  closeArtDrawer () {
+    this.setState({ isArtDrawerOpen: false })
+  }
+
+  render () {
+    const {
+      children,
+      theme,
+      updateColor,
+      setThemePreset
+    } = this.props
+    const {
+      isArtDrawerOpen
+    } = this.state
+
+    return (
       <Banners>
         <Modal />
-        <AppBar
-          iconElementLeft={
-            <IconButton>
-              <LinkHomeIcon />
+        <Backdrop>
+          <AppBar
+            style={getAppBarStyle()}
+            iconElementLeft={
+              <IconButton>
+                <LinkHomeIcon />
+              </IconButton>
+            }
+            iconElementRight={
+              !isInIframe() ? (
+                <IconButton onTouchTap={() => this.openArtDrawer()}>
+                  <PaletteIcon />
+                </IconButton>
+              ) : null
+            }
+          />
+          <Drawer width={281} openSecondary open={isArtDrawerOpen}>
+            <IconButton onTouchTap={() => this.closeArtDrawer()}>
+              <CloseIcon />
             </IconButton>
-          } />
-        <div style={{ maxWidth: 960, padding: 20, margin: '0 auto' }}>{children}</div>
-        <Exception />
+            <AdminPalette theme={theme} updateColor={updateColor} setThemePreset={setThemePreset} />
+          </Drawer>
+          <div style={{maxWidth: 960, margin: '0 auto'}}>{children}</div>
+          <Exception />
+        </Backdrop>
         <DevTools />
       </Banners>
-    </Provider>
-  </MuiThemeProvider>
+    )
+  }
+}
+const App = connect((state) => ({
+  theme: getTheme(state)
+}), (dispatch) => ({
+  updateColor: (path) => (color) => {
+    dispatch(updateThemeColor(path, color))
+    window.forceUpdateThemeing()
+  },
+  setThemePreset: (themeName) => {
+    dispatch(setThemePreset(themeName))
+    window.forceUpdateThemeing()
+  }
+}))(AppView)
+
+const ConnectedApp = (props) => (
+  <Provider store={store}>
+    <ConnectedMuiThemeProvider>
+      <App {...props} />
+    </ConnectedMuiThemeProvider>
+  </Provider>
 )
 
 export const routes = {
   path: '/',
-  component: App,
+  component: ConnectedApp,
   indexRoute: { component: Home },
   childRoutes: [
     { path: 'ldap', component: Ldap },

--- a/ui/src/main/webapp/home/components.js
+++ b/ui/src/main/webapp/home/components.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Link } from 'react-router'
+import Flexbox from 'flexbox-react'
+
+import Paper from 'material-ui/Paper'
+import muiThemeable from 'material-ui/styles/muiThemeable'
+
+import * as styles from './styles.less'
+
+const TileLinkView = ({ to, title, subtitle, Icon, muiTheme }) => (
+  <div>
+    <Link to={to}>
+      <Paper className={styles.main}>
+        <div style={{width: '100%', height: '100%'}}>
+          <Flexbox
+            alignItems='center'
+            flexDirection='column'
+            justifyContent='center'
+            style={{width: '100%', height: '100%'}}>
+
+            <p className={styles.titleTitle}>{title}</p>
+            <Icon style={{color: muiTheme.palette.primary1Color, width: '50%', height: '50%'}} />
+            <p className={styles.tileSubtitle}>{subtitle}</p>
+
+          </Flexbox>
+        </div>
+      </Paper>
+    </Link>
+  </div>
+)
+
+export const TileLink = muiThemeable()(TileLinkView)

--- a/ui/src/main/webapp/home/index.js
+++ b/ui/src/main/webapp/home/index.js
@@ -12,8 +12,9 @@ import AccountIcon from 'material-ui/svg-icons/action/account-circle'
 import LanguageIcon from 'material-ui/svg-icons/action/language'
 import VpnLockIcon from 'material-ui/svg-icons/notification/vpn-lock'
 import Divider from 'material-ui/Divider'
-import { cyan500 } from 'material-ui/styles/colors'
 import RaisedButton from 'material-ui/RaisedButton'
+import muiThemeable from 'material-ui/styles/muiThemeable'
+
 import MapDisplay from 'components/MapDisplay'
 import Spinner from 'components/Spinner'
 import confirmable from 'react-confirmable'
@@ -117,7 +118,7 @@ export const LdapTile = connect((state, { servicePid }) => ({
   onDeleteConfig: () => dispatch(actions.deleteConfig({configurationHandlerId: props.configurationType, ...props, id: 'sources'}))
 }))(LdapTileView)
 
-const TileLink = ({ to, title, subtitle, children }) => (
+let TileLink = ({ to, title, subtitle, Icon, muiTheme }) => (
   <div>
     <Link to={to}>
       <Paper className={styles.main}>
@@ -129,7 +130,7 @@ const TileLink = ({ to, title, subtitle, children }) => (
             style={{width: '100%', height: '100%'}}>
 
             <p className={styles.titleTitle}>{title}</p>
-            {children}
+            {React.createElement(Icon, { style: { color: muiTheme.palette.primary1Color, width: '50%', height: '50%' } })}
             <p className={styles.tileSubtitle}>{subtitle}</p>
 
           </Flexbox>
@@ -138,14 +139,15 @@ const TileLink = ({ to, title, subtitle, children }) => (
     </Link>
   </div>
 )
+TileLink = muiThemeable()(TileLink)
 
 const ConfigField = ({fieldName, value}) => (
   <div className={styles.configField}>{fieldName}: {value}</div>
 )
 
-const SourceConfigTiles = ({ sourceConfigs, submittingPids }) => {
+let SourceConfigTiles = ({ sourceConfigs, submittingPids, muiTheme }) => {
   if (sourceConfigs.length === 0) {
-    return <div style={{margin: '20px'}}>No Sources Configured </div>
+    return <div style={{ margin: '20px', color: muiTheme.palette.textColor }}>No Sources Configured</div>
   }
 
   return (
@@ -154,10 +156,11 @@ const SourceConfigTiles = ({ sourceConfigs, submittingPids }) => {
     </Flexbox>
   )
 }
+SourceConfigTiles = muiThemeable()(SourceConfigTiles)
 
-const LdapConfigTiles = ({ ldapConfigs, submittingPids }) => {
+let LdapConfigTiles = ({ ldapConfigs, submittingPids, muiTheme }) => {
   if (ldapConfigs.length === 0) {
-    return <div style={{margin: '20px'}}>No LDAP Servers Configured</div>
+    return <div style={{ margin: '20px', color: muiTheme.palette.textColor }}>No LDAP Servers Configured</div>
   }
 
   return (
@@ -166,10 +169,12 @@ const LdapConfigTiles = ({ ldapConfigs, submittingPids }) => {
     </Flexbox>
   )
 }
+LdapConfigTiles = muiThemeable()(LdapConfigTiles)
 
-const Title = ({ children }) => (
-  <h1 className={styles.title}>{children}</h1>
+let Title = ({ children, muiTheme }) => (
+  <h1 style={{ color: muiTheme.palette.textColor }}>{children}</h1>
 )
+Title = muiThemeable()(Title)
 
 const SourcesHomeView = ({ sourceConfigs = [], ldapConfigs = [], submittingPids = {}, onRefresh, offRefresh }) => (
   <div style={{width: '100%'}}>
@@ -183,23 +188,20 @@ const SourcesHomeView = ({ sourceConfigs = [], ldapConfigs = [], submittingPids 
       <TileLink
         to='/sources'
         title='Source Setup Wizard'
-        subtitle='Setup a new source for federating'>
-        <LanguageIcon style={{color: cyan500, width: '50%', height: '50%'}} />
-      </TileLink>
+        subtitle='Setup a new source for federating'
+        Icon={LanguageIcon} />
 
       <TileLink
         to='/web-context-policy-manager'
         title='Endpoint Security'
-        subtitle='Web context policy management'>
-        <VpnLockIcon style={{color: cyan500, width: '50%', height: '50%'}} />
-      </TileLink>
+        subtitle='Web context policy management'
+        Icon={VpnLockIcon} />
 
       <TileLink
         to='/ldap'
         title='LDAP Setup Wizard'
-        subtitle='Configure LDAP as a login'>
-        <AccountIcon style={{color: cyan500, width: '50%', height: '50%'}} />
-      </TileLink>
+        subtitle='Configure LDAP as a login'
+        Icon={AccountIcon} />
     </Flexbox>
 
     <Divider />

--- a/ui/src/main/webapp/home/styles.less
+++ b/ui/src/main/webapp/home/styles.less
@@ -15,7 +15,6 @@
   font-size: 18px;
   position: relative;
   text-align: center;
-  color: rgba(0, 0, 0, 0.70);
   margin: 5px 0px;
 }
 
@@ -23,7 +22,6 @@
   font-size: 14px;
   position: relative;
   text-align: center;
-  color: rgba(0, 0, 0, 0.541176);
   margin: 10px 30px;
 }
 
@@ -38,7 +36,6 @@
 .configField {
   font-size: 14px;
   position: relative;
-  color: rgba(0, 0, 0, 0.541176);
 }
 
 .error {

--- a/ui/src/main/webapp/index.js
+++ b/ui/src/main/webapp/index.js
@@ -2,6 +2,7 @@ import inject from 'react-tap-event-plugin'
 import React from 'react'
 import { render } from 'react-dom'
 import { Router, createMemoryHistory, hashHistory, RouterContext, match } from 'react-router'
+import deepForceUpdate from 'react-deep-force-update'
 
 import { routes } from './app'
 
@@ -16,9 +17,10 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 if (process.env.NODE_ENV !== 'production') {
+  let instance
   const AppContainer = require('react-hot-loader').AppContainer
 
-  render(
+  instance = render(
     <AppContainer errorReporter={({ error }) => { throw error }}>
       <Router history={hashHistory} routes={routes} />
     </AppContainer>,
@@ -29,13 +31,15 @@ if (process.env.NODE_ENV !== 'production') {
     // use <App /> here rather than require() a <NextApp />.
     try {
       const routes = require('./app').routes
-      render(
+      instance = render(
         <AppContainer errorReporter={({ error }) => { throw error }}>
           <Router history={hashHistory} routes={routes} />
         </AppContainer>,
         document.getElementById('root'))
     } catch (e) {}
   })
+
+  window.forceUpdateThemeing = () => setTimeout(() => deepForceUpdate(instance), 0)
 }
 
 export default ({ html, path }, done) => {

--- a/ui/src/main/webapp/lib/admin-app-bar/actions.js
+++ b/ui/src/main/webapp/lib/admin-app-bar/actions.js
@@ -1,0 +1,2 @@
+export const updateThemeColor = (path, value) => ({ type: 'THEME/SET_COLOR', path, value })
+export const setThemePreset = (themeName) => ({ type: 'THEME/SET_PRESET', themeName })

--- a/ui/src/main/webapp/lib/admin-app-bar/index.js
+++ b/ui/src/main/webapp/lib/admin-app-bar/index.js
@@ -1,0 +1,95 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { Link } from 'react-router'
+
+import PaletteIcon from 'material-ui/svg-icons/image/palette'
+import CloseIcon from 'material-ui/svg-icons/navigation/close'
+import HomeIcon from 'material-ui/svg-icons/action/home'
+
+import AppBar from 'material-ui/AppBar'
+import IconButton from 'material-ui/IconButton'
+import Drawer from 'material-ui/Drawer'
+
+import AdminPalette from 'react-swatch/admin-palette'
+
+import { updateThemeColor, setThemePreset } from './actions'
+import { getTheme } from './reducer'
+
+const LinkHomeIcon = (props) => (
+  <Link to='/'>
+    <HomeIcon {...props} />
+  </Link>
+)
+
+const isInIframe = () => {
+  return window !== window.top
+}
+
+const getAppBarStyle = () => (
+  isInIframe() ? { borderRadius: '4px 4px 0px 0px' } : {}
+)
+
+class AppBarView extends Component {
+  constructor (props) {
+    super(props)
+    this.state = { isArtDrawerOpen: false }
+  }
+
+  openArtDrawer () {
+    this.setState({ isArtDrawerOpen: true })
+  }
+
+  closeArtDrawer () {
+    this.setState({ isArtDrawerOpen: false })
+  }
+
+  render () {
+    const {
+      theme,
+      updateColor,
+      setThemePreset
+    } = this.props
+    const {
+      isArtDrawerOpen
+    } = this.state
+
+    return (
+      <div>
+        <AppBar
+          style={getAppBarStyle()}
+          iconElementLeft={
+            <IconButton>
+              <LinkHomeIcon />
+            </IconButton>
+          }
+          iconElementRight={
+            (process.env.NODE_ENV !== 'production') ? (
+              <IconButton onTouchTap={() => this.openArtDrawer()}>
+                <PaletteIcon />
+              </IconButton>
+            ) : null
+          }
+        />
+        <Drawer width={281} openSecondary open={isArtDrawerOpen}>
+          <IconButton onTouchTap={() => this.closeArtDrawer()}>
+            <CloseIcon />
+          </IconButton>
+          <AdminPalette theme={theme} updateColor={updateColor} setThemePreset={setThemePreset} />
+        </Drawer>
+      </div>
+    )
+  }
+}
+
+export default connect((state) => ({
+  theme: getTheme(state)
+}), (dispatch) => ({
+  updateColor: (path) => (color) => {
+    dispatch(updateThemeColor(path, color))
+    window.forceUpdateThemeing()
+  },
+  setThemePreset: (themeName) => {
+    dispatch(setThemePreset(themeName))
+    window.forceUpdateThemeing()
+  }
+}))(AppBarView)

--- a/ui/src/main/webapp/lib/admin-app-bar/reducer.js
+++ b/ui/src/main/webapp/lib/admin-app-bar/reducer.js
@@ -1,0 +1,33 @@
+import sub from 'redux-submarine'
+import { fromJS } from 'immutable'
+
+import defaultTheme from 'themes/defaultTheme'
+import darkTheme from 'themes/darkTheme'
+import adminTheme from 'themes/adminTheme'
+import parrettTheme from 'themes/parrettTheme'
+import solarizedDarkTheme from 'themes/solarizedDarkTheme'
+
+const presetThemes = ({
+  'Admin': adminTheme,
+  'Material': defaultTheme,
+  'Dark': darkTheme,
+  'Parrett': parrettTheme,
+  'Solarized Dark': solarizedDarkTheme
+})
+
+export const submarine = sub()
+
+export default (state = fromJS(adminTheme), { type, path, value, themeName }) => {
+  switch (type) {
+    case 'THEME/SET_COLOR':
+      const temp = state.setIn(path, value)
+      return temp.setIn(['textField', 'errorColor'], temp.getIn(['palette', 'errorColor']))
+        .setIn(['raisedButton', 'disabledColor'], temp.getIn(['palette', 'disabledColor']))
+    case 'THEME/SET_PRESET':
+      return fromJS(presetThemes[themeName])
+    default:
+      return state
+  }
+}
+
+export const getTheme = (state) => submarine(state).toJS()

--- a/ui/src/main/webapp/lib/admin-wizard/inputs.js
+++ b/ui/src/main/webapp/lib/admin-wizard/inputs.js
@@ -11,12 +11,11 @@ import SelectField from 'material-ui/SelectField'
 import AutoComplete from 'material-ui/AutoComplete'
 import IconButton from 'material-ui/IconButton'
 import InfoIcon from 'material-ui/svg-icons/action/info'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 
 import visible from 'react-visible'
 
 import Flexbox from 'flexbox-react'
-
-import { green400, orange500 } from 'material-ui/styles/colors'
 
 const mapStateToProps = (state, { id }) => getConfig(state, id)
 
@@ -24,18 +23,18 @@ const mapDispatchToProps = (dispatch, { id }) => ({
   onEdit: (value) => dispatch(editConfig(id, value))
 })
 
-const messageStyles = {
-  SUCCESS: { color: green400 },
-  WARNING: { color: orange500 }
-}
-
-const InputView = ({ value = '', label, onEdit, message = {}, tooltip, ...rest }) => {
+const InputView = ({ value = '', label, onEdit, message = {}, tooltip, muiTheme, ...rest }) => {
   for (let key in rest) {
     if (rest[key] === undefined) {
       delete rest[key]
     }
   }
   const { type, message: text } = message
+
+  const messageStyles = {
+    SUCCESS: { color: muiTheme.palette.successColor },
+    WARNING: { color: muiTheme.palette.warningColor }
+  }
 
   return (
     <Flexbox flexDirection='row' style={{position: 'relative'}}>
@@ -61,7 +60,7 @@ const InputView = ({ value = '', label, onEdit, message = {}, tooltip, ...rest }
   )
 }
 
-const Input = visible(connect(mapStateToProps, mapDispatchToProps)(InputView))
+const Input = visible(connect(mapStateToProps, mapDispatchToProps)(muiThemeable()(InputView)))
 
 const Password = ({ label = 'Password', ...rest }) => (
   <Input type='password' label={label} {...rest} />
@@ -71,12 +70,17 @@ const Hostname = ({ label = 'Hostname', ...rest }) => (
   <Input label={label} {...rest} />
 )
 
-const InputAutoView = ({ value = '', options = [], type = 'text', message = {}, onEdit, label, tooltip, ...rest }) => {
+const InputAutoView = ({ value = '', options = [], type = 'text', message = {}, onEdit, label, tooltip, muiTheme, ...rest }) => {
   const { type: messageType, message: text } = message
   for (let key in rest) {
     if (rest[key] === undefined) {
       delete rest[key]
     }
+  }
+
+  const messageStyles = {
+    SUCCESS: { color: muiTheme.palette.successColor },
+    WARNING: { color: muiTheme.palette.warningColor }
   }
 
   return (
@@ -113,7 +117,7 @@ const InputAutoView = ({ value = '', options = [], type = 'text', message = {}, 
   )
 }
 
-const InputAuto = visible(connect(mapStateToProps, mapDispatchToProps)(InputAutoView))
+const InputAuto = visible(connect(mapStateToProps, mapDispatchToProps)(muiThemeable()(InputAutoView)))
 
 const Port = ({ value = 0, label = 'Port', ...rest }) => (
   <InputAuto type='number' value={value} label={label} {...rest} />

--- a/ui/src/main/webapp/lib/components/Backdrop.js
+++ b/ui/src/main/webapp/lib/components/Backdrop.js
@@ -1,0 +1,27 @@
+import React from 'react'
+
+import muiThemeable from 'material-ui/styles/muiThemeable'
+
+const isInIframe = () => {
+  return window !== window.top
+}
+
+let BackdropView = ({ muiTheme, children, ...rest }) => {
+  let fixed = {
+    backgroundColor: muiTheme.palette.backdropColor,
+    height: '100vh'
+  }
+
+  if (isInIframe()) {
+    fixed.borderRadius = '4px'
+    fixed.height = '100%'
+  }
+
+  return (
+    <div style={fixed} {...rest}>
+      {children}
+    </div>
+  )
+}
+
+export default muiThemeable()(BackdropView)

--- a/ui/src/main/webapp/lib/components/Description.js
+++ b/ui/src/main/webapp/lib/components/Description.js
@@ -1,7 +1,10 @@
 import React from 'react'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 
 import { description } from './styles.less'
 
-export default ({ children }) => (
-  <div className={description}>{children}</div>
+const Description = ({ children, muiTheme }) => (
+  <div className={description} style={{ color: muiTheme.palette.textColor }}>{children}</div>
 )
+
+export default muiThemeable()(Description)

--- a/ui/src/main/webapp/lib/components/Information.js
+++ b/ui/src/main/webapp/lib/components/Information.js
@@ -1,20 +1,23 @@
 import React from 'react'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 
 import { informationDiv, informationLabel, informationP, informationListItemP } from './styles.less'
 
-export default ({ id, label, value }) => (
+const Information = ({ id, label, value, muiTheme }) => (
   <div className={informationDiv}>
-    <label className={informationLabel}>{label}</label>
+    <label className={informationLabel} style={{ color: muiTheme.palette.textColor }}>{label}</label>
     { value instanceof Array
       ? (
         <div className={informationP}>
           {value.map((text, i) => (
-            <p key={i} className={informationListItemP}>
+            <p key={i} className={informationListItemP} style={{ color: muiTheme.palette.textColor }}>
               {text}
             </p>))}
         </div>
         )
-      : (<p id={id} className={informationP}>{value}</p>)
+      : (<p id={id} className={informationP} style={{ color: muiTheme.palette.textColor }}>{value}</p>)
     }
   </div>
 )
+
+export default muiThemeable()(Information)

--- a/ui/src/main/webapp/lib/components/LargeStatusIndicator.js
+++ b/ui/src/main/webapp/lib/components/LargeStatusIndicator.js
@@ -2,8 +2,7 @@ import React from 'react'
 
 import CheckIcon from 'material-ui/svg-icons/action/check-circle'
 import CloseIcon from 'material-ui/svg-icons/navigation/cancel'
-
-import {green500, red500} from 'material-ui/styles/colors'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 import { center } from './styles.less'
 
 const statusIndicator = ({
@@ -11,11 +10,13 @@ const statusIndicator = ({
   height: '300px'
 })
 
-export default ({success}) => (
+const LargeStatusIndicator = ({success, muiTheme}) => (
   <div className={center}>
     {(success)
-      ? <CheckIcon style={statusIndicator} color={green500} />
-      : <CloseIcon style={statusIndicator} color={red500} />
+      ? <CheckIcon style={statusIndicator} color={muiTheme.palette.successColor} />
+      : <CloseIcon style={statusIndicator} color={muiTheme.palette.errorColor} />
     }
   </div>
 )
+
+export default muiThemeable()(LargeStatusIndicator)

--- a/ui/src/main/webapp/lib/components/Message.js
+++ b/ui/src/main/webapp/lib/components/Message.js
@@ -1,17 +1,20 @@
 import React from 'react'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 
 import * as styles from './styles.less'
 
-export default ({ type, message, children }) => {
+const Message = ({ type, message, children, muiTheme }) => {
   const styleMap = {
-    FAILURE: styles.error,
-    WARNING: styles.warning,
-    SUCCESS: styles.success
+    FAILURE: muiTheme.palette.errorColor,
+    WARNING: muiTheme.palette.warningColor,
+    SUCCESS: muiTheme.palette.successColor
   }
   return (
-    <div className={styleMap[type] || styleMap.SUCCESS}>
+    <div className={styles.messageStyle} style={{ color: muiTheme.palette.alternateTextColor, background: styleMap[type] }}>
       {message}
       {children}
     </div>
   )
 }
+
+export default muiThemeable()(Message)

--- a/ui/src/main/webapp/lib/components/Title.js
+++ b/ui/src/main/webapp/lib/components/Title.js
@@ -1,7 +1,10 @@
 import React from 'react'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 
 import { title } from './styles.less'
 
-export default ({ children }) => (
-  <p className={title}>{children}</p>
+const Title = ({ children, muiTheme }) => (
+  <p className={title} style={{ color: muiTheme.palette.textColor }}>{children}</p>
 )
+
+export default muiThemeable()(Title)

--- a/ui/src/main/webapp/lib/components/styles.less
+++ b/ui/src/main/webapp/lib/components/styles.less
@@ -2,7 +2,6 @@
   font-size: 18px;
   position: relative;
   text-align: center;
-  color: rgba(0, 0, 0, 0.70);
   margin: 10px 0px;
 }
 
@@ -10,7 +9,6 @@
   font-size: 14px;
   position: relative;
   text-align: center;
-  color: rgba(0, 0, 0, 0.541176);
   margin: 10px 30px;
 }
 
@@ -37,34 +35,8 @@
   display: flex;
 }
 
-.error {
+.messageStyle {
   margin-top: 20px;
-  color: white;
-  background: rgb(244, 67, 54);
-  padding: 10px;
-  box-sizing: border-box;
-  box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
-  border-radius: 2px;
-  font-size: 14px;
-  font-weight: bold;
-}
-
-.success {
-  margin-top: 20px;
-  color: white;
-  background: #4CAF50;
-  padding: 10px;
-  box-sizing: border-box;
-  box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;
-  border-radius: 2px;
-  font-size: 14px;
-  font-weight: bold;
-}
-
-.warning {
-  margin-top: 20px;
-  color: white;
-  background: #FF9800;
   padding: 10px;
   box-sizing: border-box;
   box-shadow: rgba(0, 0, 0, 0.117647) 0px 1px 6px, rgba(0, 0, 0, 0.117647) 0px 1px 4px;

--- a/ui/src/main/webapp/lib/react-confirmable/index.js
+++ b/ui/src/main/webapp/lib/react-confirmable/index.js
@@ -2,6 +2,12 @@ import React, { Component } from 'react'
 import Flexbox from 'flexbox-react'
 import RaisedButton from 'material-ui/RaisedButton'
 import { infoSubtitleLeft } from './styles.less'
+import muiThemeable from 'material-ui/styles/muiThemeable'
+
+const ThemedFont = muiThemeable()(({ muiTheme, children, ...rest }) => (
+  <p style={{ color: muiTheme.palette.primary1Color }} {...rest}>
+    {children}</p>
+))
 
 export default (InnerComponent) => class extends Component {
   constructor (props) {
@@ -32,7 +38,7 @@ export default (InnerComponent) => class extends Component {
       return (
         <Flexbox style={confirmableStyle}
           flexDirection='column' alignItems='center'>
-          <p className={infoSubtitleLeft}>{confirmableMessage}</p>
+          <ThemedFont className={infoSubtitleLeft}>{confirmableMessage}</ThemedFont>
           <Flexbox flexDirection='row'>
             <RaisedButton label='Yes' className='yes' primary onClick={() => this.confirm(onClick)} />
             <RaisedButton label='No' className='no' secondary onClick={() => this.deny()} />

--- a/ui/src/main/webapp/lib/react-confirmable/styles.less
+++ b/ui/src/main/webapp/lib/react-confirmable/styles.less
@@ -2,6 +2,5 @@
   font-size: 14px;
   position: relative;
   text-align: left;
-  color: rgb(0, 184, 212);
   margin: 10px 10px;
 }

--- a/ui/src/main/webapp/lib/react-swatch/admin-palette.js
+++ b/ui/src/main/webapp/lib/react-swatch/admin-palette.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react'
+
+import { Card, CardHeader } from 'material-ui/Card'
+import SelectField from 'material-ui/SelectField'
+import MenuItem from 'material-ui/MenuItem'
+
+import Swatch from './'
+import { getReadableTextColor } from './color-utils'
+
+export default class extends Component {
+  constructor (props) {
+    super(props)
+    this.state = ({ presetSelection: null })
+  }
+
+  changePreset (value) {
+    this.setState({ presetSelection: value })
+    this.props.setThemePreset(value)
+  }
+
+  render () {
+    const {
+      theme,
+      updateColor
+    } = this.props
+    const {
+      presetSelection
+    } = this.state
+
+    const cardStyle = ({
+      backgroundColor: theme.palette.backdropColor,
+      padding: '5px',
+      marginBottom: '10px'
+    })
+
+    const cardHeaderStyle = ({
+      margin: '0px',
+      fontSize: '18px',
+      whiteSpace: 'nowrap',
+      color: getReadableTextColor(theme.palette.backdropColor)
+    })
+
+    return (
+      <div style={{padding: '0px 5px'}}>
+        <Card style={cardStyle}>
+          <CardHeader title={<p style={cardHeaderStyle}>Labels & Buttons</p>} />
+          <Swatch label='Primary' background={theme.palette.primary1Color} onChange={updateColor(['palette', 'primary1Color'])} />
+          <Swatch label='Secondary' background={theme.palette.accent1Color} onChange={updateColor(['palette', 'accent1Color'])} />
+          <Swatch label='Disabled' background={theme.palette.disabledColor} onChange={updateColor(['palette', 'disabledColor'])} />
+          <Swatch label='Label Text' background={theme.palette.alternateTextColor} onChange={updateColor(['palette', 'alternateTextColor'])} />
+        </Card>
+        <Card style={cardStyle}>
+          <CardHeader title={<p style={cardHeaderStyle}>Background & Text</p>} />
+          <Swatch label='Text' background={theme.palette.textColor} onChange={updateColor(['palette', 'textColor'])} />
+          <Swatch label='Canvas' background={theme.palette.canvasColor} onChange={updateColor(['palette', 'canvasColor'])} />
+          <Swatch label='Backdrop' background={theme.palette.backdropColor} onChange={updateColor(['palette', 'backdropColor'])} />
+        </Card>
+        <Card style={cardStyle}>
+          <CardHeader title={<p style={cardHeaderStyle}>Alerts & Messages</p>} />
+          <Swatch label='Error' background={theme.palette.errorColor} onChange={updateColor(['palette', 'errorColor'])} />
+          <Swatch label='Warning' background={theme.palette.warningColor} onChange={updateColor(['palette', 'warningColor'])} />
+          <Swatch label='Success' background={theme.palette.successColor} onChange={updateColor(['palette', 'successColor'])} />
+        </Card>
+        <Card style={cardStyle}>
+          <CardHeader title={<p style={cardHeaderStyle}>Misc</p>} />
+          <Swatch label='Table Highlight' background={theme.palette.accent2Color} onChange={updateColor(['palette', 'accent2Color'])} />
+          <Swatch label='Table Header' background={theme.palette.accent3Color} onChange={updateColor(['palette', 'accent3Color'])} />
+        </Card>
+        <SelectField
+          floatingLabelText='Presets'
+          value={presetSelection}
+          onChange={(e, i, value) => this.changePreset(value)}>
+          <MenuItem value='Admin' primaryText='Admin' />
+          <MenuItem value='Material' primaryText='Material' />
+          <MenuItem value='Dark' primaryText='Dark' />
+          <MenuItem value='Parrett' primaryText='Parrett' />
+          <MenuItem value='Solarized Dark' primaryText='Solarized Dark' />
+        </SelectField>
+      </div>
+    )
+  }
+}

--- a/ui/src/main/webapp/lib/react-swatch/admin-palette.js
+++ b/ui/src/main/webapp/lib/react-swatch/admin-palette.js
@@ -62,9 +62,10 @@ export default class extends Component {
           <Swatch label='Success' background={theme.palette.successColor} onChange={updateColor(['palette', 'successColor'])} />
         </Card>
         <Card style={cardStyle}>
-          <CardHeader title={<p style={cardHeaderStyle}>Misc</p>} />
+          <CardHeader title={<p style={cardHeaderStyle}>Tables</p>} />
           <Swatch label='Table Highlight' background={theme.palette.accent2Color} onChange={updateColor(['palette', 'accent2Color'])} />
           <Swatch label='Table Header' background={theme.palette.accent3Color} onChange={updateColor(['palette', 'accent3Color'])} />
+          <Swatch label='Table Selected' background={theme.tableRow.selectedColor} onChange={updateColor(['tableRow', 'selectedColor'])} />
         </Card>
         <SelectField
           floatingLabelText='Presets'

--- a/ui/src/main/webapp/lib/react-swatch/color-utils.js
+++ b/ui/src/main/webapp/lib/react-swatch/color-utils.js
@@ -1,0 +1,9 @@
+import color from 'color'
+
+export const getReadableTextColor = (backgroundColor) => {
+  return color(backgroundColor).light() ? 'rgba(0, 0, 0, 0.5)' : 'rgba(255, 255, 255, 0.5)'
+}
+
+export const getReadableTextColorOpaque = (backgroundColor) => {
+  return color(backgroundColor).light() ? '#000000' : '#FFFFFF'
+}

--- a/ui/src/main/webapp/lib/react-swatch/index.js
+++ b/ui/src/main/webapp/lib/react-swatch/index.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import { Card, CardHeader, CardText } from 'material-ui/Card'
+import { ChromePicker } from 'react-color'
+import { getReadableTextColor } from './color-utils'
+import Collapse from 'material-ui/svg-icons/navigation/expand-less'
+import Expand from 'material-ui/svg-icons/navigation/expand-more'
+
+export default ({ background, onChange, label }) => {
+  const foreground = getReadableTextColor(background)
+
+  return (
+    <Card style={{ backgroundColor: background }}>
+      <CardHeader
+        openIcon={
+          <Collapse color={foreground} />
+        }
+        closeIcon={
+          <Expand color={foreground} />
+        }
+        showExpandableButton
+        title={
+          <span style={{ fontSize: '18px', color: foreground, fontWeight: 'bold', textTransform: 'uppercase', whiteSpace: 'nowrap', cursor: 'pointer' }}>
+            {label}
+          </span>
+        }
+        actAsExpander
+      />
+      <CardText expandable>
+        <ChromePicker
+          disableAlpha
+          color={background}
+          onChangeComplete={(color) => onChange(color.hex)} />
+      </CardText>
+    </Card>
+  )
+}

--- a/ui/src/main/webapp/lib/themes/adminTheme.js
+++ b/ui/src/main/webapp/lib/themes/adminTheme.js
@@ -1,0 +1,23 @@
+import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
+import { fromJS } from 'immutable'
+
+export default fromJS(lightBaseTheme).mergeDeep({
+  textField: {
+    errorColor: '#E74C3C'
+  },
+  raisedButton: {
+    disabledColor: '#DDDDDD'
+  },
+  palette: {
+    textColor: '#777777',
+    primary1Color: '#18BC9C',
+    accent1Color: '#2C3E50',
+    accent2Color: '#FFFFFF',
+    backdropColor: '#ECF0F1',
+    errorColor: '#E74C3C',
+    warningColor: '#DC8201',
+    successColor: '#18BC9C',
+    canvasColor: '#FFFFFF',
+    disabledColor: '#DDDDDD'
+  }
+}).toJS()

--- a/ui/src/main/webapp/lib/themes/adminTheme.js
+++ b/ui/src/main/webapp/lib/themes/adminTheme.js
@@ -8,6 +8,9 @@ export default fromJS(lightBaseTheme).mergeDeep({
   raisedButton: {
     disabledColor: '#DDDDDD'
   },
+  tableRow: {
+    selectedColor: '#DDDDDD'
+  },
   palette: {
     textColor: '#777777',
     primary1Color: '#18BC9C',

--- a/ui/src/main/webapp/lib/themes/darkTheme.js
+++ b/ui/src/main/webapp/lib/themes/darkTheme.js
@@ -1,0 +1,24 @@
+import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme'
+import { fromJS } from 'immutable'
+
+export default fromJS(darkBaseTheme).mergeDeep({
+  textField: {
+    errorColor: '#8B2635'
+  },
+  raisedButton: {
+    disabledColor: '#444444'
+  },
+  palette: {
+    textColor: '#EEEEEE',
+    alternateTextColor: '#000000',
+    primary1Color: '#3E92CC',
+    accent1Color: '#B03D67',
+    accent2Color: '#2A3943',
+    backdropColor: '#444444',
+    errorColor: '#8B2635',
+    warningColor: '#DC8201',
+    successColor: '#58955D',
+    canvasColor: '#2A2B2E',
+    disabledColor: '#444444'
+  }
+}).toJS()

--- a/ui/src/main/webapp/lib/themes/darkTheme.js
+++ b/ui/src/main/webapp/lib/themes/darkTheme.js
@@ -8,6 +8,9 @@ export default fromJS(darkBaseTheme).mergeDeep({
   raisedButton: {
     disabledColor: '#444444'
   },
+  tableRow: {
+    selectedColor: '#3A3B3E'
+  },
   palette: {
     textColor: '#EEEEEE',
     alternateTextColor: '#000000',
@@ -19,6 +22,7 @@ export default fromJS(darkBaseTheme).mergeDeep({
     warningColor: '#DC8201',
     successColor: '#58955D',
     canvasColor: '#2A2B2E',
-    disabledColor: '#444444'
+    disabledColor: '#444444',
+    borderColor: '#3A3B3E'
   }
 }).toJS()

--- a/ui/src/main/webapp/lib/themes/defaultTheme.js
+++ b/ui/src/main/webapp/lib/themes/defaultTheme.js
@@ -8,6 +8,9 @@ export default fromJS(lightBaseTheme).mergeDeep({
   raisedButton: {
     disabledColor: '#DDDDDD'
   },
+  tableRow: {
+    selectedColor: '#DDDDDD'
+  },
   palette: {
     errorColor: '#F44336',
     warningColor: '#FF9800',

--- a/ui/src/main/webapp/lib/themes/defaultTheme.js
+++ b/ui/src/main/webapp/lib/themes/defaultTheme.js
@@ -1,0 +1,19 @@
+import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme'
+import { fromJS } from 'immutable'
+
+export default fromJS(lightBaseTheme).mergeDeep({
+  textField: {
+    errorColor: '#F44336'
+  },
+  raisedButton: {
+    disabledColor: '#DDDDDD'
+  },
+  palette: {
+    errorColor: '#F44336',
+    warningColor: '#FF9800',
+    successColor: '#4CAF50',
+    accent2Color: '#FFFFFF',
+    backdropColor: '#EEEEEE',
+    disabledColor: '#DDDDDD'
+  }
+}).toJS()

--- a/ui/src/main/webapp/lib/themes/parrettTheme.js
+++ b/ui/src/main/webapp/lib/themes/parrettTheme.js
@@ -8,6 +8,9 @@ export default fromJS(darkBaseTheme).mergeDeep({
   raisedButton: {
     disabledColor: '#444444'
   },
+  tableRow: {
+    selectedColor: '#2f2f2f'
+  },
   palette: {
     accent1Color: '#753229',
     accent2Color: '#55351d',

--- a/ui/src/main/webapp/lib/themes/parrettTheme.js
+++ b/ui/src/main/webapp/lib/themes/parrettTheme.js
@@ -1,0 +1,25 @@
+import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme'
+import { fromJS } from 'immutable'
+
+export default fromJS(darkBaseTheme).mergeDeep({
+  textField: {
+    errorColor: '#6b2b3d'
+  },
+  raisedButton: {
+    disabledColor: '#444444'
+  },
+  palette: {
+    accent1Color: '#753229',
+    accent2Color: '#55351d',
+    accent3Color: '#f1dac3',
+    disabledColor: '#444444',
+    alternateTextColor: '#f7d57d',
+    backdropColor: '#333333',
+    canvasColor: '#1f1f1f',
+    errorColor: '#6b2b3d',
+    primary1Color: '#757474',
+    successColor: '#244824',
+    textColor: '#f7d57d',
+    warningColor: '#8b5300'
+  }
+}).toJS()

--- a/ui/src/main/webapp/lib/themes/solarizedDarkTheme.js
+++ b/ui/src/main/webapp/lib/themes/solarizedDarkTheme.js
@@ -2,6 +2,15 @@ import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme'
 import { fromJS } from 'immutable'
 
 export default fromJS(darkBaseTheme).mergeDeep({
+  textField: {
+    errorColor: '#6b2b3d'
+  },
+  raisedButton: {
+    disabledColor: '#586e75'
+  },
+  tableRow: {
+    selectedColor: '#073642'
+  },
   palette: {
     accent1Color: '#D33682',
     accent2Color: '#073642',
@@ -14,13 +23,6 @@ export default fromJS(darkBaseTheme).mergeDeep({
     successColor: '#859900',
     textColor: '#93A1A1',
     warningColor: '#B58900',
-    disabledColor: '#586e75',
-    borderColor: '#073642'
-  },
-  textField: {
-    errorColor: '#6b2b3d'
-  },
-  raisedButton: {
     disabledColor: '#586e75'
   }
 }).toJS()

--- a/ui/src/main/webapp/lib/themes/solarizedDarkTheme.js
+++ b/ui/src/main/webapp/lib/themes/solarizedDarkTheme.js
@@ -1,0 +1,26 @@
+import darkBaseTheme from 'material-ui/styles/baseThemes/darkBaseTheme'
+import { fromJS } from 'immutable'
+
+export default fromJS(darkBaseTheme).mergeDeep({
+  palette: {
+    accent1Color: '#D33682',
+    accent2Color: '#073642',
+    accent3Color: '#CB4B16',
+    alternateTextColor: '#FDF6E3',
+    backdropColor: '#073642',
+    canvasColor: '#002B36',
+    errorColor: '#DC322F',
+    primary1Color: '#268bd2',
+    successColor: '#859900',
+    textColor: '#93A1A1',
+    warningColor: '#B58900',
+    disabledColor: '#586e75',
+    borderColor: '#073642'
+  },
+  textField: {
+    errorColor: '#6b2b3d'
+  },
+  raisedButton: {
+    disabledColor: '#586e75'
+  }
+}).toJS()

--- a/ui/src/main/webapp/reducer/index.js
+++ b/ui/src/main/webapp/reducer/index.js
@@ -1,19 +1,4 @@
 import { combineReducers } from 'redux-immutable'
-import { fromJS } from 'immutable'
-
-import defaultTheme from 'themes/defaultTheme'
-import darkTheme from 'themes/darkTheme'
-import adminTheme from 'themes/adminTheme'
-import parrettTheme from 'themes/parrettTheme'
-import solarizedDarkTheme from 'themes/solarizedDarkTheme'
-
-const presetThemes = ({
-  'Admin': adminTheme,
-  'Material': defaultTheme,
-  'Dark': darkTheme,
-  'Parrett': parrettTheme,
-  'Solarized Dark': solarizedDarkTheme
-})
 
 import home, { submarine as homeSubmarine } from '../home/reducer'
 import systemUsage, { submarine as systemUsageSubmarine } from 'system-usage/reducer'
@@ -22,6 +7,7 @@ import fetch, { submarine as fetchSubmarine } from 'redux-fetch'
 import wizard, { submarine as wizardSubmarine } from 'admin-wizard/reducer'
 import wcpm, { submarine as wcpmSubmarine } from '../adminTools/webContextPolicyManager/reducer'
 import sourceWizard, { submarine as sourceSubmarine } from '../wizards/sources/reducer'
+import theme, { submarine as themeSubmarine } from 'admin-app-bar/reducer'
 
 const backendError = (state = {}, { type, err } = {}) => {
   switch (type) {
@@ -33,20 +19,6 @@ const backendError = (state = {}, { type, err } = {}) => {
   }
 }
 export const getBackendErrors = (state) => state.get('backendError')
-
-const theme = (state = fromJS(adminTheme), { type, path, value, themeName }) => {
-  switch (type) {
-    case 'THEME/SET_COLOR':
-      const temp = state.setIn(path, value)
-      return temp.setIn(['textField', 'errorColor'], temp.getIn(['palette', 'errorColor']))
-        .setIn(['raisedButton', 'disabledColor'], temp.getIn(['palette', 'disabledColor']))
-    case 'THEME/SET_PRESET':
-      return fromJS(presetThemes[themeName])
-    default:
-      return state
-  }
-}
-export const getTheme = (state) => state.get('theme').toJS()
 
 export default combineReducers({ fetch, wizard, backendError, sourceWizard, home, wcpm, polling, systemUsage, theme })
 
@@ -60,4 +32,5 @@ if (process.env.NODE_ENV !== 'ci') {
   wizardSubmarine.init((state) => state.get('wizard'))
   wcpmSubmarine.init((state) => state.get('wcpm'))
   sourceSubmarine.init((state) => state.get('sourceWizard'))
+  themeSubmarine.init((state) => state.get('theme'))
 }

--- a/ui/src/main/webapp/reducer/index.js
+++ b/ui/src/main/webapp/reducer/index.js
@@ -1,4 +1,19 @@
 import { combineReducers } from 'redux-immutable'
+import { fromJS } from 'immutable'
+
+import defaultTheme from 'themes/defaultTheme'
+import darkTheme from 'themes/darkTheme'
+import adminTheme from 'themes/adminTheme'
+import parrettTheme from 'themes/parrettTheme'
+import solarizedDarkTheme from 'themes/solarizedDarkTheme'
+
+const presetThemes = ({
+  'Admin': adminTheme,
+  'Material': defaultTheme,
+  'Dark': darkTheme,
+  'Parrett': parrettTheme,
+  'Solarized Dark': solarizedDarkTheme
+})
 
 import home, { submarine as homeSubmarine } from '../home/reducer'
 import systemUsage, { submarine as systemUsageSubmarine } from 'system-usage/reducer'
@@ -17,9 +32,23 @@ const backendError = (state = {}, { type, err } = {}) => {
     default: return state
   }
 }
-
 export const getBackendErrors = (state) => state.get('backendError')
-export default combineReducers({ fetch, wizard, backendError, sourceWizard, home, wcpm, polling, systemUsage })
+
+const theme = (state = fromJS(adminTheme), { type, path, value, themeName }) => {
+  switch (type) {
+    case 'THEME/SET_COLOR':
+      const temp = state.setIn(path, value)
+      return temp.setIn(['textField', 'errorColor'], temp.getIn(['palette', 'errorColor']))
+        .setIn(['raisedButton', 'disabledColor'], temp.getIn(['palette', 'disabledColor']))
+    case 'THEME/SET_PRESET':
+      return fromJS(presetThemes[themeName])
+    default:
+      return state
+  }
+}
+export const getTheme = (state) => state.get('theme').toJS()
+
+export default combineReducers({ fetch, wizard, backendError, sourceWizard, home, wcpm, polling, systemUsage, theme })
 
 // Submarines patch redux selectors which causes issues running unit tests.
 // The following if protects against the side effect during tests. Do not remove.

--- a/ui/src/main/webapp/wizards/sources/components.js
+++ b/ui/src/main/webapp/wizards/sources/components.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { connect } from 'react-redux'
+import muiThemeable from 'material-ui/styles/muiThemeable'
 
 import { getSourceStage, getStagesClean, getConfig, getStageProgress, getConfigTypeById } from './reducer'
 import { setNavStage, setConfigSource } from './actions'
@@ -17,7 +18,9 @@ import {
   animated,
   fadeIn,
   navButtonStyles,
-  navButtonStylesDisabled
+  navButtonStylesDisabled,
+  sideLines,
+  horizontalSideLines
 } from './styles.less'
 
 export const CenteredElements = ({ children, stageIndex, style }) => (
@@ -104,33 +107,33 @@ const SourceRadioButton = ({ disabled, value, label, valueSelected = 'undefined'
   }
 }
 
-export const BackNav = ({onClick, disabled}) => {
+export const BackNav = ({onClick, disabled, muiTheme}) => {
   if (!disabled) {
     return (
-      <div className={navButtonStyles} onClick={onClick}>
-        <LeftIcon style={{height: '100%', width: '100%'}} />
+      <div className={navButtonStyles} style={{ backgroundColor: muiTheme.palette.canvasColor }} onClick={onClick}>
+        <LeftIcon style={{ color: muiTheme.palette.textColor, height: '100%', width: '100%' }} />
       </div>
     )
   } else {
     return (
-      <div className={navButtonStylesDisabled}>
-        <LeftIcon style={{color: 'lightgrey', height: '100%', width: '100%'}} />
+      <div className={navButtonStylesDisabled} style={{ backgroundColor: muiTheme.palette.canvasColor }}>
+        <LeftIcon style={{ color: muiTheme.palette.textColor, height: '100%', width: '100%' }} />
       </div>
     )
   }
 }
 
-const ForwardNavView = ({onClick, clean, currentStage, maxStage, disabled}) => {
+const ForwardNavView = ({onClick, clean, currentStage, maxStage, disabled, muiTheme}) => {
   if (clean && (currentStage !== maxStage) && !disabled) {
     return (
-      <div className={navButtonStyles} onClick={onClick}>
-        <RightIcon style={{height: '100%', width: '100%'}} />
+      <div className={navButtonStyles} style={{ backgroundColor: muiTheme.palette.canvasColor }} onClick={onClick}>
+        <RightIcon style={{ color: muiTheme.palette.textColor, height: '100%', width: '100%' }} />
       </div>
     )
   } else {
     return (
-      <div className={navButtonStylesDisabled}>
-        <RightIcon style={{color: 'lightgrey', height: '100%', width: '100%'}} />
+      <div className={navButtonStylesDisabled} style={{ backgroundColor: muiTheme.palette.canvasColor }}>
+        <RightIcon style={{ color: muiTheme.palette.textColor, height: '100%', width: '100%' }} />
       </div>
     )
   }
@@ -140,14 +143,25 @@ export const ForwardNav = connect((state) => ({
   maxStage: getStageProgress(state),
   currentStage: getSourceStage(state)}))(ForwardNavView)
 
-const NavPanesView = ({ children, backClickTarget, forwardClickTarget, setNavStage, backDisabled = false, forwardDisabled = false }) => (
+const NavPanesView = ({ children, backClickTarget, forwardClickTarget, setNavStage, backDisabled = false, forwardDisabled = false, muiTheme }) => (
   <Flexbox justifyContent='center' flexDirection='row'>
-    <BackNav disabled={backDisabled} onClick={() => setNavStage(backClickTarget)} />
+    <BackNav disabled={backDisabled} onClick={() => setNavStage(backClickTarget)} muiTheme={muiTheme} />
     <CenteredElements style={{ width: '80%' }}>
       {children}
     </CenteredElements>
-    <ForwardNav disabled={forwardDisabled} onClick={() => setNavStage(forwardClickTarget)} />
+    <ForwardNav disabled={forwardDisabled} onClick={() => setNavStage(forwardClickTarget)} muiTheme={muiTheme} />
   </Flexbox>
 )
-export const NavPanes = connect(null, { setNavStage: setNavStage })(NavPanesView)
+export const NavPanes = connect(null, { setNavStage: setNavStage })(muiThemeable()(NavPanesView))
+
+const SideLinesView = ({ muiTheme, label }) => (
+  <div className={sideLines}>
+    <span style={{ color: muiTheme.palette.textColor, backgroundColor: muiTheme.palette.canvasColor }}>
+      {label}
+    </span>
+    <div className={horizontalSideLines} style={{ backgroundColor: muiTheme.palette.textColor }} />
+  </div>
+)
+
+export const SideLines = muiThemeable()(SideLinesView)
 

--- a/ui/src/main/webapp/wizards/sources/index.js
+++ b/ui/src/main/webapp/wizards/sources/index.js
@@ -23,15 +23,16 @@ const WizardView = ({ id, children, clearWizard }) => (
 
 const Wizard = connect(null, { clearWizard })(WizardView)
 
+const stageMapping = {
+  welcomeStage: WelcomeStage,
+  discoveryStage: DiscoveryStage,
+  sourceSelectionStage: SourceSelectionStage,
+  confirmationStage: ConfirmationStage,
+  completedStage: CompletedStage
+}
+
 let StageRouter = ({ stage, messages }) => {
-  const stageMapping = {
-    welcomeStage: <WelcomeStage />,
-    discoveryStage: <DiscoveryStage />,
-    sourceSelectionStage: <SourceSelectionStage />,
-    confirmationStage: <ConfirmationStage />,
-    completedStage: <CompletedStage />
-  }
-  return (stageMapping[stage])
+  return React.createElement(stageMapping[stage])
 }
 StageRouter = connect((state) => ({
   stage: getSourceStage(state)

--- a/ui/src/main/webapp/wizards/sources/stages/discovery.js
+++ b/ui/src/main/webapp/wizards/sources/stages/discovery.js
@@ -19,11 +19,7 @@ import {
   Port
 } from 'admin-wizard/inputs'
 
-import {
-  sideLines
-} from '../styles.less'
-
-import { NavPanes } from '../components'
+import { NavPanes, SideLines } from '../components'
 
 import { setDefaults } from '../../../actions'
 import Mount from 'react-mount'
@@ -102,11 +98,7 @@ const DiscoveryStageView = ({ messages, testSources, setDefaults, configs, disco
               </div>
             )
           }
-          <div className={sideLines}>
-            <span>
-                Authentication (Optional)
-              </span>
-          </div>
+          <SideLines label='Authentication (Optional)' />
           <Input
             id='sourceUserName'
             label='Username'
@@ -121,7 +113,7 @@ const DiscoveryStageView = ({ messages, testSources, setDefaults, configs, disco
               primary
               label='Check'
               disabled={nextShouldBeDisabled()}
-              onClick={() => testSources('sources', 'sourceSelectionStage', 'sourceSelectionStage', discoveryType)} />
+              onClick={() => testSources('sources', 'sourceSelectionStage', 'discoveryStage', discoveryType)} />
           </ActionGroup>
         </div>
       </NavPanes>

--- a/ui/src/main/webapp/wizards/sources/styles.less
+++ b/ui/src/main/webapp/wizards/sources/styles.less
@@ -16,21 +16,20 @@
 
 .navButtonStyles {
   opacity: 0.5;
-  background: #fff;
+  filter: invert(0%);
   width: 10%;
   transition: background-color 0.2s ease;
 }
 
 .navButtonStylesDisabled {
-  opacity: 0.2;
-  background: #fff;
+  opacity: 0.1;
   width: 10%;
 }
 
 
 .navButtonStyles:hover {
   opacity: 1.0;
-  background: #eee;
+  filter: invert(10%);
   transition: all 0.2s ease;
   cursor: pointer;
 }
@@ -74,16 +73,12 @@
   line-height: 0;
 }
 
-.sideLines:after {
-  content: "";
+.horizontalSideLines {
   width: 100%;
-  background-color: transparent;
   display: block;
   height: 1px;
-  border-top: 1px solid #e7e7e7;
   position: absolute;
   top: 50%;
-  margin-top: -1px;
   z-index: 1;
 }
 

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1292,7 +1292,7 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-color-convert@^1.3.0:
+color-convert@^1.3.0, color-convert@^1.8.2:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
@@ -1315,6 +1315,13 @@ color-string@^0.3.0:
   dependencies:
     color-name "^1.0.0"
 
+color-string@^1.4.0:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.2.tgz#26e45814bc3c9a7cbd6751648a41434514a773a9"
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
 color@^0.11.0:
   version "0.11.4"
   resolved "https://registry.yarnpkg.com/color/-/color-0.11.4.tgz#6d7b5c74fb65e841cd48792ad1ed5e07b904d764"
@@ -1322,6 +1329,13 @@ color@^0.11.0:
     clone "^1.0.2"
     color-convert "^1.3.0"
     color-string "^0.3.0"
+
+color@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/color/-/color-1.0.3.tgz#e48e832d85f14ef694fb468811c2d5cfe729b55d"
+  dependencies:
+    color-convert "^1.8.2"
+    color-string "^1.4.0"
 
 colormin@^1.0.5:
   version "1.1.2"
@@ -2867,6 +2881,10 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
 
+is-arrayish@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.1.tgz#c2dfc386abaa0c3e33c48db3fe87059e69065efd"
+
 is-binary-path@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
@@ -3427,7 +3445,7 @@ lodash.words@^3.0.0:
   dependencies:
     lodash._root "^3.0.0"
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
+lodash@^4.0.0, lodash@^4.0.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -3466,6 +3484,10 @@ macaddress@^0.2.8:
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
+
+material-colors@^1.2.1:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.5.tgz#5292593e6754cb1bcc2b98030e4e0d6a3afc9ea1"
 
 material-ui@^0.16.7:
   version "0.16.7"
@@ -4481,6 +4503,15 @@ react-base16-styling@^0.4.1:
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
 
+react-color@^2.11.4:
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/react-color/-/react-color-2.11.4.tgz#43f64630e5d47a243f6bd35300224c9c69c73921"
+  dependencies:
+    lodash "^4.0.1"
+    material-colors "^1.2.1"
+    reactcss "^1.2.0"
+    tinycolor2 "^1.1.2"
+
 react-deep-force-update@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-2.0.1.tgz#4f7f6c12c3e7de42f345992a3c518236fa1ecad3"
@@ -4570,6 +4601,12 @@ react@^15.1.0:
     fbjs "^0.8.4"
     loose-envify "^1.1.0"
     object-assign "^4.1.0"
+
+reactcss@^1.2.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/reactcss/-/reactcss-1.2.2.tgz#41b0ef43e01d54880357c34b11ac1531209350ef"
+  dependencies:
+    lodash "^4.0.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -5029,6 +5066,12 @@ simple-assign@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/simple-assign/-/simple-assign-0.1.0.tgz#17fd3066a5f3d7738f50321bb0f14ca281cc4baa"
 
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  dependencies:
+    is-arrayish "^0.3.1"
+
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
@@ -5382,6 +5425,10 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
     setimmediate "^1.0.4"
+
+tinycolor2@^1.1.2:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
 - Existing components have been updated to use Material UI's
   theming API
 - The current theme can now be dynamically modified using the
   right-hand panel
 - Themes cannot currently be permanently saved to the backend
 - Several presets have been added as an example:
   - Admin: Matches the existing Admin UI color scheme
   - Material: Default Material UI color scheme
   - Dark: Slightly modified Material UI Dark theme
   - Parrett: Dark theme utilizing a warm, autumnal color palette
   - Solarized Dark: Dark theme using the Solarized color scheme

#### What does this PR do?
This PR adds a right-hand panel to the admin beta page that opens a live-edit theming panel. There are some presets included. When being rendered in the Admin UI, a matching Admin color scheme is applied and the theme editor is hidden.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @djblue @tbatie @coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)
When in the admin ui iframe, make sure that the admin color scheme is used, the corners are rounded, and the palette icon is not visible. When in dev mode, `npm start`, make sure that the colors can modified and the correct components are updated in real time.

#### Screenshots (if appropriate)
Palette Icon:
![screen shot 2017-03-27 at 13 21 02](https://cloud.githubusercontent.com/assets/12499654/24376385/932a9142-12f0-11e7-9147-69f3e928a0fb.png)

Theme Editor (fully minimized):
![screen shot 2017-03-27 at 13 21 11](https://cloud.githubusercontent.com/assets/12499654/24376383/8ef9eef6-12f0-11e7-8d4c-cd8d2134e04b.png)

Theme Editor (2 color pickers expanded)L
![screen shot 2017-03-27 at 13 22 08](https://cloud.githubusercontent.com/assets/12499654/24376410/a5f52b34-12f0-11e7-9b75-7cb9cd396a3a.png)

Admin UI iframe:
![screen shot 2017-03-27 at 13 22 20](https://cloud.githubusercontent.com/assets/12499654/24376431/b30d21e6-12f0-11e7-9be8-f6284e57b420.png)


