### PR TITLE
DDF-2773 Disables OBR repository for the maven-bundle-plugin to speed up builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,8 @@
                     <version>3.2.0</version>
                     <extensions>true</extensions>
                     <configuration>
+                        <!-- Disabled OBR to increase build speed -->
+                        <obrRepository>NONE</obrRepository>
                         <instructions>
                             <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         </instructions>


### PR DESCRIPTION
#### What does this PR do?
Disable the processing of the `repository.xml` file beneath Maven used by the maven bundle plugin.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@garrettfreibott @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)
Travis build is sufficient

#### Any background context you want to provide?
This improvement has been made to DDF and Alliance repositories already.

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
