### PR TITLE
DDF-2773: Fixed FullScreen Backdrop Height

### DIFF
--- a/ui/src/main/webapp/lib/components/Backdrop.js
+++ b/ui/src/main/webapp/lib/components/Backdrop.js
@@ -8,13 +8,14 @@ const isInIframe = () => {
 
 let BackdropView = ({ muiTheme, children, ...rest }) => {
   let fixed = {
-    backgroundColor: muiTheme.palette.backdropColor,
-    height: '100vh'
+    backgroundColor: muiTheme.palette.backdropColor
   }
 
   if (isInIframe()) {
     fixed.borderRadius = '4px'
     fixed.height = '100%'
+  } else {
+    fixed.minHeight = '100vh'
   }
 
   return (


### PR DESCRIPTION
#### What does this PR do?
Very small change - fixes backdrop height in full-screen view. Full screen needed min-height, not just height.

#### Who is reviewing it?
@djblue @coyotesqrl 

Does not extend past bottom in Admin UI:
![screen shot 2017-03-30 at 09 35 43 1](https://cloud.githubusercontent.com/assets/12499654/24515446/8319f28c-152c-11e7-91cb-1b6c23d13903.png)


Extends all the way to bottom of elements in full-screen:
![screen shot 2017-03-30 at 09 36 03](https://cloud.githubusercontent.com/assets/12499654/24515459/8f495e1c-152c-11e7-95dc-617bdf9d1479.png)
