### PR TITLE
Validating the LDAP user attributes in directory settings and claims mapping

### DIFF
--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapMessages.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapMessages.java
@@ -39,6 +39,8 @@ public class LdapMessages {
 
     public static final String USER_ATTRIBUTE_NOT_FOUND = "USER_ATTRIBUTE_NOT_FOUND";
 
+    public static final String INVALID_USER_ATTRIBUTE = "INVALID_USER_ATTRIBUTE";
+
     public static ErrorMessage invalidDnFormatError(List<String> path) {
         return new ErrorMessageImpl(INVALID_DN, path);
     }
@@ -73,6 +75,10 @@ public class LdapMessages {
 
     public static ErrorMessage md5NeedsEncryptedError(List<String> path) {
         return new ErrorMessageImpl(MD5_NEEDS_ENCRYPTED, path);
+    }
+
+    public static ErrorMessage invalidUserAttribute(List<String> path) {
+        return new ErrorMessageImpl(INVALID_USER_ATTRIBUTE, path);
     }
 
     static ErrorMessage cannotBindError(List<String> path) {

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
+import org.codice.ddf.admin.ldap.fields.LdapAttributeName;
 import org.codice.ddf.admin.ldap.fields.LdapDistinguishedName;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
 import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField;
@@ -59,7 +60,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
     private LdapBindUserInfo bindInfo;
 
-    private StringField usernameAttribute;
+    private LdapAttributeName usernameAttribute;
 
     private LdapDistinguishedName baseUserDn;
 
@@ -75,7 +76,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
         conn = new LdapConnectionField().useDefaultRequired();
         bindInfo = new LdapBindUserInfo().useDefaultRequired();
-        usernameAttribute = new StringField(USER_NAME_ATTRIBUTE).isRequired(true);
+        usernameAttribute = new LdapAttributeName(USER_NAME_ATTRIBUTE).isRequired(true);
         baseUserDn = new LdapDistinguishedName(BASE_USER_DN);
         baseUserDn.isRequired(true);
         claimMappings = new ClaimsMapEntry.ListImpl();
@@ -114,6 +115,14 @@ public class LdapTestClaimMappings extends TestFunctionField {
         addMessages(SecurityValidation.validateStsClaimsExist(claimArgs,
                 serviceActions,
                 stsServiceProperties));
+
+        // TODO: 7/7/17 - tbatie - Currently the ClaimsMapEntry contains a StringField as a value. It really should be a LdapAttributeName. Fix this once there is a generic way to create MapField objects that contain different value field.
+
+        claimMappings.getList()
+                .stream()
+                .map(ClaimsMapEntry::claimValueField)
+                .map(claim -> LdapAttributeName.validate(claim.getValue(), claim.path()))
+                .forEach(this::addArgumentMessages);
     }
 
     @Override

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapAttributeName.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapAttributeName.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.ldap.fields;
+
+import static org.codice.ddf.admin.ldap.commons.LdapMessages.invalidUserAttribute;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+import org.codice.ddf.admin.api.report.ErrorMessage;
+import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+
+/**
+ * The description of an attribute names and the logic for validating them are defined in RFC 4512.
+ * @see <a href="https://www.ietf.org/rfc/rfc4512.txt"> RFC 4512 </a>
+ */
+
+public class LdapAttributeName extends StringField {
+
+    public static final String DEFAULT_FIELD_NAME = "attriName";
+
+    public static final String FIELD_TYPE_NAME = "LdapAttributeName";
+
+    public static final String DESCRIPTION =
+            "The short descriptive name of an LDAP attribute as defined in RFC4512.";
+
+    private static final Pattern ATTRIBUTE_NAME_PATTERN =
+            Pattern.compile("^[a-zA-Z][a-zA-Z0-9-]*$");
+
+    public LdapAttributeName() {
+        super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
+    }
+
+    public LdapAttributeName(String fieldName) {
+        super(fieldName, FIELD_TYPE_NAME, DESCRIPTION);
+    }
+
+    @Override
+    public List<ErrorMessage> validate() {
+        List<ErrorMessage> errors = super.validate();
+        if (!errors.isEmpty()) {
+            return errors;
+        }
+
+        if (getValue() != null) {
+            errors.addAll(validate(getValue(), path()));
+        }
+        return errors;
+    }
+
+    // TODO: 7/7/17 - tbatie - This validate should be reformatted once there is a generic way to create MapField objects that contain different value field.
+    public static List<ErrorMessage> validate(String attribute, List<String> path) {
+        List<ErrorMessage> errors = new ArrayList<>();
+
+        if (!ATTRIBUTE_NAME_PATTERN.matcher(attribute)
+                .matches()) {
+            errors.add(invalidUserAttribute(path));
+        }
+        return errors;
+    }
+
+    @Override
+    public LdapAttributeName isRequired(boolean required) {
+        super.isRequired(required);
+        return this;
+    }
+}

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapDirectorySettingsField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/config/LdapDirectorySettingsField.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.common.fields.base.BaseObjectField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.ldap.fields.LdapAttributeName;
 import org.codice.ddf.admin.ldap.fields.LdapDistinguishedName;
 import org.codice.ddf.admin.security.common.fields.ldap.LdapUseCase;
 
@@ -41,9 +42,10 @@ public class LdapDirectorySettingsField extends BaseObjectField {
 
     public static final String GROUP_ATTRIBUTE_HOLDING_MEMBER = "groupAttributeHoldingMember";
 
-    public static final String MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP = "memberAttributeReferencedInGroup";
+    public static final String MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP =
+            "memberAttributeReferencedInGroup";
 
-    private StringField usernameAttribute;
+    private LdapAttributeName usernameAttribute;
 
     private LdapDistinguishedName baseUserDn;
 
@@ -51,21 +53,22 @@ public class LdapDirectorySettingsField extends BaseObjectField {
 
     private StringField groupObjectClass;
 
-    private StringField groupAttributeHoldingMember;
+    private LdapAttributeName groupAttributeHoldingMember;
 
-    private StringField memberAttributeReferencedInGroup;
+    private LdapAttributeName memberAttributeReferencedInGroup;
 
     private LdapUseCase useCase;
 
     public LdapDirectorySettingsField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
 
-        this.usernameAttribute = new StringField(USER_NAME_ATTRIBUTE);
+        this.usernameAttribute = new LdapAttributeName(USER_NAME_ATTRIBUTE);
         this.baseUserDn = new LdapDistinguishedName(BASE_USER_DN);
         this.baseGroupDn = new LdapDistinguishedName(BASE_GROUP_DN);
         this.groupObjectClass = new StringField(GROUP_OBJECT_CLASS);
-        this.groupAttributeHoldingMember = new StringField(GROUP_ATTRIBUTE_HOLDING_MEMBER);
-        this.memberAttributeReferencedInGroup = new StringField(MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP);
+        this.groupAttributeHoldingMember = new LdapAttributeName(GROUP_ATTRIBUTE_HOLDING_MEMBER);
+        this.memberAttributeReferencedInGroup = new LdapAttributeName(
+                MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP);
         this.useCase = new LdapUseCase();
 
         updateInnerFieldPaths();
@@ -83,7 +86,7 @@ public class LdapDirectorySettingsField extends BaseObjectField {
     }
 
     //Field getters
-    public StringField usernameAttributeField() {
+    public LdapAttributeName usernameAttributeField() {
         return usernameAttribute;
     }
 
@@ -103,11 +106,11 @@ public class LdapDirectorySettingsField extends BaseObjectField {
         return groupObjectClass;
     }
 
-    public StringField groupAttributeHoldingMemberField() {
+    public LdapAttributeName groupAttributeHoldingMemberField() {
         return groupAttributeHoldingMember;
     }
 
-    public StringField memberAttributeReferencedInGroupField() {
+    public LdapAttributeName memberAttributeReferencedInGroupField() {
         return memberAttributeReferencedInGroup;
     }
 

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapAttributeNameSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapAttributeNameSpec.groovy
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.ldap.discover
+
+import org.codice.ddf.admin.ldap.commons.LdapMessages
+import org.codice.ddf.admin.ldap.fields.LdapAttributeName
+import spock.lang.Specification
+
+class LdapAttributeNameSpec extends Specification {
+    LdapAttributeName ldapAttributeName
+
+    def setup() {
+        ldapAttributeName = new LdapAttributeName()
+    }
+
+    def 'Valid attribute names'() {
+        setup:
+        ldapAttributeName.setValue(attribute)
+
+        expect:
+        ldapAttributeName.validate().isEmpty()
+
+        where:
+        attribute << ['correctFormat',
+                'ItIs2017',
+                'lettersAnd1234',
+                'correct-format',
+                'still-correct-2015',
+                'can-end-with-dash-',
+                'CanStartWithUpperCase'
+        ]
+    }
+
+    def 'Invalid attribute names'() {
+        setup:
+        ldapAttributeName.setValue(attribute)
+
+        when:
+        def errors = ldapAttributeName.validate()
+
+        then:
+        errors.size() == 1
+        errors[0].getCode() == LdapMessages.INVALID_USER_ATTRIBUTE;
+        errors[0].getPath() == [LdapAttributeName.DEFAULT_FIELD_NAME]
+
+        where:
+        attribute << ['no space',
+                '-can-not-start-with-dash',
+                'speci@! c&@r@cters',
+                'no.dots.or_underscores',
+                '2017'
+        ]
+    }
+}

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
@@ -22,11 +22,11 @@ import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.ldap.TestLdapServer
 import org.codice.ddf.admin.ldap.commons.LdapMessages
 import org.codice.ddf.admin.ldap.fields.config.LdapDirectorySettingsField
-import org.codice.ddf.admin.security.common.fields.ldap.LdapUseCase
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindMethod
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo
 import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField
 import org.codice.ddf.admin.ldap.fields.connection.LdapEncryptionMethodField
+import org.codice.ddf.admin.security.common.fields.ldap.LdapUseCase
 import spock.lang.Specification
 
 import static org.codice.ddf.admin.ldap.LdapTestingCommons.*
@@ -56,21 +56,24 @@ class LdapTestDirectorySettingsSpec extends Specification {
 
         // Initialize bad paths
         baseMsg = [LdapTestDirectorySettings.FIELD_NAME, FunctionField.ARGUMENT]
-        badPaths = [missingHostPath        : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, HostnameField.DEFAULT_FIELD_NAME],
-                    missingPortPath        : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, PortField.DEFAULT_FIELD_NAME],
-                    missingEncryptPath     : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, LdapEncryptionMethodField.DEFAULT_FIELD_NAME],
-                    missingUsernamePath    : baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.USERNAME_FIELD_NAME],
-                    missingUserpasswordPath: baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.PASSWORD_FIELD_NAME],
-                    missingBindMethodPath  : baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, LdapBindMethod.DEFAULT_FIELD_NAME],
-                    missingUseCasePath     : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapUseCase.DEFAULT_FIELD_NAME],
-                    missingUserPath        : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_USER_DN],
-                    missingGroupPath       : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_GROUP_DN],
-                    missingUserNameAttrPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.USER_NAME_ATTRIBUTE],
-                    missingGroupObjectPath : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_OBJECT_CLASS],
-                    missingGroupAttribPath : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_ATTRIBUTE_HOLDING_MEMBER],
-                    missingMemberAttribPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP],
-                    badUserDnPath          : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_USER_DN],
-                    badGroupDnPath         : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_GROUP_DN]
+        badPaths = [missingHostPath            : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, HostnameField.DEFAULT_FIELD_NAME],
+                    missingPortPath            : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, PortField.DEFAULT_FIELD_NAME],
+                    missingEncryptPath         : baseMsg + [LdapConnectionField.DEFAULT_FIELD_NAME, LdapEncryptionMethodField.DEFAULT_FIELD_NAME],
+                    missingUsernamePath        : baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.USERNAME_FIELD_NAME],
+                    missingUserpasswordPath    : baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.PASSWORD_FIELD_NAME],
+                    missingBindMethodPath      : baseMsg + [LdapBindUserInfo.DEFAULT_FIELD_NAME, LdapBindMethod.DEFAULT_FIELD_NAME],
+                    missingUseCasePath         : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapUseCase.DEFAULT_FIELD_NAME],
+                    missingUserPath            : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_USER_DN],
+                    missingGroupPath           : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_GROUP_DN],
+                    missingUserNameAttrPath    : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.USER_NAME_ATTRIBUTE],
+                    missingGroupObjectPath     : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_OBJECT_CLASS],
+                    missingGroupAttribPath     : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_ATTRIBUTE_HOLDING_MEMBER],
+                    missingMemberAttribPath    : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP],
+                    badUserDnPath              : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_USER_DN],
+                    badGroupDnPath             : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.BASE_GROUP_DN],
+                    badUserNameAttribFormatPath: baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.USER_NAME_ATTRIBUTE],
+                    badGroupAttribFormatPath   : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.GROUP_ATTRIBUTE_HOLDING_MEMBER],
+                    badMemberAttribFormatPath  : baseMsg + [LdapDirectorySettingsField.DEFAULT_FIELD_NAME, LdapDirectorySettingsField.MEMBER_ATTRIBUTE_REFERENCED_IN_GROUP]
         ]
     }
 
