### PR TITLE
DDF-2773: Add getServiceReferences to ConfigReader interface

### DIFF
--- a/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfigReader.java
+++ b/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfigReader.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.configurator;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Map;
 
 /**
@@ -75,4 +76,16 @@ public interface ConfigReader {
      * @throws ConfiguratorException if any errors occur
      */
     <S> S getServiceReference(Class<S> serviceClass) throws ConfiguratorException;
+
+    /**
+     * Retrieves the services. The services should only be used for reading purposes,
+     * any changes should be done through a commit
+     *
+     * @param <S> service interface
+     * @param serviceClass Class of service to retrieve
+     * @param filter the filter expression or {@code null} for all services, null returns all services
+     * @return list of services of the serviceClass
+     * @throws ConfiguratorException if any errors occur
+     */
+    <S> Collection<S> getServices(Class<S> serviceClass, String filter) throws ConfiguratorException;
 }

--- a/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfigReader.java
+++ b/configurator/configurator-api/src/main/java/org/codice/ddf/admin/configurator/ConfigReader.java
@@ -14,8 +14,8 @@
 package org.codice.ddf.admin.configurator;
 
 import java.nio.file.Path;
-import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Provides reader methods to system configuration items.
@@ -84,8 +84,8 @@ public interface ConfigReader {
      * @param <S> service interface
      * @param serviceClass Class of service to retrieve
      * @param filter the filter expression or {@code null} for all services, null returns all services
-     * @return list of services of the serviceClass
+     * @return a set of services of the serviceClass
      * @throws ConfiguratorException if any errors occur
      */
-    <S> Collection<S> getServices(Class<S> serviceClass, String filter) throws ConfiguratorException;
+    <S> Set<S> getServices(Class<S> serviceClass, String filter) throws ConfiguratorException;
 }

--- a/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorImpl.java
+++ b/configurator/configurator-impl/src/main/java/org/codice/ddf/admin/configurator/impl/ConfiguratorImpl.java
@@ -20,14 +20,13 @@ import static org.codice.ddf.admin.configurator.impl.ConfigValidator.validateStr
 import java.lang.management.ManagementFactory;
 import java.nio.file.Path;
 import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import javax.management.MBeanServerInvocationHandler;
 import javax.management.MalformedObjectNameException;
@@ -358,16 +357,14 @@ public class ConfiguratorImpl implements Configurator, ConfigReader {
     }
 
     @Override
-    public <S> Collection<S> getServices(Class<S> serviceClass, String filter)
+    public <S> Set<S> getServices(Class<S> serviceClass, String filter)
             throws ConfiguratorException {
         BundleContext context = getBundleContext();
-
         try {
-            Collection<ServiceReference<S>> refs = context.getServiceReferences(serviceClass, filter);
-
-            List<S> services = new ArrayList<>();
-            refs.forEach(ref -> services.add(context.getService(ref)));
-            return services;
+            return context.getServiceReferences(serviceClass, filter)
+                    .stream()
+                    .map(context::getService)
+                    .collect(Collectors.toSet());
         } catch (InvalidSyntaxException e) {
             LOGGER.debug("Invalid filter [{}].", filter, e);
             throw new ConfiguratorException(String.format("Received invalid filter [%s]", filter));


### PR DESCRIPTION
#### What does this PR do?
Adds a `getServices` method to the ConfigReader interface.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @tbatie 

#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?
We need to be able to get a list of services.

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
