### PR TITLE
DDF-2773: Add paths to Fields

### DIFF
--- a/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigValidator.java
+++ b/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfigValidator.java
@@ -52,7 +52,7 @@ class ConfigValidator {
 
         Path ddfHomePath = Paths.get(ddfHomeProp);
         if (!propFile.startsWith(ddfHomePath)) {
-            throw new IllegalArgumentException(String.format("%s is not beneath the %s root",
+            throw new IllegalArgumentException(String.format("File [%s] is not beneath ddf home directory [%s]",
                     propFile.toString(),
                     ddfHomePath.toString()));
         }

--- a/query/api/src/main/java/org/codice/ddf/admin/api/fields/Field.java
+++ b/query/api/src/main/java/org/codice/ddf/admin/api/fields/Field.java
@@ -32,6 +32,23 @@ public interface Field<T> {
 
     List<Message> validate();
 
+    /**
+     * Returns a path to this {@code Field}. A {@code Field}'s path describes the location of the field
+     * when nested in {@link ObjectField}'s. For example, if {@code ObjectField} x encapsulates {@code ObjectField} y, which
+     * itself encapsulates {@link Field} z, z's path is defined as a list of fields [x, y, z]. If a {@code Field}
+     * exists outside an {@link ObjectField}, its path is itself.
+     *
+     * @return a {@code List} of {@link Field}s describing this {@code Field}'s location.
+     */
+    List<String> path();
+
+    /**
+     * Pushes a {@code Field}'s name to the deque of {@code String}s that describe this {@code Field}'s path.
+     *
+     * @param fieldName field name to add to path
+     */
+    void addToPath(String fieldName);
+
     boolean isRequired();
 
     Field<T> isRequired(boolean required);

--- a/query/api/src/main/java/org/codice/ddf/admin/api/fields/Field.java
+++ b/query/api/src/main/java/org/codice/ddf/admin/api/fields/Field.java
@@ -33,21 +33,18 @@ public interface Field<T> {
     List<Message> validate();
 
     /**
-     * Returns a path to this {@code Field}. A {@code Field}'s path describes the location of the field
-     * when nested in {@link ObjectField}'s. For example, if {@code ObjectField} x encapsulates {@code ObjectField} y, which
-     * itself encapsulates {@link Field} z, z's path is defined as a list of fields [x, y, z]. If a {@code Field}
-     * exists outside an {@link ObjectField}, its path is itself.
+     * Returns a path that uniquely identifies this {@code Field}.
      *
-     * @return a {@code List} of {@link Field}s describing this {@code Field}'s location.
+     * @return a {@code List} of Strings identifying this {@code Field}
      */
     List<String> path();
 
     /**
-     * Pushes a {@code Field}'s name to the deque of {@code String}s that describe this {@code Field}'s path.
+     * Adds a sub-path to the list of Strings that describes this {@code Field}'s path.
      *
-     * @param fieldName field name to add to path
+     * @param subPath unique identifier to add to the path
      */
-    void addToPath(String fieldName);
+    void addToPath(String subPath);
 
     boolean isRequired();
 

--- a/query/common/pom.xml
+++ b/query/common/pom.xml
@@ -38,6 +38,14 @@
             <artifactId>admin-query-api</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!--Spock dependencies-->
+        <dependency>
+            <groupId>ddf.lib</groupId>
+            <artifactId>spock-shaded</artifactId>
+            <version>${ddf.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/query/common/src/main/java/org/codice/ddf/admin/common/actions/BaseAction.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/actions/BaseAction.java
@@ -93,7 +93,7 @@ public abstract class BaseAction<T extends Field> implements Action<T> {
         return this;
     }
 
-    protected BaseAction addReturnValueMessage(Message msg) {
+    protected BaseAction addMessage(Message msg) {
         Message copy = msg.copy();
         copy.addSubpath(name);
         report.addMessage(copy);
@@ -105,8 +105,8 @@ public abstract class BaseAction<T extends Field> implements Action<T> {
         return this;
     }
 
-    protected BaseAction addReturnValueMessages(List<Message> msgs) {
-        msgs.forEach(msg -> addReturnValueMessage(msg));
+    protected BaseAction addMessages(List<Message> msgs) {
+        msgs.forEach(msg -> addMessage(msg));
         return this;
     }
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseEnumField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseEnumField.java
@@ -25,6 +25,7 @@ import org.codice.ddf.admin.api.fields.Field;
 
 public abstract class BaseEnumField<S> extends BaseField<S> implements EnumField<S, Field<S>> {
 
+    // TODO: 4/18/17 phuffer -  Replace this list with a single value. look at removing overriding getValue()
     private Field<S> enumValue;
 
     private List<Field<S>> enumValues;

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseField.java
@@ -16,10 +16,14 @@ package org.codice.ddf.admin.common.fields.base;
 import static org.codice.ddf.admin.common.message.DefaultMessages.missingRequiredFieldError;
 
 import java.util.ArrayList;
+import java.util.Deque;
+import java.util.LinkedList;
 import java.util.List;
 
 import org.codice.ddf.admin.api.action.Message;
 import org.codice.ddf.admin.api.fields.Field;
+
+import com.google.common.collect.ImmutableList;
 
 public abstract class BaseField<T> implements Field<T> {
 
@@ -33,6 +37,8 @@ public abstract class BaseField<T> implements Field<T> {
 
     private boolean isRequired;
 
+    private Deque<String> path;
+
     public BaseField(String fieldName, String fieldTypeName, String description,
             FieldBaseType fieldBaseType) {
         this.fieldName = fieldName;
@@ -40,6 +46,8 @@ public abstract class BaseField<T> implements Field<T> {
         this.fieldBaseType = fieldBaseType;
         this.description = description;
         isRequired = false;
+        path = new LinkedList<>();
+        path.push(this.fieldName);
     }
 
     @Override
@@ -74,10 +82,20 @@ public abstract class BaseField<T> implements Field<T> {
     }
 
     @Override
+    public List<String> path() {
+        return ImmutableList.copyOf(this.path);
+    }
+
+    @Override
+    public void addToPath(String fieldName) {
+        path.push(fieldName);
+    }
+
+    @Override
     public List<Message> validate() {
         List<Message> errors = new ArrayList<>();
 
-        if(isRequired() && getValue() == null) {
+        if (isRequired() && getValue() == null) {
             errors.add(missingRequiredFieldError(fieldName()));
         }
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
@@ -27,13 +27,15 @@ import org.codice.ddf.admin.api.fields.ObjectField;
 public abstract class BaseObjectField extends BaseField<Map<String, Object>>
         implements ObjectField {
 
-    public BaseObjectField(String fieldName, String fieldTypeName, String description) {
-        super(fieldName, fieldTypeName, description, OBJECT);
-    }
-
     protected BaseObjectField(String fieldName, String fieldTypeName, String description,
             FieldBaseType baseType) {
         super(fieldName, fieldTypeName, description, baseType);
+        this.initializeFields();
+        getFields().forEach(field -> field.addToPath(this.fieldName()));
+    }
+
+    public BaseObjectField(String fieldName, String fieldTypeName, String description) {
+        this(fieldName, fieldTypeName, description, OBJECT);
     }
 
     @Override
@@ -97,5 +99,17 @@ public abstract class BaseObjectField extends BaseField<Map<String, Object>>
                 .map(ObjectField.class::cast)
                 .forEach(objField -> objField.innerFieldRequired(required, fieldName));
         return this;
+    }
+
+    /**
+     * Initializes all the {@link org.codice.ddf.admin.api.fields.Field} of an {@code ObjectField}. Any {@link org.codice.ddf.admin.api.fields.Field} that gets initialized
+     * in this method, and is also returned by the {@link ObjectField#getFields()}, will have the {@code ObjectField} added to its path.
+     */
+    public abstract void initializeFields();
+
+    @Override
+    public void addToPath(String fieldName) {
+        super.addToPath(fieldName);
+        getFields().forEach(child -> child.addToPath(fieldName));
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
@@ -30,8 +30,8 @@ public abstract class BaseObjectField extends BaseField<Map<String, Object>>
     protected BaseObjectField(String fieldName, String fieldTypeName, String description,
             FieldBaseType baseType) {
         super(fieldName, fieldTypeName, description, baseType);
-        this.initializeFields();
-        getFields().forEach(field -> field.addToPath(this.fieldName()));
+        initializeFields();
+        getFields().forEach(field -> field.addToPath(fieldName()));
     }
 
     public BaseObjectField(String fieldName, String fieldTypeName, String description) {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/ListFieldImpl.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/ListFieldImpl.java
@@ -86,7 +86,7 @@ public class ListFieldImpl<T extends Field> extends BaseField<List>
                 T newField = (T) getListFieldType().getClass()
                         .newInstance();
                 newField.setValue(val);
-                this.path().forEach(fieldName -> newField.addToPath(fieldName));
+                path().forEach(fieldName -> newField.addToPath(fieldName));
                 add(newField);
             } catch (IllegalAccessException | InstantiationException e) {
                 LOGGER.debug("Unable to create instance of fieldType {}",

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/ListFieldImpl.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/ListFieldImpl.java
@@ -86,7 +86,6 @@ public class ListFieldImpl<T extends Field> extends BaseField<List>
                 T newField = (T) getListFieldType().getClass()
                         .newInstance();
                 newField.setValue(val);
-                path().forEach(fieldName -> newField.addToPath(fieldName));
                 add(newField);
             } catch (IllegalAccessException | InstantiationException e) {
                 LOGGER.debug("Unable to create instance of fieldType {}",
@@ -100,6 +99,7 @@ public class ListFieldImpl<T extends Field> extends BaseField<List>
         // TODO: 4/10/17 perform special validation for object fields
         // TODO: 4/10/17 Copy the obj instead
         value.isRequired(listFieldType.isRequired());
+        path().forEach(value::addToPath);
         fields.add(value);
         return this;
     }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/ListFieldImpl.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/ListFieldImpl.java
@@ -86,6 +86,7 @@ public class ListFieldImpl<T extends Field> extends BaseField<List>
                 T newField = (T) getListFieldType().getClass()
                         .newInstance();
                 newField.setValue(val);
+                this.path().forEach(fieldName -> newField.addToPath(fieldName));
                 add(newField);
             } catch (IllegalAccessException | InstantiationException e) {
                 LOGGER.debug("Unable to create instance of fieldType {}",

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/AddressField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/AddressField.java
@@ -34,12 +34,16 @@ public class AddressField extends BaseObjectField {
 
     public AddressField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        this.hostname = new HostnameField();
-        this.port = new PortField();
     }
 
     @Override
     public List<Field> getFields() {
         return ImmutableList.of(hostname, port);
+    }
+
+    @Override
+    public void initializeFields() {
+        this.hostname = new HostnameField();
+        this.port = new PortField();
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
@@ -35,8 +35,6 @@ public class CredentialsField extends BaseObjectField {
 
     public CredentialsField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        this.username = new StringField("username");
-        this.password = new StringField("password");
     }
 
     public CredentialsField username(String username) {
@@ -49,8 +47,22 @@ public class CredentialsField extends BaseObjectField {
         return this;
     }
 
+    public StringField password() {
+        return password;
+    }
+
+    public StringField username() {
+        return username;
+    }
+
     @Override
     public List<Field> getFields() {
         return ImmutableList.of(username, password);
+    }
+
+    @Override
+    public void initializeFields() {
+        this.username = new StringField("username");
+        this.password = new StringField("password");
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
@@ -27,7 +27,7 @@ public class CredentialsField extends BaseObjectField {
 
     public static final String FIELD_TYPE_NAME = "Credentials";
 
-    public static final String DESCRIPTION = "Credentials required for base64 authentication.";
+    public static final String DESCRIPTION = "Credentials required for authentication.";
 
     private StringField username;
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
@@ -47,12 +47,12 @@ public class CredentialsField extends BaseObjectField {
         return this;
     }
 
-    public StringField password() {
-        return password;
+    public String password() {
+        return password.getValue();
     }
 
-    public StringField username() {
-        return username;
+    public String username() {
+        return username.getValue();
     }
 
     @Override

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
@@ -48,6 +48,7 @@ public class MapField extends BaseObjectField {
 
     @Override
     public void initializeFields() {
+        // TODO: 4/18/17 phuffer - replace with a MapField
         entries = new ListFieldImpl<>("entries", PairField.class);
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
@@ -34,7 +34,6 @@ public class MapField extends BaseObjectField {
 
     public MapField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        entries = new ListFieldImpl<>("entries", PairField.class);
     }
 
     @Override
@@ -47,4 +46,8 @@ public class MapField extends BaseObjectField {
         return this;
     }
 
+    @Override
+    public void initializeFields() {
+        entries = new ListFieldImpl<>("entries", PairField.class);
+    }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PairField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PairField.java
@@ -35,8 +35,6 @@ public class PairField extends BaseObjectField {
 
     public PairField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        key = new StringField("key");
-        value = new StringField("value");
     }
 
     @Override
@@ -60,5 +58,11 @@ public class PairField extends BaseObjectField {
 
     public String value() {
         return value.getValue();
+    }
+
+    @Override
+    public void initializeFields() {
+        key = new StringField("key");
+        value = new StringField("value");
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/message/BaseMessage.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/message/BaseMessage.java
@@ -27,6 +27,8 @@ public abstract class BaseMessage implements Message {
 
     private List<String> path;
 
+    private Field field;
+
     public BaseMessage(MessageType type, String code) {
         this.type = type;
         this.code = code;

--- a/query/common/src/main/java/org/codice/ddf/admin/common/message/BaseMessage.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/message/BaseMessage.java
@@ -27,8 +27,6 @@ public abstract class BaseMessage implements Message {
 
     private List<String> path;
 
-    private Field field;
-
     public BaseMessage(MessageType type, String code) {
         this.type = type;
         this.code = code;

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
@@ -13,24 +13,17 @@
  **/
 package org.codice.ddf.admin.common.fields.base
 
-import com.google.common.collect.ImmutableList
-
-import org.codice.ddf.admin.api.fields.Field
 import org.codice.ddf.admin.api.fields.ObjectField
+import org.codice.ddf.admin.common.fields.TestObjectField
+import org.codice.ddf.admin.common.fields.base.scalar.StringField
 import spock.lang.Specification
 
 class BaseFieldTest extends Specification {
 
-    static final OBJECT_FIELD_NAME1 = "mockObjectField1"
-
-    static final OBJECT_FIELD_NAME2 = "mockObjectField2"
-
-    static final FIELD_NAME = "mockField"
-
     BaseObjectField field
 
     def setup() {
-       field = new TestObjectField(OBJECT_FIELD_NAME1, "MockObjectField1", "Description of MockObjectField1")
+       field = new TestObjectField()
     }
 
     def 'test field paths of nested ObjectFields is correct order'() {
@@ -39,66 +32,8 @@ class BaseFieldTest extends Specification {
         def field2 = ((ObjectField) field1).getFields().get(0)
 
         then:
-        field.path() == [OBJECT_FIELD_NAME1]
-        field1.path() == [OBJECT_FIELD_NAME1, OBJECT_FIELD_NAME2]
-        field2.path() == [OBJECT_FIELD_NAME1, OBJECT_FIELD_NAME2, FIELD_NAME]
-    }
-
-    /*
-        Test class fields
-     */
-    class TestObjectField extends BaseObjectField {
-
-        def objectField
-
-        TestObjectField(String fieldName, String fieldTypeName, String description) {
-            super(fieldName, fieldTypeName, description)
-        }
-
-        @Override
-        List<Field> getFields() {
-            return ImmutableList.of(objectField)
-        }
-
-        @Override
-        void initializeFields() {
-            objectField = new TestObjectField1(OBJECT_FIELD_NAME2,  "MockObjectField2", "Description of MockObjectField2")
-        }
-    }
-
-    class TestObjectField1 extends BaseObjectField {
-
-        def field
-
-        TestObjectField1(String fieldName, String fieldTypeName, String description) {
-            super(fieldName, fieldTypeName, description)
-        }
-
-        @Override
-        List<Field> getFields() {
-            return ImmutableList.of(field)
-        }
-
-        @Override
-        void initializeFields() {
-            field = new TestBaseField(FIELD_NAME, "MockField", "Description of MockField", Field.FieldBaseType.STRING)
-        }
-    }
-
-    class TestBaseField extends BaseField {
-
-        TestBaseField(String fieldName, String fieldTypeName, String description, Field.FieldBaseType fieldBaseType) {
-            super(fieldName, fieldTypeName, description, fieldBaseType)
-        }
-
-        @Override
-        Object getValue() {
-            return value
-        }
-
-        @Override
-        void setValue(Object value) {
-            this.value = value
-        }
+        field.path() == [TestObjectField.DEFAULT_FIELD_NAME]
+        field1.path() == [TestObjectField.DEFAULT_FIELD_NAME, TestObjectField.InnerTestObjectField.DEFAULT_FIELD_NAME]
+        field2.path() == [TestObjectField.DEFAULT_FIELD_NAME, TestObjectField.InnerTestObjectField.DEFAULT_FIELD_NAME, StringField.DEFAULT_FIELD_NAME]
     }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
@@ -20,20 +20,24 @@ import spock.lang.Specification
 
 class BaseFieldTest extends Specification {
 
-    BaseObjectField field
+    BaseObjectField topLevelField
 
     def setup() {
-       field = new TestObjectField()
+        topLevelField = new TestObjectField()
     }
 
     def 'test field paths of nested ObjectFields is correct order'() {
         when:
-        def field1 = field.getFields().get(0)
-        def field2 = ((ObjectField) field1).getFields().get(0)
+        def innerField = topLevelField.getFields().get(0)
+        def subFieldOfInnerField = ((ObjectField) innerField).getFields().get(0)
+
+        List<String> topLevelFieldPath = topLevelField.path()
+        List<String> innerFieldPath = innerField.path()
+        List<String> subFieldOfInnerFieldPath = subFieldOfInnerField.path()
 
         then:
-        field.path() == [TestObjectField.DEFAULT_FIELD_NAME]
-        field1.path() == [TestObjectField.DEFAULT_FIELD_NAME, TestObjectField.InnerTestObjectField.DEFAULT_FIELD_NAME]
-        field2.path() == [TestObjectField.DEFAULT_FIELD_NAME, TestObjectField.InnerTestObjectField.DEFAULT_FIELD_NAME, StringField.DEFAULT_FIELD_NAME]
+        topLevelFieldPath == [TestObjectField.DEFAULT_FIELD_NAME]
+        innerFieldPath == [topLevelFieldPath, TestObjectField.InnerTestObjectField.DEFAULT_FIELD_NAME].flatten()
+        subFieldOfInnerFieldPath == [innerFieldPath, StringField.DEFAULT_FIELD_NAME].flatten()
     }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFieldTest.groovy
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.common.fields.base
+
+import com.google.common.collect.ImmutableList
+
+import org.codice.ddf.admin.api.fields.Field
+import org.codice.ddf.admin.api.fields.ObjectField
+import spock.lang.Specification
+
+class BaseFieldTest extends Specification {
+
+    static final OBJECT_FIELD_NAME1 = "mockObjectField1"
+
+    static final OBJECT_FIELD_NAME2 = "mockObjectField2"
+
+    static final FIELD_NAME = "mockField"
+
+    BaseObjectField field
+
+    def setup() {
+       field = new TestObjectField(OBJECT_FIELD_NAME1, "MockObjectField1", "Description of MockObjectField1")
+    }
+
+    def 'test field paths of nested ObjectFields is correct order'() {
+        when:
+        def field1 = field.getFields().get(0)
+        def field2 = ((ObjectField) field1).getFields().get(0)
+
+        then:
+        field.path() == [OBJECT_FIELD_NAME1]
+        field1.path() == [OBJECT_FIELD_NAME1, OBJECT_FIELD_NAME2]
+        field2.path() == [OBJECT_FIELD_NAME1, OBJECT_FIELD_NAME2, FIELD_NAME]
+    }
+
+    /*
+        Test class fields
+     */
+    class TestObjectField extends BaseObjectField {
+
+        def objectField
+
+        TestObjectField(String fieldName, String fieldTypeName, String description) {
+            super(fieldName, fieldTypeName, description)
+        }
+
+        @Override
+        List<Field> getFields() {
+            return ImmutableList.of(objectField)
+        }
+
+        @Override
+        void initializeFields() {
+            objectField = new TestObjectField1(OBJECT_FIELD_NAME2,  "MockObjectField2", "Description of MockObjectField2")
+        }
+    }
+
+    class TestObjectField1 extends BaseObjectField {
+
+        def field
+
+        TestObjectField1(String fieldName, String fieldTypeName, String description) {
+            super(fieldName, fieldTypeName, description)
+        }
+
+        @Override
+        List<Field> getFields() {
+            return ImmutableList.of(field)
+        }
+
+        @Override
+        void initializeFields() {
+            field = new TestBaseField(FIELD_NAME, "MockField", "Description of MockField", Field.FieldBaseType.STRING)
+        }
+    }
+
+    class TestBaseField extends BaseField {
+
+        TestBaseField(String fieldName, String fieldTypeName, String description, Field.FieldBaseType fieldBaseType) {
+            super(fieldName, fieldTypeName, description, fieldBaseType)
+        }
+
+        @Override
+        Object getValue() {
+            return value
+        }
+
+        @Override
+        void setValue(Object value) {
+            this.value = value
+        }
+    }
+}

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/ListFieldImplTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/ListFieldImplTest.groovy
@@ -14,6 +14,8 @@
 package org.codice.ddf.admin.common.fields.base
 
 import org.codice.ddf.admin.api.fields.Field
+import org.codice.ddf.admin.api.fields.ObjectField
+import org.codice.ddf.admin.common.fields.TestObjectField
 import org.codice.ddf.admin.common.fields.base.scalar.StringField
 import spock.lang.Specification
 
@@ -38,5 +40,18 @@ class ListFieldImplTest extends Specification {
         then:
         listField.path() == [LIST_FIELD_NAME]
         ((Field) listField.getList().get(0)).path() == [LIST_FIELD_NAME, StringField.DEFAULT_FIELD_NAME]
+    }
+
+    def 'test the path of ObjectFields and their inner fields in listfields'() {
+        when:
+        listField = new ListFieldImpl<>(LIST_FIELD_NAME, TestObjectField.class)
+        def field = new TestObjectField()
+        listField.setValue(Collections.singletonList(field.getValue()))
+
+        then:
+        listField.path() == [LIST_FIELD_NAME]
+        ((Field) listField.getList().get(0)).path() == [LIST_FIELD_NAME, TestObjectField.DEFAULT_FIELD_NAME]
+        ((BaseObjectField) listField.getList().get(0)).getFields().get(0).path() == [LIST_FIELD_NAME, TestObjectField.DEFAULT_FIELD_NAME, TestObjectField.InnerTestObjectField.DEFAULT_FIELD_NAME]
+        ((BaseObjectField)((BaseObjectField) listField.getList().get(0)).getFields().get(0)).getFields().get(0).path() == [LIST_FIELD_NAME, TestObjectField.DEFAULT_FIELD_NAME, TestObjectField.InnerTestObjectField.DEFAULT_FIELD_NAME, StringField.DEFAULT_FIELD_NAME]
     }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/ListFieldImplTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/ListFieldImplTest.groovy
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.common.fields.base
+
+import org.codice.ddf.admin.api.fields.Field
+import org.codice.ddf.admin.common.fields.base.scalar.StringField
+import spock.lang.Specification
+
+class ListFieldImplTest extends Specification {
+
+    static final String FIELD_NAME = "testFieldName"
+
+    static final String LIST_FIELD_NAME = "listFieldName"
+
+    ListFieldImpl listField
+
+    def setup() {
+
+    }
+
+    def 'test the path of fields in listfields are the listfields path + their own'() {
+        when:
+        listField = new ListFieldImpl<>(LIST_FIELD_NAME, StringField.class)
+        def field = new StringField(FIELD_NAME)
+        listField.setValue(Collections.singletonList(field))
+
+        then:
+        listField.path() == [LIST_FIELD_NAME]
+        ((Field) listField.getList().get(0)).path() == [LIST_FIELD_NAME, StringField.DEFAULT_FIELD_NAME]
+    }
+}

--- a/query/common/src/test/java/org/codice/ddf/admin/common/fields/TestObjectField.java
+++ b/query/common/src/test/java/org/codice/ddf/admin/common/fields/TestObjectField.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.common.fields;
+
+import java.util.List;
+
+import org.codice.ddf.admin.api.fields.Field;
+import org.codice.ddf.admin.common.fields.base.BaseObjectField;
+import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+
+import com.google.common.collect.ImmutableList;
+
+public class TestObjectField extends BaseObjectField {
+
+    public static final String DEFAULT_FIELD_NAME = "testObjectField";
+
+    public static final String FIELD_TYPE_NAME = "TestObjectField";
+
+    public static final String DESCRIPTION = "TestObjectField Description";
+
+    private InnerTestObjectField testField;
+
+    public TestObjectField() {
+        this(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION, FieldBaseType.OBJECT);
+    }
+
+    public TestObjectField(String fieldName) {
+        this(fieldName, FIELD_TYPE_NAME, DESCRIPTION, FieldBaseType.OBJECT);
+    }
+
+    public TestObjectField(String fieldName, String fieldTypeName, String description,
+            FieldBaseType baseType) {
+        super(fieldName, fieldTypeName, description, baseType);
+    }
+
+    @Override
+    public List<Field> getFields() {
+        return ImmutableList.of(testField);
+    }
+
+    @Override
+    public void initializeFields() {
+        testField = new InnerTestObjectField();
+    }
+
+
+    public class InnerTestObjectField extends BaseObjectField {
+
+        public static final String DEFAULT_FIELD_NAME = "innerTestObjectField";
+
+        public static final String FIELD_TYPE_NAME = "InnerTestObjectField";
+
+        public static final String DESCRIPTION = "InnerTestObjectField Description";
+
+        StringField field;
+
+        InnerTestObjectField() {
+            this(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
+        }
+
+        InnerTestObjectField(String fieldName, String fieldTypeName, String description) {
+            super(fieldName, fieldTypeName, description);
+        }
+
+        @Override
+        public List<Field> getFields() {
+            return ImmutableList.of(field);
+        }
+
+        @Override
+        public void initializeFields() {
+            field = new StringField();
+        }
+    }
+}

--- a/query/common/src/test/java/org/codice/ddf/admin/common/fields/TestObjectField.java
+++ b/query/common/src/test/java/org/codice/ddf/admin/common/fields/TestObjectField.java
@@ -63,7 +63,7 @@ public class TestObjectField extends BaseObjectField {
 
         public static final String DESCRIPTION = "InnerTestObjectField Description";
 
-        StringField field;
+        StringField subFieldOfInnerField;
 
         InnerTestObjectField() {
             this(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
@@ -75,12 +75,12 @@ public class TestObjectField extends BaseObjectField {
 
         @Override
         public List<Field> getFields() {
-            return ImmutableList.of(field);
+            return ImmutableList.of(subFieldOfInnerField);
         }
 
         @Override
         public void initializeFields() {
-            field = new StringField();
+            subFieldOfInnerField = new StringField();
         }
     }
 }

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ClaimsMapEntry.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ClaimsMapEntry.java
@@ -36,8 +36,6 @@ public class ClaimsMapEntry extends BaseObjectField {
 
     public ClaimsMapEntry() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        claim = new StringField("claim");
-        claimValue = new StringField("claimValue");
     }
 
     public ClaimsMapEntry claim(String claim) {
@@ -67,5 +65,11 @@ public class ClaimsMapEntry extends BaseObjectField {
     @Override
     public List<Field> getFields() {
         return ImmutableList.of(claim, claimValue);
+    }
+
+    @Override
+    public void initializeFields() {
+        claim = new StringField("claim");
+        claimValue = new StringField("claimValue");
     }
 }

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ContextPolicyBin.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ContextPolicyBin.java
@@ -143,6 +143,7 @@ public class ContextPolicyBin extends BaseObjectField {
         contexts = new ListFieldImpl<>("paths", ContextPath.class);
         authTypes = new ListFieldImpl<>("authTypes", AuthType.class);
         realm = new Realm();
+        // TODO: 4/18/17 phuffer -  Replace with a MapField
         claimsMapping = new ListFieldImpl<>("claimsMapping", ClaimsMapEntry.class);
     }
 }

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ContextPolicyBin.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ContextPolicyBin.java
@@ -46,10 +46,6 @@ public class ContextPolicyBin extends BaseObjectField {
 
     public ContextPolicyBin() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        contexts = new ListFieldImpl<>("paths", ContextPath.class);
-        authTypes = new ListFieldImpl<>("authTypes", AuthType.class);
-        realm = new Realm();
-        claimsMapping = new ListFieldImpl<>("claimsMapping", ClaimsMapEntry.class);
     }
 
     public ContextPolicyBin realm(String realm) {
@@ -104,14 +100,12 @@ public class ContextPolicyBin extends BaseObjectField {
     }
 
     public ContextPolicyBin authTypes(Collection<String> authTypes) {
-        authTypes.stream()
-                .forEach(authType -> addAuthType(authType));
+        authTypes.forEach(authType -> addAuthType(authType));
         return this;
     }
 
     public ContextPolicyBin contexts(Collection<String> contexts) {
-        contexts.stream()
-                .forEach(context -> addContextPath(context));
+        contexts.forEach(context -> addContextPath(context));
         return this;
     }
 
@@ -142,5 +136,13 @@ public class ContextPolicyBin extends BaseObjectField {
     public ContextPolicyBin allFieldsRequired(boolean required) {
         super.allFieldsRequired(required);
         return this;
+    }
+
+    @Override
+    public void initializeFields() {
+        contexts = new ListFieldImpl<>("paths", ContextPath.class);
+        authTypes = new ListFieldImpl<>("authTypes", AuthType.class);
+        realm = new Realm();
+        claimsMapping = new ListFieldImpl<>("claimsMapping", ClaimsMapEntry.class);
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/LdapTestingUtils.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/LdapTestingUtils.java
@@ -108,8 +108,8 @@ public class LdapTestingUtils {
 
         try {
             BindRequest bindRequest = selectBindMethod(bindInfo.bindMethod(),
-                    bindInfo.credentials().username().getValue(),
-                    bindInfo.credentials().password().getValue(),
+                    bindInfo.credentials().username(),
+                    bindInfo.credentials().password(),
                     bindInfo.realm(),
                     null);
             connection.bind(bindRequest);

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/LdapTestingUtils.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/LdapTestingUtils.java
@@ -108,8 +108,8 @@ public class LdapTestingUtils {
 
         try {
             BindRequest bindRequest = selectBindMethod(bindInfo.bindMethod(),
-                    bindInfo.username(),
-                    bindInfo.password(),
+                    bindInfo.credentials().username().getValue(),
+                    bindInfo.credentials().password().getValue(),
                     bindInfo.realm(),
                     null);
             connection.bind(bindRequest);

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/services/LdapClaimsHandlerServiceProperties.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/services/LdapClaimsHandlerServiceProperties.java
@@ -119,8 +119,8 @@ public class LdapClaimsHandlerServiceProperties {
             boolean startTls = isStartTls(config.connectionField());
             props.put(URL, ldapUrl + config.connectionField().hostname() + ":" + config.connectionField().port());
             props.put(START_TLS, startTls);
-            props.put(LDAP_BIND_USER_DN, config.bindUserInfoField().username());
-            props.put(PASSWORD, config.bindUserInfoField().password());
+            props.put(LDAP_BIND_USER_DN, config.bindUserInfoField().credentials().username());
+            props.put(PASSWORD, config.bindUserInfoField().credentials().password());
             props.put(BIND_METHOD, config.bindUserInfoField().bindMethod());
             props.put(LOGIN_USER_ATTRIBUTE, config.settingsField().usernameAttribute());
             props.put(USER_BASE_DN, config.settingsField().baseUserDn());

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/services/LdapLoginServiceProperties.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/commons/services/LdapLoginServiceProperties.java
@@ -101,8 +101,8 @@ public class LdapLoginServiceProperties {
 
             ldapStsConfig.put(LDAP_URL, ldapUrl + config.connectionField().hostname() + ":" + config.connectionField().port());
             ldapStsConfig.put(START_TLS, Boolean.toString(startTls));
-            ldapStsConfig.put(LDAP_BIND_USER_DN, config.bindUserInfoField().username());
-            ldapStsConfig.put(LDAP_BIND_USER_PASS, config.bindUserInfoField().password());
+            ldapStsConfig.put(LDAP_BIND_USER_DN, config.bindUserInfoField().credentials().username());
+            ldapStsConfig.put(LDAP_BIND_USER_PASS, config.bindUserInfoField().credentials().password());
             ldapStsConfig.put(BIND_METHOD, config.bindUserInfoField().bindMethod());
             //        ldapStsConfig.put(KDC_ADDRESS, config.bindKdcAddress());
             ldapStsConfig.put(REALM, config.bindUserInfoField().realm());

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapQuery.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapQuery.java
@@ -74,7 +74,7 @@ public class LdapQuery extends BaseAction<ListField<MapField>> {
     public ListField<MapField> performAction() {
 
         LdapConnectionAttempt connectionAttempt = utils.bindUserToLdapConnection(conn, creds);
-        addReturnValueMessages(connectionAttempt.messages());
+        addMessages(connectionAttempt.messages());
 
         if(!connectionAttempt.connection().isPresent()) {
             return null;

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapRecommendedSettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapRecommendedSettings.java
@@ -58,7 +58,7 @@ public class LdapRecommendedSettings extends BaseAction<LdapRecommendedSettingsF
     @Override
     public LdapRecommendedSettingsField performAction() {
         LdapConnectionAttempt connectionAttempt = utils.bindUserToLdapConnection(conn, creds);
-        addReturnValueMessages(connectionAttempt.messages());
+        addMessages(connectionAttempt.messages());
         if(!connectionAttempt.connection().isPresent()) {
             return null;
         }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapTestBind.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapTestBind.java
@@ -52,7 +52,7 @@ public class LdapTestBind extends TestAction {
     @Override
     public BooleanField performAction() {
         LdapConnectionAttempt connectionAttempt = utils.bindUserToLdapConnection(conn, creds);
-        addReturnValueMessages(connectionAttempt.messages());
+        addMessages(connectionAttempt.messages());
         return new BooleanField(connectionAttempt.connection().isPresent());
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapTestConnection.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapTestConnection.java
@@ -49,7 +49,7 @@ public class LdapTestConnection extends TestAction {
     @Override
     public BooleanField performAction() {
         LdapConnectionAttempt connectionAttempt = utils.getLdapConnection(connection);
-        addReturnValueMessages(connectionAttempt.messages());
+        addMessages(connectionAttempt.messages());
         return new BooleanField(connectionAttempt.connection().isPresent());
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapTestSettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/discover/LdapTestSettings.java
@@ -71,7 +71,7 @@ public class LdapTestSettings extends TestAction {
     @Override
     public BooleanField performAction() {
         LdapConnectionAttempt connectionAttempt = utils.bindUserToLdapConnection(conn, bindInfo);
-        addReturnValueMessages(connectionAttempt.messages());
+        addMessages(connectionAttempt.messages());
 
         if (!connectionAttempt.connection()
                 .isPresent()) {

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/embedded/InstallEmbeddedLdap.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/actions/embedded/InstallEmbeddedLdap.java
@@ -83,14 +83,14 @@ public class InstallEmbeddedLdap extends BaseAction<BooleanField> {
             LOGGER.debug("Unrecognized LDAP use case \"{}\". No commits will be made. ",
                     useCase.getValue());
             // TODO: tbatie - 4/4/17 - change this to specify the arg that was unknown
-            addReturnValueMessage(new ErrorMessage("FAILED_PERSIST"));
+            addMessage(new ErrorMessage("FAILED_PERSIST"));
             return new BooleanField(false);
         }
 
         OperationReport report = configurator.commit();
 
         if(report.containsFailedResults()) {
-            addReturnValueMessage(new ErrorMessage("CANNOT_INSTALL"));
+            addMessage(new ErrorMessage("CANNOT_INSTALL"));
             return new BooleanField(false);
 
         }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapAttributeEntryField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapAttributeEntryField.java
@@ -40,8 +40,6 @@ public class LdapAttributeEntryField extends BaseObjectField {
 
     public LdapAttributeEntryField() {
         super(FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        stsClaim = new StsClaimField(STS_CLAIM);
-        userAttribute = new StringField(USER_ATTRIBUTE);
     }
 
     public LdapAttributeEntryField stsClaim(String claim) {
@@ -71,5 +69,11 @@ public class LdapAttributeEntryField extends BaseObjectField {
     public LdapAttributeEntryField allFieldsRequired(boolean required) {
         super.allFieldsRequired(required);
         return this;
+    }
+
+    @Override
+    public void initializeFields() {
+        stsClaim = new StsClaimField(STS_CLAIM);
+        userAttribute = new StringField(USER_ATTRIBUTE);
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapConfigurationField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapConfigurationField.java
@@ -42,10 +42,6 @@ public class LdapConfigurationField extends BaseObjectField {
 
     public LdapConfigurationField() {
         super(FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        this.pid = new PidField();
-        this.connection = new LdapConnectionField();
-        this.bindUserInfo = new LdapBindUserInfo();
-        this.settings = new LdapSettingsField();
     }
 
     public LdapConfigurationField connection(LdapConnectionField connection) {
@@ -97,5 +93,13 @@ public class LdapConfigurationField extends BaseObjectField {
     public LdapConfigurationField allFieldsRequired(boolean required) {
         super.allFieldsRequired(required);
         return this;
+    }
+
+    @Override
+    public void initializeFields() {
+        this.pid = new PidField();
+        this.connection = new LdapConnectionField();
+        this.bindUserInfo = new LdapBindUserInfo();
+        this.settings = new LdapSettingsField();
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapSettingsField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapSettingsField.java
@@ -55,15 +55,6 @@ public class LdapSettingsField extends BaseObjectField {
 
     public LdapSettingsField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        this.usernameAttribute = new StringField("userNameAttribute");
-        this.baseUserDn = new LdapDistinguishedName("baseUserDn");
-        this.baseGroupDn = new LdapDistinguishedName("baseGroupDn");
-        this.groupObjectClass = new StringField("groupObjectClass");
-        this.groupMembershipAttribute = new StringField("groupMembershipAttribute");
-        this.groupAttributeHoldingMember = new StringField("groupAttributeHoldingMember");
-        this.memberAttributeReferencedInGroup = new StringField("memberAttributeReferencedInGroup");
-        this.attributeMap = new ListFieldImpl<>("attributeMapping", LdapAttributeEntryField.class);
-        this.useCase = new LdapUseCase();
     }
 
     @Override
@@ -73,6 +64,7 @@ public class LdapSettingsField extends BaseObjectField {
                 groupMembershipAttribute,
                 groupAttributeHoldingMember,
                 memberAttributeReferencedInGroup,
+                attributeMap,
                 useCase);
     }
 
@@ -203,5 +195,18 @@ public class LdapSettingsField extends BaseObjectField {
     public LdapSettingsField useCase(String useCase) {
         this.useCase.setValue(useCase);
         return this;
+    }
+
+    @Override
+    public void initializeFields() {
+        this.usernameAttribute = new StringField("userNameAttribute");
+        this.baseUserDn = new LdapDistinguishedName("baseUserDn");
+        this.baseGroupDn = new LdapDistinguishedName("baseGroupDn");
+        this.groupObjectClass = new StringField("groupObjectClass");
+        this.groupMembershipAttribute = new StringField("groupMembershipAttribute");
+        this.groupAttributeHoldingMember = new StringField("groupAttributeHoldingMember");
+        this.memberAttributeReferencedInGroup = new StringField("memberAttributeReferencedInGroup");
+        this.attributeMap = new ListFieldImpl<>("attributeMapping", LdapAttributeEntryField.class);
+        this.useCase = new LdapUseCase();
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapBindUserInfo.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapBindUserInfo.java
@@ -43,12 +43,12 @@ public class LdapBindUserInfo extends BaseObjectField {
     }
 
     public LdapBindUserInfo username(String username) {
-        this.creds.username().setValue(username);
+        this.creds.username(username);
         return this;
     }
 
     public LdapBindUserInfo password(String password) {
-        this.creds.password().setValue(password);
+        this.creds.password(password);
         return this;
     }
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapBindUserInfo.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapBindUserInfo.java
@@ -20,7 +20,7 @@ import java.util.List;
 import org.codice.ddf.admin.api.action.Message;
 import org.codice.ddf.admin.api.fields.Field;
 import org.codice.ddf.admin.common.fields.base.BaseObjectField;
-import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.fields.common.CredentialsField;
 
 import com.google.common.collect.ImmutableList;
 
@@ -32,13 +32,7 @@ public class LdapBindUserInfo extends BaseObjectField {
     public static final String DESCRIPTION =
             "Contains the required information to bind a user to an LDAP connection. When the bindMethod is set to DigestMD5SASL, a realm must be provided.";
 
-    public static final String USERNAME = "username";
-
-    public static final String PASSWORD = "password";
-
-    private StringField username;
-
-    private StringField password;
+    private CredentialsField creds;
 
     private LdapBindMethod bindMethod;
 
@@ -46,19 +40,15 @@ public class LdapBindUserInfo extends BaseObjectField {
 
     public LdapBindUserInfo() {
         super(FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        this.username = new StringField(USERNAME);
-        this.password = new StringField(PASSWORD);
-        this.bindMethod = new LdapBindMethod();
-        this.realm = new LdapRealm();
     }
 
     public LdapBindUserInfo username(String username) {
-        this.username.setValue(username);
+        this.creds.username().setValue(username);
         return this;
     }
 
     public LdapBindUserInfo password(String password) {
-        this.password.setValue(password);
+        this.creds.password().setValue(password);
         return this;
     }
 
@@ -72,13 +62,8 @@ public class LdapBindUserInfo extends BaseObjectField {
         return this;
     }
 
-
-    public String username() {
-        return username.getValue();
-    }
-
-    public String password() {
-        return password.getValue();
+    public CredentialsField credentials() {
+        return creds;
     }
 
     public String bindMethod() {
@@ -98,7 +83,14 @@ public class LdapBindUserInfo extends BaseObjectField {
     }
 
     @Override
+    public void initializeFields() {
+        this.creds = new CredentialsField();
+        this.bindMethod = new LdapBindMethod();
+        this.realm = new LdapRealm();
+    }
+
+    @Override
     public List<Field> getFields() {
-        return ImmutableList.of(username, password, bindMethod, realm);
+        return ImmutableList.of(creds, bindMethod, realm);
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapConnectionField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapConnectionField.java
@@ -38,9 +38,6 @@ public class LdapConnectionField extends BaseObjectField {
 
     public LdapConnectionField() {
         super(FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        hostname = new HostnameField();
-        port = new PortField();
-        encryptionMethod = new LdapEncryptionMethodField();
     }
 
     public LdapConnectionField hostname(String hostname) {
@@ -74,5 +71,12 @@ public class LdapConnectionField extends BaseObjectField {
     @Override
     public List<Field> getFields() {
         return ImmutableList.of(hostname, port, encryptionMethod);
+    }
+
+    @Override
+    public void initializeFields() {
+        hostname = new HostnameField();
+        port = new PortField();
+        encryptionMethod = new LdapEncryptionMethodField();
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapRecommendedSettingsField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapRecommendedSettingsField.java
@@ -42,13 +42,6 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
 
     public LdapRecommendedSettingsField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        userDns = new ListFieldImpl<>("userDns", LdapDistinguishedName.class);
-        groupDns = new ListFieldImpl<>("groupsDns", LdapDistinguishedName.class);
-        userNameAttributes = new ListFieldImpl<>("userNameAttributes", StringField.class);
-        groupObjectClasses = new ListFieldImpl<>("groupObjectClasses", StringField.class);
-        groupAttributesHoldingMember = new ListFieldImpl<>("groupAttributesHoldingMember", StringField.class);
-        memberAttributesReferencedInGroup =  new ListFieldImpl<>("memberAttributesReferencedInGroup", StringField.class);
-        queryBases = new ListFieldImpl<>("queryBases", LdapDistinguishedName.class);
     }
 
     public LdapRecommendedSettingsField userDns(List<String> baseDns) {
@@ -95,5 +88,16 @@ public class LdapRecommendedSettingsField extends BaseObjectField {
     public List<Field> getFields() {
         return ImmutableList.of(userDns, groupDns, userNameAttributes, groupObjectClasses, groupAttributesHoldingMember, memberAttributesReferencedInGroup,
                 queryBases);
+    }
+
+    @Override
+    public void initializeFields() {
+        userDns = new ListFieldImpl<>("userDns", LdapDistinguishedName.class);
+        groupDns = new ListFieldImpl<>("groupsDns", LdapDistinguishedName.class);
+        userNameAttributes = new ListFieldImpl<>("userNameAttributes", StringField.class);
+        groupObjectClasses = new ListFieldImpl<>("groupObjectClasses", StringField.class);
+        groupAttributesHoldingMember = new ListFieldImpl<>("groupAttributesHoldingMember", StringField.class);
+        memberAttributesReferencedInGroup =  new ListFieldImpl<>("memberAttributesReferencedInGroup", StringField.class);
+        queryBases = new ListFieldImpl<>("queryBases", LdapDistinguishedName.class);
     }
 }

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/SourceInfoField.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/SourceInfoField.java
@@ -32,7 +32,6 @@ public class SourceInfoField extends BaseObjectField {
     private static final String DESCRIPTION =
             "Contains various information such as if the source is reachable, and the source configuration";
 
-    // TODO: tbatie - 2/27/17 - Replace with a boolean scalar once implemented
     private BooleanField isAvailable;
 
     private StringField sourceHandlerName;

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/SourceInfoField.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/SourceInfoField.java
@@ -33,11 +33,11 @@ public class SourceInfoField extends BaseObjectField {
             "Contains various information such as if the source is reachable, and the source configuration";
 
     // TODO: tbatie - 2/27/17 - Replace with a boolean scalar once implemented
-    private BooleanField isAvailable = new BooleanField("isAvailable");
+    private BooleanField isAvailable;
 
-    private StringField sourceHandlerName = new StringField("sourceHandlerName");
+    private StringField sourceHandlerName;
 
-    private SourceConfigUnionField config = new SourceConfigUnionField();
+    private SourceConfigUnionField config;
 
     public SourceInfoField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
@@ -67,5 +67,12 @@ public class SourceInfoField extends BaseObjectField {
     public SourceInfoField allFieldsRequired(boolean required) {
         super.allFieldsRequired(required);
         return this;
+    }
+
+    @Override
+    public void initializeFields() {
+        isAvailable = new BooleanField("isAvailable");
+        sourceHandlerName = new StringField("sourceHandlerName");
+        config = new SourceConfigUnionField();
     }
 }

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/type/CswSourceConfigurationField.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/type/CswSourceConfigurationField.java
@@ -27,14 +27,12 @@ public class CswSourceConfigurationField extends SourceConfigUnionField {
     public static final String DESCRIPTION =
             "Represents a CSW configuration containing properties to be saved.";
 
-    private StringField outputSchema = new StringField("outputSchema");
+    private StringField outputSchema;
 
-    private StringField forceSpatialFilter = new StringField("forceSpatialFilter");
+    private StringField forceSpatialFilter;
 
     public CswSourceConfigurationField() {
         super(FIELD_TYPE_NAME, DESCRIPTION);
-        this.endpointUrl.setValue("SampleCswUrl");
-        this.id.setValue("SampleCswId");
     }
 
     public CswSourceConfigurationField outputSchema(String outputSchema) {
@@ -65,5 +63,12 @@ public class CswSourceConfigurationField extends SourceConfigUnionField {
     public CswSourceConfigurationField innerFieldRequired(boolean required, String fieldName) {
         super.innerFieldRequired(required, fieldName);
         return this;
+    }
+
+    @Override
+    public void initializeFields() {
+        super.initializeFields();
+        outputSchema = new StringField("outputSchema");
+        forceSpatialFilter = new StringField("forceSpatialFilter");
     }
 }

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/type/SourceConfigUnionField.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/type/SourceConfigUnionField.java
@@ -38,13 +38,13 @@ public class SourceConfigUnionField extends BaseUnionField {
                     new WfsSourceConfigurationField(),
                     new OpensearchSourceConfigurationField());
 
-    protected PidField id = new PidField();
+    protected PidField id;
 
-    protected StringField sourceName = new StringField("sourceName");
+    protected StringField sourceName;
 
-    protected UrlField endpointUrl = new UrlField("endpointUrl");
+    protected UrlField endpointUrl;
 
-    protected CredentialsField creds = new CredentialsField();
+    protected CredentialsField creds;
 
     public SourceConfigUnionField() {
         super(FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION, UNION_TYPES, false);
@@ -78,5 +78,13 @@ public class SourceConfigUnionField extends BaseUnionField {
     @Override
     public List<Field> getFields() {
         return ImmutableList.of(id, sourceName, endpointUrl, creds);
+    }
+
+    @Override
+    public void initializeFields() {
+        id = new PidField();
+        sourceName = new StringField("sourceName");
+        endpointUrl = new UrlField("endpointUrl");
+        creds = new CredentialsField();
     }
 }

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/type/WfsSourceConfigurationField.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/fields/type/WfsSourceConfigurationField.java
@@ -26,8 +26,6 @@ public class WfsSourceConfigurationField extends SourceConfigUnionField {
 
     public WfsSourceConfigurationField() {
         super(FIELD_TYPE_NAME, DESCRIPTION);
-        this.endpointUrl.setValue("SampleWfsUrl");
-        this.id.setValue("SampleWfsId");
     }
 
     @Override

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/actions/persist/SaveCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/actions/persist/SaveCswConfiguration.java
@@ -51,7 +51,7 @@ public class SaveCswConfiguration extends BaseAction<SourceInfoField> {
 
     @Override
     public SourceInfoField performAction() {
-        addReturnValueMessage(new ErrorMessage("SAVE_CSW_CONFIG_ERROR"));
+        addMessage(new ErrorMessage("SAVE_CSW_CONFIG_ERROR"));
         return SAMPLE_CSW_SOURCE_INFO;
     }
 }


### PR DESCRIPTION
#### What does this PR do?
- Adds a path to `Field`s which is defined as a list of `Field`s. This is intended to locate a `Field` when it is nested in any amount of `ObjectField`s.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@adimka @coyotesqrl @tbatie 

#### How should this be tested? (List steps with links to updated documentation)
Full build.
Start up Admin Console Beta and persist some configurations (LdapConfigurations work). The best way may be to debug and ensure that calling the `.path()` method on any Field returns the correct path.

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
