### PR TITLE
DDF-2825 Reenables unit tests

### DIFF
--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseFunctionField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseFunctionField.java
@@ -107,7 +107,7 @@ public abstract class BaseFunctionField<T extends DataType> extends BaseField<Ma
     }
 
     protected BaseFunctionField addArgumentMessages(List<Message> msgs) {
-        msgs.forEach(msg -> addArgumentMessage(msg));
+        msgs.forEach(this::addArgumentMessage);
         return this;
     }
 

--- a/query/security/wcpm/pom.xml
+++ b/query/security/wcpm/pom.xml
@@ -87,17 +87,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.69</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.67</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/query/sources/impl/pom.xml
+++ b/query/sources/impl/pom.xml
@@ -160,17 +160,17 @@
                                         <limit>
                                             <counter>INSTRUCTION</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.62</minimum>
                                         </limit>
                                         <limit>
                                             <counter>BRANCH</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.53</minimum>
                                         </limit>
                                         <limit>
                                             <counter>COMPLEXITY</counter>
                                             <value>COVEREDRATIO</value>
-                                            <minimum>0.00</minimum>
+                                            <minimum>0.58</minimum>
                                         </limit>
                                     </limits>
                                 </rule>

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/CswFieldProviderTest.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/CswFieldProviderTest.groovy
@@ -14,7 +14,10 @@
 package org.codice.ddf.admin.sources.csw
 
 import org.codice.ddf.admin.api.FieldProvider
-import spock.lang.Ignore
+import org.codice.ddf.admin.configurator.ConfiguratorFactory
+import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions
+import org.codice.ddf.internal.admin.configurator.actions.ServiceActions
+import org.codice.ddf.internal.admin.configurator.actions.ServiceReader
 import spock.lang.Specification
 
 class CswFieldProviderTest extends Specification {
@@ -22,10 +25,12 @@ class CswFieldProviderTest extends Specification {
     CswFieldProvider cswFieldProvider
 
     def setup() {
-        cswFieldProvider = new CswFieldProvider()
+        cswFieldProvider = new CswFieldProvider(Mock(ConfiguratorFactory),
+                Mock(ServiceActions),
+                Mock(ManagedServiceActions),
+                Mock(ServiceReader))
     }
 
-    @Ignore
     def 'Verify discovery fields immutability'() {
         when:
         cswFieldProvider.getDiscoveryFields().add(Mock(FieldProvider))
@@ -34,7 +39,6 @@ class CswFieldProviderTest extends Specification {
         thrown(UnsupportedOperationException)
     }
 
-    @Ignore
     def 'Verify persist functions immutability'() {
         when:
         cswFieldProvider.getMutationFunctions().add(Mock(FieldProvider))

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/OpenSearchFieldProviderTest.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/OpenSearchFieldProviderTest.groovy
@@ -14,7 +14,10 @@
 package org.codice.ddf.admin.sources.opensearch
 
 import org.codice.ddf.admin.api.FieldProvider
-import spock.lang.Ignore
+import org.codice.ddf.admin.configurator.ConfiguratorFactory
+import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions
+import org.codice.ddf.internal.admin.configurator.actions.ServiceActions
+import org.codice.ddf.internal.admin.configurator.actions.ServiceReader
 import spock.lang.Specification
 
 class OpenSearchFieldProviderTest extends Specification {
@@ -22,10 +25,12 @@ class OpenSearchFieldProviderTest extends Specification {
     OpenSearchFieldProvider openSearchFieldProvider
 
     def setup() {
-        openSearchFieldProvider = new OpenSearchFieldProvider()
+        openSearchFieldProvider = new OpenSearchFieldProvider(Mock(ConfiguratorFactory),
+                Mock(ServiceActions),
+                Mock(ManagedServiceActions),
+                Mock(ServiceReader))
     }
 
-    @Ignore
     def 'Verify discovery fields immutability'() {
         when:
         openSearchFieldProvider.getDiscoveryFields().add(Mock(FieldProvider))
@@ -34,7 +39,6 @@ class OpenSearchFieldProviderTest extends Specification {
         thrown(UnsupportedOperationException)
     }
 
-    @Ignore
     def 'Verify persist functions immutability'() {
         when:
         openSearchFieldProvider.getMutationFunctions().add(Mock(FieldProvider))

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/WfsFieldProviderTest.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/WfsFieldProviderTest.groovy
@@ -14,7 +14,10 @@
 package org.codice.ddf.admin.sources.wfs
 
 import org.codice.ddf.admin.api.FieldProvider
-import spock.lang.Ignore
+import org.codice.ddf.admin.configurator.ConfiguratorFactory
+import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions
+import org.codice.ddf.internal.admin.configurator.actions.ServiceActions
+import org.codice.ddf.internal.admin.configurator.actions.ServiceReader
 import spock.lang.Specification
 
 class WfsFieldProviderTest extends Specification {
@@ -22,10 +25,12 @@ class WfsFieldProviderTest extends Specification {
     WfsFieldProvider wfsFieldProvider
 
     def setup() {
-        wfsFieldProvider = new WfsFieldProvider()
+        wfsFieldProvider = new WfsFieldProvider(Mock(ConfiguratorFactory),
+                Mock(ServiceActions),
+                Mock(ManagedServiceActions),
+                Mock(ServiceReader))
     }
 
-    @Ignore
     def 'Verify discovery fields immutability'() {
         when:
         wfsFieldProvider.getDiscoveryFields().add(Mock(FieldProvider))
@@ -34,7 +39,6 @@ class WfsFieldProviderTest extends Specification {
         thrown(UnsupportedOperationException)
     }
 
-    @Ignore
     def 'Verify persist functions immutability'() {
         when:
         wfsFieldProvider.getMutationFunctions().add(Mock(FieldProvider))


### PR DESCRIPTION
#### What does this PR do?
Reenables tests that had been ignored as part of the configurator refactor.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@peterhuffer @garrettfreibott 

#### How should this be tested? (List steps with links to updated documentation)
Full CI run is sufficient

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2825](https://codice.atlassian.net/browse/DDF-2825)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [ ] Documentation Updated
- [X] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
