### PR TITLE
DDF-2773: Created ArtifactSizeEnforcerRule to enforce artifact sizes

### DIFF
--- a/artifact-size-enforcer/pom.xml
+++ b/artifact-size-enforcer/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+/**
+ * Copyright (c) Codice Foundation
+ *
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General Public License as published by the Free Software Foundation, either
+ * version 3 of the License, or any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Lesser General Public License for more details. A copy of the GNU Lesser General Public License is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ *
+ **/
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>admin</artifactId>
+        <groupId>org.codice.ddf.admin.beta</groupId>
+        <version>0.1.3-SNAPSHOT</version>
+    </parent>
+    <artifactId>artifact-size-enforcer</artifactId>
+    <name>DDF Admin (Beta) :: Artifact Size Enforcer</name>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.maven.enforcer</groupId>
+            <artifactId>enforcer-api</artifactId>
+            <version>1.4.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <version>1.4.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.80</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.75</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.65</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/artifact-size-enforcer/src/main/java/org/codice/ddf/admin/beta/enforcer/ArtifactSizeEnforcerRule.java
+++ b/artifact-size-enforcer/src/main/java/org/codice/ddf/admin/beta/enforcer/ArtifactSizeEnforcerRule.java
@@ -1,0 +1,197 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.beta.enforcer;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRule;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.util.StringUtils;
+
+/**
+ * When the ArtifactSizeEnforceRule is active, it will look up the packaging type and enforce a maximum artifact size.
+ * If the packing type is unknown to the rule, enforcement will be skipped. The only currently supported packing types are bundle and jar.
+ *
+ * The following arguments can be specified to the ArtifactSizeEnforcerRule:
+ *
+ * maxArtifactSize - If the specified artifact is larger than this maxArtifactSize then an exception will be thrown. The unit of this argument should end with `_B` (Bytes), `_KB` (Kilobytes), or `_MB` (MegaBytes). By default, maxArtifactSize is set to 1_MB.
+ * artifactLocation - A path to the file to be checked. If a artifactLocation is not looked up, a default artifact will attempt to be found using the project version, packaging and artifactId.
+ * skip - The ArtifactSizeEnforceRule will not run.
+ */
+public class ArtifactSizeEnforcerRule implements EnforcerRule {
+
+    public static final String PROJECT_PACKAGING_PROP = "${project.packaging}";
+    public static final String PROJECT_ARTIFACT_ID_PROP = "${project.artifactId}";
+    public static final String PROJECT_VERSION_PROP = "${project.version}";
+    public static final String PROJECT_BUILD_DIR_PROP = "${project.build.directory}";
+
+    public static final String DEFAULT_MAX_ARTIFACT_SIZE = "1_MB";
+    public static final String BYTES = "_B";
+    public static final String MEGA_BYTES = "_MB";
+    public static final String KILO_BYTES = "_KB";
+
+    public static final String JAR = "jar";
+    public static final String BUNDLE = "bundle";
+    public static final List<String> SUPPORTED_PACKAGE_TYPES = Arrays.asList(JAR, BUNDLE);
+
+    public static final String MAX_FILE_SIZE_EXCEEDED_MSG = "The specified artifact is larger than the set maximum artifact size. %n%n\tArtifact: %s%n\tArtifact Size: %d Bytes%n\tMax Artifact Size: %d Bytes%n."
+            + " Either reduce the artifact size (highly recommended) or set the maxArtifactSize property in the enforcer-plugin to a higher value.";
+
+    public static final String DEFAULT_ARTIFACT_INFO_MSG = "Using the following parameters to find artifact: %n\tArtifactId: %s%n\tVersion: %s%n\tPackaging: %s%n\tArtifact Directory: %s";
+
+    public static final String UNKNOWN_ARTIFACT_SIZE_UNIT_MSG = "Unknown artifact size unit. The artifactSize property must end with either: %n\t%s: Bytes%n\t%s: KiloBytes%n\t%s: MegaBytes";
+
+    //Rule arguments. These properties are set through reflection when running as a rule via the enforcer-plugin, not through setters.
+    protected String maxArtifactSize;
+    protected String artifactLocation;
+    protected boolean skip;
+
+    @Override
+    public void execute(EnforcerRuleHelper helper) throws EnforcerRuleException {
+        if (skip) {
+            return;
+        }
+
+        String packaging = getPackaging(helper);
+        if (!SUPPORTED_PACKAGE_TYPES.contains(packaging)) {
+            helper.getLog().info(String.format("Unsupported package type %s. Skipping artifact size enforcement.", packaging));
+            return;
+        }
+
+        String artifactPath = getArtifactPath(helper);
+        long maxArtifactSizeBytes = maxArtifactSizeToBytes(helper);
+        long artifactSize = getArtifact(artifactPath).length();
+
+        if (artifactSize >= maxArtifactSizeBytes) {
+            throw new EnforcerRuleException(String.format(
+                    MAX_FILE_SIZE_EXCEEDED_MSG,
+                    artifactPath,
+                    artifactSize,
+                    maxArtifactSizeBytes));
+        }
+    }
+
+    private String getArtifactPath(EnforcerRuleHelper helper) throws EnforcerRuleException {
+        String convertedArtifactLocation = artifactLocation;
+
+        if (StringUtils.isNotEmpty(convertedArtifactLocation)) {
+            helper.getLog().info(String.format("Using specified artifactLocation %s",
+                    convertedArtifactLocation));
+        } else {
+            try {
+                helper.getLog().info(
+                        "artifactLocation property not specified. Looking up artifact using maven properties.");
+
+                String artifactId = (String) helper.evaluate(PROJECT_ARTIFACT_ID_PROP);
+                String version = (String) helper.evaluate(PROJECT_VERSION_PROP);
+                String packaging = getPackaging(helper);
+                String buildDir = (String) helper.evaluate(PROJECT_BUILD_DIR_PROP);
+                helper.getLog().debug(String.format(DEFAULT_ARTIFACT_INFO_MSG,
+                        artifactId,
+                        version,
+                        packaging,
+                        buildDir));
+
+                convertedArtifactLocation =
+                        buildDir + File.separator + artifactId + "-" + version + "." + packaging;
+                helper.getLog().debug(String.format("Complete generated artifact path: %s",
+                        convertedArtifactLocation));
+            } catch (ExpressionEvaluationException e) {
+                throw new EnforcerRuleException(e.getMessage());
+            }
+        }
+
+        return convertedArtifactLocation;
+    }
+
+    private File getArtifact(String artifactPath) throws EnforcerRuleException {
+        File artifact = new File(artifactPath);
+        if (!artifact.exists()) {
+            throw new EnforcerRuleException(String.format(
+                    "No file found for artifact location: %s",  artifactPath));
+        }
+
+        return artifact;
+    }
+
+    protected String getPackaging(EnforcerRuleHelper helper) throws EnforcerRuleException {
+        String packaging;
+        try {
+            packaging = (String) helper.evaluate(PROJECT_PACKAGING_PROP);
+        } catch (ExpressionEvaluationException e) {
+            throw new EnforcerRuleException(e.getMessage());
+        }
+
+        switch (packaging) {
+        case JAR:
+            return JAR;
+        case BUNDLE:
+            return JAR;
+        default:
+            return packaging;
+        }
+    }
+
+    long maxArtifactSizeToBytes(EnforcerRuleHelper helper) throws EnforcerRuleException {
+        String convertArtifactSize = maxArtifactSize;
+        if (StringUtils.isEmpty(convertArtifactSize)) {
+            helper.getLog().info(String.format(
+                    "maxArtifactSize property not specified. Using default maxArtifactSize size: %s",
+                    DEFAULT_MAX_ARTIFACT_SIZE));
+            convertArtifactSize = DEFAULT_MAX_ARTIFACT_SIZE;
+        }
+
+        if (convertArtifactSize.endsWith(BYTES)) {
+            return Long.parseLong(convertArtifactSize.split(BYTES)[0]);
+        } else if (convertArtifactSize.endsWith(KILO_BYTES)) {
+            return (long) (Double.parseDouble(convertArtifactSize.split(KILO_BYTES)[0]) * 1024);
+        } else if (convertArtifactSize.endsWith(MEGA_BYTES)) {
+            return (long) (Double.parseDouble(convertArtifactSize.split(MEGA_BYTES)[0]) * 1024 * 1024);
+        } else {
+            throw new EnforcerRuleException(String.format(UNKNOWN_ARTIFACT_SIZE_UNIT_MSG,
+                    BYTES,
+                    KILO_BYTES,
+                    MEGA_BYTES));
+        }
+    }
+
+    @Override
+    public boolean isCacheable() {
+        return false;
+    }
+
+    @Override
+    public boolean isResultValid(EnforcerRule enforcerRule) {
+        return false;
+    }
+
+    @Override
+    public String getCacheId() {
+        return null;
+    }
+
+    public ArtifactSizeEnforcerRule setMaxArtifactSize(String maxArtifactSize) {
+        this.maxArtifactSize = maxArtifactSize;
+        return this;
+    }
+
+    public ArtifactSizeEnforcerRule setArtifactLocation(String artifactLocation) {
+        this.artifactLocation = artifactLocation;
+        return this;
+    }
+}

