### PR TITLE
DDF-2825 Extracts configuration reader functionality from Configurator interface

### DIFF
--- a/api/src/main/java/org/codice/ddf/admin/api/services/LdapClaimsHandlerServiceProperties.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/services/LdapClaimsHandlerServiceProperties.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.admin.api.config.ldap.LdapConfiguration;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 
 public class LdapClaimsHandlerServiceProperties {
 
@@ -64,7 +64,7 @@ public class LdapClaimsHandlerServiceProperties {
     // ---
 
     public static LdapConfiguration ldapClaimsHandlerServiceToLdapConfig(Map<String, Object> props,
-            Configurator configurator) {
+            ConfigReader configReader) {
         LdapConfiguration config = new LdapConfiguration();
         config.servicePid(
                 props.get(SERVICE_PID_KEY) == null ? null : (String) props.get(SERVICE_PID_KEY));
@@ -98,7 +98,7 @@ public class LdapClaimsHandlerServiceProperties {
             if (!mappingPath.startsWith(ddfHome)) {
                 mappingPath = ddfHome.resolve(mappingPath);
             }
-            Map<String, String> attributeMappings = new HashMap<>(configurator.getProperties(
+            Map<String, String> attributeMappings = new HashMap<>(configReader.getProperties(
                     mappingPath));
             config.attributeMappings(attributeMappings);
         }

--- a/api/src/main/java/org/codice/ddf/admin/api/services/PolicyManagerServiceProperties.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/services/PolicyManagerServiceProperties.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.collections.ListUtils;
 import org.codice.ddf.admin.api.config.context.ContextPolicyBin;
 import org.codice.ddf.admin.api.config.context.ContextPolicyConfiguration;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.security.policy.context.ContextPolicy;
 import org.codice.ddf.security.policy.context.ContextPolicyManager;
 import org.codice.ddf.security.policy.context.impl.PolicyManager;
@@ -40,8 +40,8 @@ public class PolicyManagerServiceProperties {
     public static final String IDP_SERVER_BUNDLE_NAME = "security-idp-server";
 
     public static ContextPolicyConfiguration contextPolicyServiceToContextPolicyConfig(
-            Configurator configurator) {
-        ContextPolicyManager ref = configurator.getServiceReference(ContextPolicyManager.class);
+            ConfigReader configReader) {
+        ContextPolicyManager ref = configReader.getServiceReference(ContextPolicyManager.class);
         PolicyManager policyManager = ((PolicyManager) ref);
         return new ContextPolicyConfiguration().contextPolicyBins(policyManagerSettingsToBins(
                 policyManager))

--- a/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
+++ b/api/src/main/java/org/codice/ddf/admin/api/validation/SourceValidationUtils.java
@@ -35,7 +35,7 @@ import javax.annotation.Nonnull;
 import org.apache.commons.lang.StringUtils;
 import org.codice.ddf.admin.api.config.sources.SourceConfiguration;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,8 +46,9 @@ public class SourceValidationUtils {
             List<String> pidList, String configId) {
         List<ConfigurationMessage> errors = validateString(factoryPid, configId);
         if (errors.isEmpty() && !pidList.contains(factoryPid)) {
-            errors.add(createInvalidFieldMsg("Unknown factory PID type <" + factoryPid + ">."
-                    + "FactoryPid must be one of: " + String.join(",", pidList), configId));
+            errors.add(createInvalidFieldMsg(
+                    "Unknown factory PID type <" + factoryPid + ">." + "FactoryPid must be one of: "
+                            + String.join(",", pidList), configId));
         }
         return errors;
     }
@@ -71,19 +72,19 @@ public class SourceValidationUtils {
      *
      * @param sourceName   a non null name to validate
      * @param factoryPids  a list of non null factory pids of the configuration to validate names against
-     * @param configurator configurator to fetch configurations for the given {@code factoryPids}
+     * @param configReader configReader to fetch configurations for the given {@code factoryPids}
      * @return a {@link List} of {@link ConfigurationMessage}s containing failure messages, or empty {@link List}
      * if there are no duplicate source names found
      */
     public List<ConfigurationMessage> validateSourceName(@Nonnull String sourceName,
-            @Nonnull List<String> factoryPids, Configurator configurator) {
+            @Nonnull List<String> factoryPids, ConfigReader configReader) {
         List<ConfigurationMessage> errors = validateString(sourceName, SOURCE_NAME);
-        if(!errors.isEmpty()) {
+        if (!errors.isEmpty()) {
             return errors;
         }
 
         List<Map<String, Map<String, Object>>> configurations = factoryPids.stream()
-                .map(configurator::getManagedServiceConfigs)
+                .map(configReader::getManagedServiceConfigs)
                 .filter(config -> !config.isEmpty())
                 .collect(Collectors.toList());
 
@@ -125,7 +126,8 @@ public class SourceValidationUtils {
         return results;
     }
 
-    public static List<ConfigurationMessage> validateHostnameAndPort(SourceConfiguration configuration) {
+    public static List<ConfigurationMessage> validateHostnameAndPort(
+            SourceConfiguration configuration) {
         List<ConfigurationMessage> validationResults = new ArrayList<>();
         if (configuration.sourceHostName() != null) {
             validationResults.addAll(configuration.validate(Arrays.asList(SOURCE_HOSTNAME, PORT)));
@@ -135,7 +137,8 @@ public class SourceValidationUtils {
         return validationResults;
     }
 
-    public static List<ConfigurationMessage> validateEndpointUrl(SourceConfiguration configuration) {
+    public static List<ConfigurationMessage> validateEndpointUrl(
+            SourceConfiguration configuration) {
         List<ConfigurationMessage> validationResults = new ArrayList<>();
         if (configuration.endpointUrl() != null) {
             validationResults.addAll(configuration.validate(Collections.singletonList(ENDPOINT_URL)));

--- a/api/src/test/groovy/org/codice/ddf/admin/api/services/LdapClaimsHandlerServicePropertiesTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/services/LdapClaimsHandlerServicePropertiesTest.groovy
@@ -16,7 +16,7 @@ package org.codice.ddf.admin.api.services
 import org.codice.ddf.admin.api.config.ldap.LdapConfiguration
 import org.codice.ddf.admin.api.validation.LdapValidationUtils
 import org.codice.ddf.admin.api.validation.ValidationUtils
-import org.codice.ddf.admin.configurator.Configurator
+import org.codice.ddf.admin.configurator.ConfigReader
 import spock.lang.Shared
 import spock.lang.Specification
 
@@ -29,7 +29,7 @@ class LdapClaimsHandlerServicePropertiesTest extends Specification {
 
     LdapClaimsHandlerServiceProperties ldapClaimsHandlerServiceProperties
 
-    Configurator configurator
+    ConfigReader configReader
 
     static final TEST_SERVICE_PID = "someServicePid"
 
@@ -69,11 +69,11 @@ class LdapClaimsHandlerServicePropertiesTest extends Specification {
         System.setProperty('ddf.home', tempPath)
 
         ldapClaimsHandlerServiceProperties = new LdapClaimsHandlerServiceProperties()
-        configurator = Mock(Configurator)
+        configReader = Mock(ConfigReader)
         def props = new Properties()
         props.load(new FileReader(Paths.get(TEST_PROPERTY_FILE_LOCATION).toFile()))
 
-        configurator.getProperties(Paths.get(tempPath, TEST_PROPERTY_FILE_LOCATION)) >> props
+        configReader.getProperties(Paths.get(tempPath, TEST_PROPERTY_FILE_LOCATION)) >> props
     }
 
     void cleanup() {
@@ -102,7 +102,7 @@ class LdapClaimsHandlerServicePropertiesTest extends Specification {
                 .toSpreadMap()
 
         when:
-        LdapConfiguration ldapConfiguration = ldapClaimsHandlerServiceProperties.ldapClaimsHandlerServiceToLdapConfig(properties, configurator)
+        LdapConfiguration ldapConfiguration = ldapClaimsHandlerServiceProperties.ldapClaimsHandlerServiceToLdapConfig(properties, configReader)
 
         then:
         ldapConfiguration.servicePid() == TEST_SERVICE_PID
@@ -142,7 +142,7 @@ class LdapClaimsHandlerServicePropertiesTest extends Specification {
                 .toSpreadMap()
 
         when:
-        LdapConfiguration ldapConfiguration = ldapClaimsHandlerServiceProperties.ldapClaimsHandlerServiceToLdapConfig(properties, configurator)
+        LdapConfiguration ldapConfiguration = ldapClaimsHandlerServiceProperties.ldapClaimsHandlerServiceToLdapConfig(properties, configReader)
 
         then:
         ldapConfiguration.servicePid() == null
@@ -170,7 +170,7 @@ class LdapClaimsHandlerServicePropertiesTest extends Specification {
                 .toSpreadMap()
 
         when:
-        LdapConfiguration ldapConfiguration = ldapClaimsHandlerServiceProperties.ldapClaimsHandlerServiceToLdapConfig(properties, configurator)
+        LdapConfiguration ldapConfiguration = ldapClaimsHandlerServiceProperties.ldapClaimsHandlerServiceToLdapConfig(properties, configReader)
 
         then:
         ldapConfiguration.encryptionMethod() == TEST_URI_SCHEME

--- a/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
+++ b/api/src/test/groovy/org/codice/ddf/admin/api/validation/SourceValidationUtilsTest.groovy
@@ -2,6 +2,7 @@ package org.codice.ddf.admin.api.validation
 
 import org.codice.ddf.admin.api.config.sources.SourceConfiguration
 import org.codice.ddf.admin.api.handler.ConfigurationMessage
+import org.codice.ddf.admin.configurator.ConfigReader
 import org.codice.ddf.admin.configurator.Configurator
 import spock.lang.Specification
 
@@ -20,7 +21,7 @@ class SourceValidationUtilsTest extends Specification {
     def sourceValidationUtils
 
     def setup() {
-        configurator = mockConfigurator(EXISTING_SOURCE_NAME)
+        configurator = mockConfigReader(EXISTING_SOURCE_NAME)
         sourceValidationUtils = new SourceValidationUtils()
     }
 
@@ -56,7 +57,7 @@ class SourceValidationUtilsTest extends Specification {
 
     def 'test validateSourceName(String, String, Configurator) with invalid existing config id property'() {
         when:
-        configurator = mockConfigurator(true)
+        configurator = mockConfigReader(true)
         sourceValidationUtils = new SourceValidationUtils()
         List<ConfigurationMessage> results = sourceValidationUtils.validateSourceName(NEW_SOURCE_NAME, FACTORY_IDS, configurator)
 
@@ -66,8 +67,8 @@ class SourceValidationUtilsTest extends Specification {
         results.get(0).subtype() == ConfigurationMessage.INTERNAL_ERROR
     }
 
-    def mockConfigurator(Object sourceName) {
-        return Mock(Configurator) {
+    def mockConfigReader(Object sourceName) {
+        return Mock(ConfigReader) {
             getManagedServiceConfigs(_ as String) >> ["fid": ["id": sourceName]] >> [:]
         }
     }

--- a/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfigReader.java
+++ b/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfigReader.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.configurator;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Provides reader methods to system configuration items.
+ * <p>
+ * <b> This code is experimental. While this class is functional and tested, it may change or be
+ * removed in a future version of the library. </b>
+ */
+public interface ConfigReader {
+    /**
+     * Determines if the bundle with the given name is started.
+     *
+     * @param bundleSymName the symbolic name of the bundle
+     * @return true if started; else, false
+     */
+    boolean isBundleStarted(String bundleSymName);
+
+    /**
+     * Determines if the feature with the given name is started.
+     *
+     * @param featureName the name of the feature
+     * @return true if started; else, false
+     */
+    boolean isFeatureStarted(String featureName);
+
+    /**
+     * Gets the current key:value pairs set in the given property file.
+     *
+     * @param propFile the property file to query
+     * @return the current set of key:value pairs
+     */
+    Map<String, String> getProperties(Path propFile);
+
+    /**
+     * Gets the current key:value pairs set in the given configuration file.
+     *
+     * @param configPid the configId of the bundle configuration file to query
+     * @return the current set of key:value pairs
+     */
+    Map<String, Object> getConfig(String configPid);
+
+    /**
+     * For the given managed service factory, retrieves the full complement of configuration properties.
+     * <p>
+     * This will get all the key:value pairs for each available configuration.
+     *
+     * @param factoryPid the factoryPid of the service to query
+     * @return the the current sets of key:value pairs, in a map keyed on {@code configId}
+     */
+    Map<String, Map<String, Object>> getManagedServiceConfigs(String factoryPid);
+
+    /**
+     * Retrieves the service reference. The reference should only be used for reading purposes,
+     * any changes should be done through a commit
+     *
+     * @param <S>          Service interface
+     * @param serviceClass - Class of service to retrieve
+     * @return first found service reference of serviceClass
+     * @throws ConfiguratorException if any errors occur
+     */
+    <S> S getServiceReference(Class<S> serviceClass) throws ConfiguratorException;
+}

--- a/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Configurator.java
+++ b/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/Configurator.java
@@ -17,6 +17,12 @@ import java.nio.file.Path;
 import java.util.Map;
 
 /**
+ * Provides pseudo-transactional semantics to system configuration tasks.
+ * <p>
+ * In order to use, invoke the various {@code start}, {@code stop}, {@code create}, {@code delete},
+ * {@code update}, methods in the intended order of operation, then invoke one of the {@code commit}
+ * methods to complete the transaction.
+ * <p>
  * <b> This code is experimental. While this class is functional and tested, it may change or be
  * removed in a future version of the library. </b>
  */
@@ -28,10 +34,9 @@ public interface Configurator {
      * <p>
      * In the case of a successful commit, changes should be logged.
      *
-     * @param auditMessage In the case of a successful commit, the message to pass to a
-     *                     {@code SecurityLogger}
-     * @param auditParams  In the case of a successful commit, the optional parameters to pass to a
-     *                     {@code SecurityLogger} to be interpolated into the message
+     * @param auditMessage In the case of a successful commit, the message to pass to be audited
+     * @param auditParams  In the case of a successful commit, optional parameters to pass to be
+     *                     interpolated into the message
      * @return report of the commit status, whether successful, successfully rolled back, or partially
      * rolled back with errors
      */
@@ -66,14 +71,6 @@ public interface Configurator {
     String stopBundle(String bundleSymName);
 
     /**
-     * Determines if the bundle with the given name is started.
-     *
-     * @param bundleSymName the symbolic name of the bundle
-     * @return true if started; else, false
-     */
-    boolean isBundleStarted(String bundleSymName);
-
-    /**
      * Installs and starts the feature with the given name.
      *
      * @param featureName the name of the feature
@@ -90,14 +87,6 @@ public interface Configurator {
      * final {@link OperationReport}
      */
     String stopFeature(String featureName);
-
-    /**
-     * Determines if the feature with the given name is started.
-     *
-     * @param featureName the name of the feature
-     * @return true if started; else, false
-     */
-    boolean isFeatureStarted(String featureName);
 
     /**
      * Creates a property file in the system with the given set of new key:value pairs.
@@ -133,14 +122,6 @@ public interface Configurator {
     String updatePropertyFile(Path propFile, Map<String, String> properties, boolean keepIgnored);
 
     /**
-     * Gets the current key:value pairs set in the given property file.
-     *
-     * @param propFile the property file to query
-     * @return the current set of key:value pairs
-     */
-    Map<String, String> getProperties(Path propFile);
-
-    /**
      * Updates a bundle configuration file in the system with the given set of new key:value pairs.
      *
      * @param configPid   the configId of the bundle configuration file to update
@@ -153,14 +134,6 @@ public interface Configurator {
      * final {@link OperationReport}
      */
     String updateConfigFile(String configPid, Map<String, Object> configs, boolean keepIgnored);
-
-    /**
-     * Gets the current key:value pairs set in the given configuration file.
-     *
-     * @param configPid the configId of the bundle configuration file to query
-     * @return the current set of key:value pairs
-     */
-    Map<String, Object> getConfig(String configPid);
 
     /**
      * Creates a new managed service for the given factory.
@@ -180,25 +153,4 @@ public interface Configurator {
      * final {@link OperationReport}
      */
     String deleteManagedService(String configPid);
-
-    /**
-     * For the given managed service factory, retrieves the full complement of configuration properties.
-     *
-     * This will get all the key:value pairs for each available configuration.
-     *
-     * @param factoryPid the factoryPid of the service to query
-     * @return the the current sets of key:value pairs, in a map keyed on {@code configId}
-     */
-    Map<String, Map<String, Object>> getManagedServiceConfigs(String factoryPid);
-
-    /**
-     * Retrieves the service reference. The reference should only be used for reading purposes,
-     * any changes should be done through a commit
-     *
-     * @param <S> Service interface
-     * @param serviceClass - Class of service to retrieve
-     * @return first found service reference of serviceClass
-     * @throws ConfiguratorException if any errors occur
-     */
-    <S> S getServiceReference(Class<S> serviceClass) throws ConfiguratorException;
 }

--- a/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfiguratorFactory.java
+++ b/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfiguratorFactory.java
@@ -19,4 +19,6 @@ package org.codice.ddf.admin.configurator;
  */
 public interface ConfiguratorFactory {
     Configurator getConfigurator();
+
+    ConfigReader getConfigReader();
 }

--- a/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorFactoryImpl.java
+++ b/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorFactoryImpl.java
@@ -13,12 +13,18 @@
  **/
 package org.codice.ddf.admin.configurator.impl;
 
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 
 public class ConfiguratorFactoryImpl implements ConfiguratorFactory {
     @Override
     public Configurator getConfigurator() {
+        return new ConfiguratorImpl();
+    }
+
+    @Override
+    public ConfigReader getConfigReader() {
         return new ConfiguratorImpl();
     }
 }

--- a/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorImpl.java
+++ b/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorImpl.java
@@ -30,6 +30,7 @@ import javax.management.MBeanServerInvocationHandler;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.ConfiguratorException;
 import org.codice.ddf.admin.configurator.OperationReport;
@@ -62,7 +63,7 @@ import ddf.security.common.audit.SecurityLogger;
  * {@link #commit()} method to write the changes to the system. The resulting {@link OperationReport}
  * will have the outcome.
  */
-public class ConfiguratorImpl implements Configurator {
+public class ConfiguratorImpl implements Configurator, ConfigReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConfiguratorImpl.class);
 
     private final Map<String, Operation> configHandlers = new LinkedHashMap<>();

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceConfigurationHandler.java
@@ -32,7 +32,7 @@ import org.codice.ddf.admin.api.handler.method.TestMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
 import org.codice.ddf.admin.api.handler.report.Report;
 import org.codice.ddf.admin.api.services.CswServiceProperties;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.csw.persist.CreateCswSourcePersistMethod;
 import org.codice.ddf.admin.sources.csw.persist.DeleteCswSourcePersistMethod;
@@ -88,9 +88,9 @@ public class CswSourceConfigurationHandler extends DefaultConfigurationHandler<S
 
     @Override
     public List<SourceConfiguration> getConfigurations() {
-        Configurator configurator = configuratorFactory.getConfigurator();
+        ConfigReader configReader = configuratorFactory.getConfigReader();
         return CSW_FACTORY_PIDS.stream()
-                .flatMap(factoryPid -> configurator.getManagedServiceConfigs(factoryPid)
+                .flatMap(factoryPid -> configReader.getManagedServiceConfigs(factoryPid)
                         .values()
                         .stream())
                 .map(CswServiceProperties::servicePropsToCswConfig)

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/csw/test/SourceNameExistsCswTestMethod.java
@@ -63,7 +63,7 @@ public class SourceNameExistsCswTestMethod extends TestMethod<SourceConfiguratio
         List<ConfigurationMessage> results =
                 sourceValidationUtils.validateSourceName(configuration.sourceName(),
                         CSW_FACTORY_PIDS,
-                        configuratorFactory.getConfigurator());
+                        configuratorFactory.getConfigReader());
 
         if (results.isEmpty()) {
             return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceConfigurationHandler.java
@@ -33,7 +33,7 @@ import org.codice.ddf.admin.api.handler.method.TestMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
 import org.codice.ddf.admin.api.handler.report.Report;
 import org.codice.ddf.admin.api.services.OpenSearchServiceProperties;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.opensearch.persist.CreateOpenSearchSourcePersistMethod;
 import org.codice.ddf.admin.sources.opensearch.persist.DeleteOpenSearchSourcePersistMethod;
@@ -91,8 +91,8 @@ public class OpenSearchSourceConfigurationHandler
 
     @Override
     public List<SourceConfiguration> getConfigurations() {
-        Configurator configurator = configuratorFactory.getConfigurator();
-        return configurator.getManagedServiceConfigs(OPENSEARCH_FACTORY_PID)
+        ConfigReader configReader = configuratorFactory.getConfigReader();
+        return configReader.getManagedServiceConfigs(OPENSEARCH_FACTORY_PID)
                 .values()
                 .stream()
                 .map(OpenSearchServiceProperties::servicePropsToOpenSearchConfig)

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/opensearch/test/SourceNameExistsOpenSearchTestMethod.java
@@ -59,7 +59,7 @@ public class SourceNameExistsOpenSearchTestMethod extends TestMethod<SourceConfi
         List<ConfigurationMessage> results =
                 sourceValidationUtils.validateSourceName(configuration.sourceName(),
                         Collections.singletonList(OPENSEARCH_FACTORY_PID),
-                        configuratorFactory.getConfigurator());
+                        configuratorFactory.getConfigReader());
 
         if (results.isEmpty()) {
             return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceConfigurationHandler.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceConfigurationHandler.java
@@ -33,7 +33,7 @@ import org.codice.ddf.admin.api.handler.method.TestMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
 import org.codice.ddf.admin.api.handler.report.Report;
 import org.codice.ddf.admin.api.services.WfsServiceProperties;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.wfs.persist.CreateWfsSourcePersistMethod;
 import org.codice.ddf.admin.sources.wfs.persist.DeleteWfsSourcePersistMethod;
@@ -89,9 +89,9 @@ public class WfsSourceConfigurationHandler extends DefaultConfigurationHandler<S
 
     @Override
     public List<SourceConfiguration> getConfigurations() {
-        Configurator configurator = configuratorFactory.getConfigurator();
+        ConfigReader configReader = configuratorFactory.getConfigReader();
         return WFS_FACTORY_PIDS.stream()
-                .flatMap(factoryPid -> configurator.getManagedServiceConfigs(factoryPid)
+                .flatMap(factoryPid -> configReader.getManagedServiceConfigs(factoryPid)
                         .values()
                         .stream())
                 .map(WfsServiceProperties::servicePropsToWfsConfig)

--- a/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
+++ b/federation/source-config-handlers/src/main/java/org/codice/ddf/admin/sources/wfs/test/SourceNameExistsWfsTestMethod.java
@@ -58,7 +58,7 @@ public class SourceNameExistsWfsTestMethod extends TestMethod<SourceConfiguratio
         List<ConfigurationMessage> results =
                 sourceValidationUtils.validateSourceName(configuration.sourceName(),
                         WFS_FACTORY_PIDS,
-                        configuratorFactory.getConfigurator());
+                        configuratorFactory.getConfigReader());
 
         if (results.isEmpty()) {
             return new Report(buildMessage(SUCCESS_TYPES, FAILURE_TYPES, null, SUCCESSFUL_TEST));

--- a/security/contextpolicy-config-handler/src/main/java/org/codice/ddf/admin/security/context/ContextPolicyManagerHandler.java
+++ b/security/contextpolicy-config-handler/src/main/java/org/codice/ddf/admin/security/context/ContextPolicyManagerHandler.java
@@ -70,7 +70,7 @@ public class ContextPolicyManagerHandler
     @Override
     public List<ContextPolicyConfiguration> getConfigurations() {
         return Collections.singletonList(contextPolicyServiceToContextPolicyConfig(
-                configuratorFactory.getConfigurator()));
+                configuratorFactory.getConfigReader()));
     }
 
     @Override

--- a/security/contextpolicy-config-handler/src/main/java/org/codice/ddf/admin/security/context/probe/AvailableOptionsProbeMethod.java
+++ b/security/contextpolicy-config-handler/src/main/java/org/codice/ddf/admin/security/context/probe/AvailableOptionsProbeMethod.java
@@ -44,7 +44,7 @@ import org.codice.ddf.admin.api.config.ldap.LdapConfiguration;
 import org.codice.ddf.admin.api.handler.ConfigurationHandler;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,13 +78,13 @@ public class AvailableOptionsProbeMethod extends ProbeMethod<ContextPolicyConfig
 
     private ConfigurationHandler ldapConfigHandler;
 
-    private final Configurator configurator;
+    private final ConfigReader configReader;
 
     public AvailableOptionsProbeMethod(ConfigurationHandler ldapConfigHandler,
             ConfiguratorFactory configuratorFactory) {
         super(ID, DESCRIPTION, null, null, SUCCESS_TYPES, FAILED_TYPES, null, RETURN_TYPES);
         this.ldapConfigHandler = ldapConfigHandler;
-        configurator = configuratorFactory.getConfigurator();
+        configReader = configuratorFactory.getConfigReader();
     }
 
     @Override
@@ -110,7 +110,7 @@ public class AvailableOptionsProbeMethod extends ProbeMethod<ContextPolicyConfig
         // TODO: tbatie - 1/12/17 - (Ticket) need to eventually check if these handlers are running for these auth types instead of hardcoding
         List<String> authTypes = new ArrayList<>(Arrays.asList(BASIC, SAML, PKI, GUEST));
 
-        if (configurator.isBundleStarted(IDP_CLIENT_BUNDLE_NAME)) {
+        if (configReader.isBundleStarted(IDP_CLIENT_BUNDLE_NAME)) {
             authTypes.add(IDP_AUTH);
         }
 
@@ -120,7 +120,7 @@ public class AvailableOptionsProbeMethod extends ProbeMethod<ContextPolicyConfig
     public List<String> getRealms() {
         List<String> realms = new ArrayList<>(Collections.singletonList(KARAF));
         // If an IdpConfigurationHandler exists replace this with a service reference
-        if (configurator.isBundleStarted(IDP_SERVER_BUNDLE_NAME)) {
+        if (configReader.isBundleStarted(IDP_SERVER_BUNDLE_NAME)) {
             realms.add(IDP_REALM);
         }
 
@@ -136,7 +136,7 @@ public class AvailableOptionsProbeMethod extends ProbeMethod<ContextPolicyConfig
     }
 
     public Object getClaims() {
-        Map<String, Object> stsConfig = configurator.getConfig(STS_CLAIMS_CONFIGURATION_CONFIG_ID);
+        Map<String, Object> stsConfig = configReader.getConfig(STS_CLAIMS_CONFIGURATION_CONFIG_ID);
         return stsConfig == null ? null : stsConfig.get(STS_CLAIMS_PROPS_KEY_CLAIMS);
     }
 }

--- a/security/embedded-ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/embedded/EmbeddedLdapConfigurationHandler.java
+++ b/security/embedded-ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/embedded/EmbeddedLdapConfigurationHandler.java
@@ -64,7 +64,7 @@ public class EmbeddedLdapConfigurationHandler
 
     @Override
     public List<EmbeddedLdapConfiguration> getConfigurations() {
-        Map<String, Object> serviceProps = configuratorFactory.getConfigurator()
+        Map<String, Object> serviceProps = configuratorFactory.getConfigReader()
                 .getConfig(EMBEDDED_LDAP_MANAGER_SERVICE_PID);
         if (serviceProps == null) {
             LOGGER.debug(

--- a/security/embedded-ldap-config-handler/src/test/groovy/org/codice/ddf/admin/security/ldap/embedded/EmbeddedLdapConfigurationHandlerTest.groovy
+++ b/security/embedded-ldap-config-handler/src/test/groovy/org/codice/ddf/admin/security/ldap/embedded/EmbeddedLdapConfigurationHandlerTest.groovy
@@ -15,7 +15,7 @@ package org.codice.ddf.admin.security.ldap.embedded
 
 import org.codice.ddf.admin.api.config.ldap.EmbeddedLdapConfiguration
 import org.codice.ddf.admin.api.services.EmbeddedLdapServiceProperties
-import org.codice.ddf.admin.configurator.Configurator
+import org.codice.ddf.admin.configurator.ConfigReader
 import org.codice.ddf.admin.configurator.ConfiguratorFactory
 import org.codice.ddf.admin.security.ldap.embedded.persist.DefaultEmbeddedLdapPersistMethod
 import spock.lang.Specification
@@ -23,12 +23,12 @@ import spock.lang.Specification
 class EmbeddedLdapConfigurationHandlerTest extends Specification {
 
     EmbeddedLdapConfigurationHandler embeddedLdapConfigurationHandler
-    ConfiguratorFactory configuratorFactory;
+    ConfiguratorFactory configuratorFactory
 
     def setup() {
         configuratorFactory = Mock(ConfiguratorFactory)
-        def configurator = Mock(Configurator)
-        configuratorFactory.getConfigurator() >> configurator
+        def configReader = Mock(ConfigReader)
+        configuratorFactory.getConfigReader() >> configReader
         embeddedLdapConfigurationHandler = new EmbeddedLdapConfigurationHandler(configuratorFactory)
     }
 
@@ -37,7 +37,7 @@ class EmbeddedLdapConfigurationHandlerTest extends Specification {
         def configurations = embeddedLdapConfigurationHandler.getConfigurations()
 
         then:
-        1 * configuratorFactory.getConfigurator()
+        1 * configuratorFactory.getConfigReader()
                 .getConfig(EmbeddedLdapServiceProperties.EMBEDDED_LDAP_MANAGER_SERVICE_PID) >> null
         configurations == Collections.emptyList()
     }
@@ -47,7 +47,7 @@ class EmbeddedLdapConfigurationHandlerTest extends Specification {
         def configurations = embeddedLdapConfigurationHandler.getConfigurations()
 
         then:
-        1 * configuratorFactory.getConfigurator()
+        1 * configuratorFactory.getConfigReader()
                 .getConfig(EmbeddedLdapServiceProperties.EMBEDDED_LDAP_MANAGER_SERVICE_PID) >> [(EmbeddedLdapConfiguration.EMBEDDED_LDAP_PORT): 123]
         configurations.size() == 1
         configurations.get(0).toString().contains("123")

--- a/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/LdapConfigurationHandler.java
+++ b/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/LdapConfigurationHandler.java
@@ -29,7 +29,7 @@ import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.method.TestMethod;
 import org.codice.ddf.admin.api.services.LdapClaimsHandlerServiceProperties;
 import org.codice.ddf.admin.api.services.LdapLoginServiceProperties;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.security.ldap.persist.CreateLdapConfigMethod;
 import org.codice.ddf.admin.security.ldap.persist.DeleteLdapConfigMethod;
@@ -67,10 +67,10 @@ public class LdapConfigurationHandler extends DefaultConfigurationHandler<LdapCo
     @Override
     public List<ProbeMethod> getProbeMethods() {
         LdapTestingCommons ldapTestingCommons = new LdapTestingCommons();
-        Configurator configurator = configuratorFactory.getConfigurator();
+        ConfigReader configReader = configuratorFactory.getConfigReader();
         return ImmutableList.of(new DefaultDirectoryStructureProbe(ldapTestingCommons),
                 new LdapQueryProbe(ldapTestingCommons),
-                new SubjectAttributeProbe(ldapTestingCommons, configurator));
+                new SubjectAttributeProbe(ldapTestingCommons, configReader));
     }
 
     @Override
@@ -80,7 +80,7 @@ public class LdapConfigurationHandler extends DefaultConfigurationHandler<LdapCo
                 new BindUserTestMethod(ldapTestingCommons),
                 new DirectoryStructTestMethod(ldapTestingCommons),
                 new AttributeMappingTestMethod(ldapTestingCommons,
-                        configuratorFactory.getConfigurator()));
+                        configuratorFactory.getConfigReader()));
     }
 
     @Override
@@ -91,20 +91,20 @@ public class LdapConfigurationHandler extends DefaultConfigurationHandler<LdapCo
 
     @Override
     public List<LdapConfiguration> getConfigurations() {
-        List<LdapConfiguration> ldapLoginConfigs = configuratorFactory.getConfigurator()
+        List<LdapConfiguration> ldapLoginConfigs = configuratorFactory.getConfigReader()
                 .getManagedServiceConfigs(LDAP_LOGIN_MANAGED_SERVICE_FACTORY_PID)
                 .values()
                 .stream()
                 .map(LdapLoginServiceProperties::ldapLoginServiceToLdapConfiguration)
                 .collect(Collectors.toList());
 
-        List<LdapConfiguration> ldapClaimsHandlerConfigs = configuratorFactory.getConfigurator()
+        List<LdapConfiguration> ldapClaimsHandlerConfigs = configuratorFactory.getConfigReader()
                 .getManagedServiceConfigs(LDAP_CLAIMS_HANDLER_MANAGED_SERVICE_FACTORY_PID)
                 .values()
                 .stream()
                 .map((props) -> LdapClaimsHandlerServiceProperties.ldapClaimsHandlerServiceToLdapConfig(
                         props,
-                        configuratorFactory.getConfigurator()))
+                        configuratorFactory.getConfigReader()))
                 .collect(Collectors.toList());
 
         return Stream.concat(ldapLoginConfigs.stream(), ldapClaimsHandlerConfigs.stream())

--- a/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/probe/SubjectAttributeProbe.java
+++ b/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/probe/SubjectAttributeProbe.java
@@ -36,7 +36,7 @@ import org.codice.ddf.admin.api.config.ldap.LdapConfiguration;
 import org.codice.ddf.admin.api.handler.ConfigurationMessage;
 import org.codice.ddf.admin.api.handler.method.ProbeMethod;
 import org.codice.ddf.admin.api.handler.report.ProbeReport;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.codice.ddf.admin.security.ldap.ServerGuesser;
 import org.codice.ddf.admin.security.ldap.test.LdapTestingCommons;
 import org.forgerock.opendj.ldap.LdapException;
@@ -76,9 +76,9 @@ public class SubjectAttributeProbe extends ProbeMethod<LdapConfiguration> {
 
     private final LdapTestingCommons ldapTestingCommons;
 
-    private final Configurator configurator;
+    private final ConfigReader configReader;
 
-    public SubjectAttributeProbe(LdapTestingCommons ldapTestingCommons, Configurator configurator) {
+    public SubjectAttributeProbe(LdapTestingCommons ldapTestingCommons, ConfigReader configReader) {
         super(SUBJECT_ATTRIBUTES_PROBE_ID,
                 DESCRIPTION,
                 REQUIRED_FIELDS,
@@ -89,13 +89,13 @@ public class SubjectAttributeProbe extends ProbeMethod<LdapConfiguration> {
                 RETURN_TYPES);
 
         this.ldapTestingCommons = ldapTestingCommons;
-        this.configurator = configurator;
+        this.configReader = configReader;
     }
 
     @Override
     public ProbeReport probe(LdapConfiguration configuration) {
         ProbeReport probeReport = new ProbeReport();
-        Object subjectClaims = configurator.getConfig(STS_CLAIMS_CONFIGURATION_CONFIG_ID)
+        Object subjectClaims = configReader.getConfig(STS_CLAIMS_CONFIGURATION_CONFIG_ID)
                 .get(STS_CLAIMS_PROPS_KEY_CLAIMS);
 
         LdapTestingCommons.LdapConnectionAttempt ldapConnectionAttempt =

--- a/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/test/AttributeMappingTestMethod.java
+++ b/security/ldap-config-handler/src/main/java/org/codice/ddf/admin/security/ldap/test/AttributeMappingTestMethod.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 import org.codice.ddf.admin.api.config.ldap.LdapConfiguration;
 import org.codice.ddf.admin.api.handler.method.TestMethod;
 import org.codice.ddf.admin.api.handler.report.Report;
-import org.codice.ddf.admin.configurator.Configurator;
+import org.codice.ddf.admin.configurator.ConfigReader;
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.Filter;
 import org.forgerock.opendj.ldap.SearchScope;
@@ -65,12 +65,12 @@ public class AttributeMappingTestMethod extends TestMethod<LdapConfiguration> {
                     .put(INVALID_FIELD, "The given attribute mapping is invalid.")
                     .build();
 
-    private final Configurator configurator;
+    private final ConfigReader configReader;
 
     private final LdapTestingCommons ldapTestingCommons;
 
     public AttributeMappingTestMethod(LdapTestingCommons ldapTestingCommons,
-            Configurator configurator) {
+            ConfigReader configReader) {
         super(LDAP_ATTRIBUTE_MAPPING_TEST_ID,
                 DESCRIPTION,
                 REQUIRED_FIELDS,
@@ -80,14 +80,14 @@ public class AttributeMappingTestMethod extends TestMethod<LdapConfiguration> {
                 null);
 
         this.ldapTestingCommons = ldapTestingCommons;
-        this.configurator = configurator;
+        this.configReader = configReader;
     }
 
     @Override
     public Report test(LdapConfiguration configuration) {
         // First check for any unknown claims. This should never happen in a correctly configured
         // system. Bail out on first unknown claim.
-        List stsClaims = Arrays.asList((String[]) configurator.getConfig(
+        List stsClaims = Arrays.asList((String[]) configReader.getConfig(
                 STS_CLAIMS_CONFIGURATION_CONFIG_ID)
                 .get(STS_CLAIMS_PROPS_KEY_CLAIMS));
         Optional<String> unknownStsClaim = configuration.attributeMappings()

--- a/security/ldap-config-handler/src/test/groovy/org/codice/ddf/admin/security/ldap/probe/SubjectAttributeProbeTest.groovy
+++ b/security/ldap-config-handler/src/test/groovy/org/codice/ddf/admin/security/ldap/probe/SubjectAttributeProbeTest.groovy
@@ -2,7 +2,7 @@ package org.codice.ddf.admin.security.ldap.probe
 
 import org.codice.ddf.admin.api.config.ldap.LdapConfiguration
 import org.codice.ddf.admin.api.handler.report.ProbeReport
-import org.codice.ddf.admin.configurator.Configurator
+import org.codice.ddf.admin.configurator.ConfigReader
 import org.codice.ddf.admin.security.ldap.LdapConnectionResult
 import org.codice.ddf.admin.security.ldap.test.LdapTestingCommons
 import org.forgerock.opendj.ldap.SearchResultReferenceIOException
@@ -23,7 +23,7 @@ class SubjectAttributeProbeTest extends Specification {
         def ldapTestingCommons = Mock(LdapTestingCommons)
         def connectionAttempt = Mock(LdapTestingCommons.LdapConnectionAttempt)
         ldapTestingCommons.bindUserToLdapConnection(configuration) >> connectionAttempt
-        def configurator = Mock(Configurator)
+        def configurator = Mock(ConfigReader)
         def subjectClaims = ['one', 'two', 'three']
         configurator.getConfig(STS_CLAIMS_CONFIGURATION_CONFIG_ID) >>
                 [(STS_CLAIMS_PROPS_KEY_CLAIMS): subjectClaims]

--- a/security/ldap-config-handler/src/test/groovy/org/codice/ddf/admin/security/ldap/test/AttributeMappingTestMethodTest.groovy
+++ b/security/ldap-config-handler/src/test/groovy/org/codice/ddf/admin/security/ldap/test/AttributeMappingTestMethodTest.groovy
@@ -2,7 +2,7 @@ package org.codice.ddf.admin.security.ldap.test
 
 import org.codice.ddf.admin.api.config.ldap.LdapConfiguration
 import org.codice.ddf.admin.api.handler.report.Report
-import org.codice.ddf.admin.configurator.Configurator
+import org.codice.ddf.admin.configurator.ConfigReader
 import org.forgerock.opendj.ldap.Connection
 import spock.lang.Specification
 
@@ -14,7 +14,7 @@ class AttributeMappingTestMethodTest extends Specification {
     private ldapTestingCommons
     private connection
     private connectionAttempt
-    private configurator
+    private configReader
     private tester
 
     def setup() {
@@ -22,10 +22,10 @@ class AttributeMappingTestMethodTest extends Specification {
         connection = Mock(Connection)
         connectionAttempt = Mock(LdapTestingCommons.LdapConnectionAttempt)
 
-        configurator = Mock(Configurator)
-        configurator.getConfig(STS_CLAIMS_CONFIGURATION_CONFIG_ID) >>
+        configReader = Mock(ConfigReader)
+        configReader.getConfig(STS_CLAIMS_CONFIGURATION_CONFIG_ID) >>
                 [(STS_CLAIMS_PROPS_KEY_CLAIMS): ['a', 'b', 'c'] as String[]]
-        tester = new AttributeMappingTestMethod(ldapTestingCommons, configurator)
+        tester = new AttributeMappingTestMethod(ldapTestingCommons, configReader)
     }
 
     def 'fail due to failed connection'() {


### PR DESCRIPTION
#### What does this PR do?
This more clearly delineates the operation/transaction code, separating it out from the reader helper methods.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @peterhuffer @adimka 

#### How should this be tested? (List steps with links to updated documentation)
Full build/test and short heroing of all three wizards.

#### Any background context you want to provide?
As the Configurator is currently under review for contribution to DDF, suggested changes being made there are being reflected back here as this project is the only one exercising its functionality.

See [this PR](https://github.com/codice/ddf/pull/1806) for more details.

#### What are the relevant tickets?
[DDF-2825](https://codice.atlassian.net/browse/DDF-2825)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
