### PR TITLE
DDF-2773 Resolve validation issue with property paths when reading configurations

### DIFF
--- a/api/src/main/java/org/codice/ddf/admin/api/services/LdapClaimsHandlerServiceProperties.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/services/LdapClaimsHandlerServiceProperties.java
@@ -21,6 +21,7 @@ import static org.codice.ddf.admin.api.validation.LdapValidationUtils.ATTRIBUTE_
 import static org.codice.ddf.admin.api.validation.ValidationUtils.SERVICE_PID_KEY;
 
 import java.net.URI;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -92,8 +93,13 @@ public class LdapClaimsHandlerServiceProperties {
         config.attributeMappingsPath(attributeMappingsPath);
 
         if (StringUtils.isNotEmpty(attributeMappingsPath)) {
+            Path ddfHome = Paths.get(System.getProperty("ddf.home"));
+            Path mappingPath = Paths.get(attributeMappingsPath);
+            if (!mappingPath.startsWith(ddfHome)) {
+                mappingPath = ddfHome.resolve(mappingPath);
+            }
             Map<String, String> attributeMappings = new HashMap<>(configurator.getProperties(
-                    Paths.get(attributeMappingsPath)));
+                    mappingPath));
             config.attributeMappings(attributeMappings);
         }
         config.ldapUseCase(ATTRIBUTE_STORE);

--- a/api/src/test/groovy/org/codice/ddf/admin/api/services/LdapClaimsHandlerServicePropertiesTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/services/LdapClaimsHandlerServicePropertiesTest.groovy
@@ -17,11 +17,15 @@ import org.codice.ddf.admin.api.config.ldap.LdapConfiguration
 import org.codice.ddf.admin.api.validation.LdapValidationUtils
 import org.codice.ddf.admin.api.validation.ValidationUtils
 import org.codice.ddf.admin.configurator.Configurator
+import spock.lang.Shared
 import spock.lang.Specification
 
+import java.nio.file.Files
 import java.nio.file.Paths
 
 class LdapClaimsHandlerServicePropertiesTest extends Specification {
+    @Shared
+    String originalDdfHome
 
     LdapClaimsHandlerServiceProperties ldapClaimsHandlerServiceProperties
 
@@ -58,11 +62,26 @@ class LdapClaimsHandlerServicePropertiesTest extends Specification {
     static final TEST_PROPERTY_FILE_LOCATION = "src/test/resources/testLdap.properties"
 
     def setup() {
+        originalDdfHome = System.getProperty('ddf.home')
+        def tempDir = Files.createTempDirectory("testroot")
+
+        def tempPath = tempDir.toString()
+        System.setProperty('ddf.home', tempPath)
+
         ldapClaimsHandlerServiceProperties = new LdapClaimsHandlerServiceProperties()
         configurator = Mock(Configurator)
         def props = new Properties()
         props.load(new FileReader(Paths.get(TEST_PROPERTY_FILE_LOCATION).toFile()))
-        configurator.getProperties(Paths.get(TEST_PROPERTY_FILE_LOCATION)) >> props
+
+        configurator.getProperties(Paths.get(tempPath, TEST_PROPERTY_FILE_LOCATION)) >> props
+    }
+
+    void cleanup() {
+        if (originalDdfHome != null) {
+            System.setProperty('ddf.home', originalDdfHome)
+        } else {
+            System.clearProperty('ddf.home')
+        }
     }
 
     def 'test ldapClaimsHandlerServiceToLdapConfig(Map<String, Object>) all present values success'() {


### PR DESCRIPTION
#### What does this PR do?

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@adimka @tbatie @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)
Deploy and create an LDAP config. It should save and any saved configurations should be displayed on the home page.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
