### PR TITLE
DDF-2773: Removes react-color from prod & optimizes dev import

### DIFF
--- a/ui/src/main/webapp/lib/admin-app-bar/index.js
+++ b/ui/src/main/webapp/lib/admin-app-bar/index.js
@@ -10,7 +10,15 @@ import AppBar from 'material-ui/AppBar'
 import IconButton from 'material-ui/IconButton'
 import Drawer from 'material-ui/Drawer'
 
-import AdminPalette from 'react-swatch/admin-palette'
+let AdminPalette
+
+if (process.env.NODE_ENV === 'production') {
+  AdminPalette = () => null
+}
+
+if (process.env.NODE_ENV !== 'production') {
+  AdminPalette = require('react-swatch/admin-palette').default
+}
 
 import { updateThemeColor, setThemePreset } from './actions'
 import { getTheme } from './reducer'

--- a/ui/src/main/webapp/lib/react-swatch/index.js
+++ b/ui/src/main/webapp/lib/react-swatch/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Card, CardHeader, CardText } from 'material-ui/Card'
-import { ChromePicker } from 'react-color'
+import ChromePicker from 'react-color/lib/components/chrome/Chrome'
 import { getReadableTextColor } from './color-utils'
 import Collapse from 'material-ui/svg-icons/navigation/expand-less'
 import Expand from 'material-ui/svg-icons/navigation/expand-more'


### PR DESCRIPTION
#### What does this PR do?
Removes react-color from the production build and imports less of react-color in dev-mode.

#### Who is reviewing it)?
@tbatie 
@djblue 
@peterhuffer 