--- a/artifact-size-enforcer/src/test/java/org/codice/ddf/admin/beta/enforcer/ArtifactSizeEnforcerRuleTest.java
+++ b/artifact-size-enforcer/src/test/java/org/codice/ddf/admin/beta/enforcer/ArtifactSizeEnforcerRuleTest.java
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ */
+package org.codice.ddf.admin.beta.enforcer;
+
+import static org.codice.ddf.admin.beta.enforcer.ArtifactSizeEnforcerRule.PROJECT_ARTIFACT_ID_PROP;
+import static org.codice.ddf.admin.beta.enforcer.ArtifactSizeEnforcerRule.PROJECT_BUILD_DIR_PROP;
+import static org.codice.ddf.admin.beta.enforcer.ArtifactSizeEnforcerRule.PROJECT_PACKAGING_PROP;
+import static org.codice.ddf.admin.beta.enforcer.ArtifactSizeEnforcerRule.PROJECT_VERSION_PROP;
+import static org.codice.ddf.admin.beta.enforcer.ArtifactSizeEnforcerRule.SUPPORTED_PACKAGE_TYPES;
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.fail;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.maven.enforcer.rule.api.EnforcerRuleException;
+import org.apache.maven.enforcer.rule.api.EnforcerRuleHelper;
+import org.apache.maven.plugin.logging.Log;
+import org.apache.maven.plugin.logging.SystemStreamLog;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.component.configurator.expression.ExpressionEvaluationException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class ArtifactSizeEnforcerRuleTest {
+
+    private static final String SAMPLE_ARTIFACT_ID = "SampleArtifactId";
+    private static final String SAMPLE_VERSION = "SampleVersion";
+    private static final String SAMPLE_ARTIFACT_FILE_NAME = SAMPLE_ARTIFACT_ID + "-" + SAMPLE_VERSION + ".jar";
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    private File sampleBuildDir;
+    private MockEnforcementRuleHelper defaultMockhelper;
+
+    @Before
+    public void before() throws IOException {
+        sampleBuildDir = tempFolder.getRoot();
+        defaultMockhelper = new MockEnforcementRuleHelper().artifactId(SAMPLE_ARTIFACT_ID)
+                .packaging(ArtifactSizeEnforcerRule.JAR)
+                .version(SAMPLE_VERSION)
+                .buildDir(sampleBuildDir.getPath());
+    }
+    @Test
+    public void unknownPackaging() {
+        ArtifactSizeEnforcerRule enforcer = new ArtifactSizeEnforcerRule();
+        defaultMockhelper.packaging("UnknownPackageType");
+        try {
+            String packaging = enforcer.getPackaging(defaultMockhelper);
+            assertTrue(!SUPPORTED_PACKAGE_TYPES.contains(packaging));
+        } catch (EnforcerRuleException e) {
+            fail("ArtifactSizerEnforcerRule was unable to skip an unknown packing type.");
+        }
+    }
+
+    @Test
+    public void specifiedArtifactExists() throws IOException {
+        String sampleArtifactPath = tempFolder.newFile("SampleArtifact.jar").getPath();
+        ArtifactSizeEnforcerRule enforcer = new ArtifactSizeEnforcerRule().setArtifactLocation(sampleArtifactPath);
+        try {
+            enforcer.execute(defaultMockhelper);
+        } catch (EnforcerRuleException e) {
+            fail("Unable to find specified artifact.");
+        }
+    }
+
+    @Test(expected=EnforcerRuleException.class)
+    public void specifiedArtifactDoesNotExist() throws EnforcerRuleException {
+        ArtifactSizeEnforcerRule enforcer = new ArtifactSizeEnforcerRule().setArtifactLocation("ArtifactDoesNotExist.jar");
+        enforcer.execute(defaultMockhelper);
+    }
+
+    @Test
+    public void successfullyDiscoverArtifact() throws IOException {
+        tempFolder.newFile(SAMPLE_ARTIFACT_FILE_NAME);
+        ArtifactSizeEnforcerRule enforcer =  new ArtifactSizeEnforcerRule();
+        try {
+            enforcer.execute(defaultMockhelper);
+        } catch (EnforcerRuleException e) {
+            fail("Failed to discover artifact.");
+        }
+    }
+
+    @Test(expected=EnforcerRuleException.class)
+    public void failToDiscoverArtifact() throws EnforcerRuleException {
+        ArtifactSizeEnforcerRule enforcer =  new ArtifactSizeEnforcerRule();
+        enforcer.execute(defaultMockhelper);
+    }
+
+    @Test(expected=EnforcerRuleException.class)
+    public void artifactSizeAboveMax() throws EnforcerRuleException, IOException {
+        tempFolder.newFile(SAMPLE_ARTIFACT_FILE_NAME);
+        ArtifactSizeEnforcerRule enforcer = new ArtifactSizeEnforcerRule().setMaxArtifactSize("-1_MB");
+        enforcer.execute(defaultMockhelper);
+    }
+
+    @Test (expected=EnforcerRuleException.class)
+    public void invalidArtifactSizeUnit() throws IOException, EnforcerRuleException {
+        tempFolder.newFile(SAMPLE_ARTIFACT_FILE_NAME);
+        ArtifactSizeEnforcerRule enforcer = new ArtifactSizeEnforcerRule();
+        enforcer.setMaxArtifactSize("INVALID_UNIT");
+        enforcer.execute(defaultMockhelper);
+    }
+    @Test
+    public void testByteConversion() throws EnforcerRuleException {
+        ArtifactSizeEnforcerRule enforcer =  new ArtifactSizeEnforcerRule();
+        enforcer.setMaxArtifactSize("1024_B");
+        assertEquals(enforcer.maxArtifactSizeToBytes(defaultMockhelper), 1024);
+
+        enforcer.setMaxArtifactSize("1_KB");
+        assertEquals(enforcer.maxArtifactSizeToBytes(defaultMockhelper), 1024);
+
+        enforcer.setMaxArtifactSize("1_MB");
+        assertEquals(enforcer.maxArtifactSizeToBytes(defaultMockhelper), 1024 * 1024);
+    }
+
+    public class MockEnforcementRuleHelper implements EnforcerRuleHelper {
+
+        private String packaging;
+        private String artifactId;
+        private String version;
+        private String buildDir;
+
+        @Override
+        public Log getLog() {
+            return new SystemStreamLog();
+        }
+
+        @Override
+        public Object getComponent(Class clazz) throws ComponentLookupException {
+            return null;
+        }
+
+        @Override
+        public Object getComponent(String componentKey) throws ComponentLookupException {
+            return null;
+        }
+
+        @Override
+        public Object getComponent(String role, String roleHint) throws ComponentLookupException {
+            return null;
+        }
+
+        @Override
+        public Map getComponentMap(String role) throws ComponentLookupException {
+            return null;
+        }
+
+        @Override
+        public List getComponentList(String role) throws ComponentLookupException {
+            return null;
+        }
+
+        @Override
+        public PlexusContainer getContainer() {
+            return null;
+        }
+
+        @Override
+        public Object evaluate(String s) throws ExpressionEvaluationException {
+            switch (s) {
+            case PROJECT_PACKAGING_PROP:
+                return packaging;
+            case PROJECT_ARTIFACT_ID_PROP:
+                return artifactId;
+            case PROJECT_VERSION_PROP:
+                return version;
+            case PROJECT_BUILD_DIR_PROP:
+                return buildDir;
+            default:
+                fail("Unknown evaluate arg: " + s);
+                return null;
+            }
+        }
+
+        @Override
+        public File alignToBaseDirectory(File file) {
+            return null;
+        }
+
+        public MockEnforcementRuleHelper packaging(String packaging) {
+            this.packaging = packaging;
+            return this;
+        }
+
+        public MockEnforcementRuleHelper artifactId(String artifactId) {
+            this.artifactId = artifactId;
+            return this;
+        }
+
+        public MockEnforcementRuleHelper version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        public MockEnforcementRuleHelper buildDir(String buildDir) {
+            this.buildDir = buildDir;
+            return this;
+
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -385,5 +385,6 @@
         <module>app</module>
         <module>commons</module>
         <module>admin-module</module>
+        <module>artifact-size-enforcer</module>
     </modules>
 </project>

--- a/query/graphql-dependencies/pom.xml
+++ b/query/graphql-dependencies/pom.xml
@@ -21,6 +21,7 @@
         <groupId>org.codice.ddf.admin.beta</groupId>
         <version>0.1.3-SNAPSHOT</version>
     </parent>
+    <name>DDF :: Admin (Beta) :: GraphQL Dependencies</name>
     <artifactId>graphql-dependencies</artifactId>
 
     <dependencies>
@@ -129,7 +130,9 @@
                             <filters>
                                 <filter>
                                     <artifact>com.graphql-java:graphql-java-servlet</artifact>
-                                    <includes>graphql/servlet/**</includes>
+                                    <includes>
+                                        <include>graphql/servlet/**</include>
+                                    </includes>
                                     <excludes>
                                         <exclude>graphql/servlet/GraphQLServlet.*</exclude>
                                         <exclude>graphql/servlet/OsgiGraphQLServlet.*</exclude>

--- a/query/graphql/pom.xml
+++ b/query/graphql/pom.xml
@@ -115,6 +115,34 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codice.ddf.admin.beta</groupId>
+                        <artifactId>artifact-size-enforcer</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>check-artifact-size</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <ArtifactSizeEnforcerRule implementation="org.codice.ddf.admin.beta.enforcer.ArtifactSizeEnforcerRule">
+                                    <maxArtifactSize>4.7_MB</maxArtifactSize>
+                                </ArtifactSizeEnforcerRule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <executions>

--- a/query/pom.xml
+++ b/query/pom.xml
@@ -54,4 +54,35 @@
             <version>2.6</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>1.4.1</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.codice.ddf.admin.beta</groupId>
+                        <artifactId>artifact-size-enforcer</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>check-artifact-size</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <ArtifactSizeEnforcerRule implementation="org.codice.ddf.admin.beta.enforcer.ArtifactSizeEnforcerRule" />
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
#### What does this PR do?
When the ArtifactSizeEnforceRule is active, it will look up the packaging type and enforce a maximum artifact size.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @djblue @adimka @peterhuffer @garrettfreibott 

#### How should this be tested? (List steps with links to updated documentation)
Perform a clean install of the entire repo. Ensure any bundles are being enforced and any other types are not being enforced.