### PR TITLE
DDF-2773 Supports iframeresizer in either of its two source locations

### DIFF
--- a/ui/src/main/resources/index.html
+++ b/ui/src/main/resources/index.html
@@ -54,5 +54,6 @@
     </div>
     <script type="text/javascript" src="bundle.js"></script>
     <script type="text/javascript" src="/admin/iframe-resizer/2.6.2/js/iframeResizer.contentWindow.min.js"></script>
+    <script type="text/javascript" src="/admin/lib/iframe-resizer/js/iframeResizer.contentWindow.min.js"></script>
   </body>
 </html>


### PR DESCRIPTION
#### What does this PR do?
DDF master and DDF 2.10.x have different paths to the frameresizer script; this allows for deployment to either version.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@djblue @garrettfreibott 

#### How should this be tested? (List steps with links to updated documentation)
Deploy to DDF 2.10.x and DDF 2.11.x; ensure that the iframed console appears and scrolls correctly.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