@@ -285,6 +288,75 @@ class LdapTestDirectorySettingsSpec extends Specification {
 
         report.messages()*.getPath() as Set == [badPaths.badUserDnPath,
                                                 badPaths.missingUserNameAttrPath] as Set
+    }
+
+    def 'fail when the usernameAttribute format is incorrect'() {
+        setup:
+        def ldapSettings = initLdapSettings(ATTRIBUTE_STORE, true)
+                .usernameAttribute("space & speci@l ch@r@cters")
+
+        args = [(LdapConnectionField.DEFAULT_FIELD_NAME)       : noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)          : simpleBindInfo().getValue(),
+                (LdapDirectorySettingsField.DEFAULT_FIELD_NAME): ldapSettings.getValue()]
+        action.setValue(args)
+        action.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
+
+        when:
+        FunctionReport report = action.getValue()
+
+        then:
+        report.argumentMessages().size() == 1
+        report.messages().count {
+            it.getCode() == LdapMessages.INVALID_USER_ATTRIBUTE
+        } == 1
+
+        report.messages()*.getPath() as Set == [badPaths.badUserNameAttribFormatPath] as Set
+    }
+
+    def 'fail when the groupAttributeHoldingMember format is incorrect'() {
+        setup:
+        def ldapSettings = initLdapSettings(ATTRIBUTE_STORE, true)
+                .groupAttributeHoldingMember("sp&ci@!Ch@r@cters")
+
+        args = [(LdapConnectionField.DEFAULT_FIELD_NAME)       : noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)          : simpleBindInfo().getValue(),
+                (LdapDirectorySettingsField.DEFAULT_FIELD_NAME): ldapSettings.getValue()]
+        action.setValue(args)
+        action.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
+
+        when:
+        FunctionReport report = action.getValue()
+
+        then:
+        report.argumentMessages().size() == 1
+        report.messages().count {
+            it.getCode() == LdapMessages.INVALID_USER_ATTRIBUTE
+        } == 1
+
+        report.messages()*.getPath() as Set == [badPaths.badGroupAttribFormatPath] as Set
+    }
+
+    def 'fail when the memberAttributeReferencedInGroup format is incorrect'() {
+        setup:
+        def ldapSettings = initLdapSettings(ATTRIBUTE_STORE, true)
+                .memberAttributeReferencedInGroup("space with sp&ci@! ch@r@cters")
+
+        args = [(LdapConnectionField.DEFAULT_FIELD_NAME)       : noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)          : simpleBindInfo().getValue(),
+                (LdapDirectorySettingsField.DEFAULT_FIELD_NAME): ldapSettings.getValue()]
+        action.setValue(args)
+        action.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
+
+        when:
+        FunctionReport report = action.getValue()
+
+        then:
+        report.argumentMessages().size() == 1
+        report.messages().count {
+            it.getCode() == LdapMessages.INVALID_USER_ATTRIBUTE
+        } == 1
+
+        report.messages()*.getPath() as Set == [badPaths.badMemberAttribFormatPath] as Set
     }
 
     def 'succeed'() {

--- a/ui/src/main/webapp/lib/graphql-errors/index.js
+++ b/ui/src/main/webapp/lib/graphql-errors/index.js
@@ -23,7 +23,8 @@ const friendlyMessage = {
   NO_GROUPS_IN_BASE_GROUP_DN: 'Could not find any groups in the base group dn.',
   NO_GROUPS_WITH_MEMBERS: 'No groups were found containing any members.',
   NO_REFERENCED_MEMBER: 'Unable to find a user with the member attribute specified for groups.',
-  USER_ATTRIBUTE_NOT_FOUND: 'Could not find attribute on any users.'
+  USER_ATTRIBUTE_NOT_FOUND: 'Could not find attribute on any users.',
+  INVALID_USER_ATTRIBUTE: 'Invalid LDAP user attribute.'
 }
 
 export const genericMessage = (code) => `There was a problem with the request to the server: ${code}`

--- a/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/attribute-mapping.js
@@ -133,7 +133,7 @@ const testClaimMappings = (conn, info, userNameAttribute, dn, mapping) => ({
     query TestClaimMappings(
       $conn: LdapConnection!,
       $info: BindUserInfo!,
-      $userNameAttribute: String!,
+      $userNameAttribute: LdapAttributeName!,
       $dn: DistinguishedName!
       $mapping: [ClaimsMapEntry]!
     ) {


### PR DESCRIPTION
#### What does this PR do?
It validates user LDAP attributes and trows a USER_ATTRIBUTE_WRONG_FORMAT error instead of the Internal Error it use to display.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @peterhuffer @tbatie @djblue 

#### How should this be tested?
There are tests that were added and it can also be tested manually by going through the LDAP wizard.

#### Any background context you want to provide?
The format of the attributes is based on RFC4519 and a manual test done before any changes were made.

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests