### PR TITLE
DDF-2773: Modal only shows when not in iFrame

### DIFF
--- a/ui/src/main/webapp/lib/system-usage/Modal.js
+++ b/ui/src/main/webapp/lib/system-usage/Modal.js
@@ -7,8 +7,12 @@ import { getSystemUsageProperties, getSystemUsageAccepted } from './reducer'
 import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
 
+const isInIframe = () => {
+  return window !== window.top
+}
+
 let Modal = ({ settings, fetchSystemUsageProperties, getSystemUsageAccepted, acceptSystemUsage }) => {
-  if (settings && settings.systemUsageEnabled) {
+  if (settings && settings.systemUsageEnabled && !isInIframe()) {
     const acceptButton = (
       <FlatButton
         label='OK'


### PR DESCRIPTION
#### What does this PR do?
System Usage modal only shows up when not iframe'd. The admin UI should display the modal already, so a second modal is unnecessary.

#### Who is reviewing it?
@coyotesqrl @tbatie 