### PR TITLE
DDF-2773 Forces MD5 bindings to be over encrypted (LDAPS/startTLS) connections

### DIFF
--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapMessages.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapMessages.java
@@ -19,6 +19,7 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.report.message.ErrorMessageImpl;
 
 public class LdapMessages {
+    public static final String MD5_NEEDS_ENCRYPTED = "MD5_NEEDS_ENCRYPTED";
 
     public static final String CANNOT_BIND = "CANNOT_BIND";
 
@@ -68,6 +69,10 @@ public class LdapMessages {
 
     public static ErrorMessage userAttributeNotFoundError(List<String> path) {
         return new ErrorMessageImpl(USER_ATTRIBUTE_NOT_FOUND, path);
+    }
+
+    public static ErrorMessage md5NeedsEncryptedError(List<String> path) {
+        return new ErrorMessageImpl(MD5_NEEDS_ENCRYPTED, path);
     }
 
     static ErrorMessage cannotBindError(List<String> path) {

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
@@ -13,6 +13,11 @@
  **/
 package org.codice.ddf.admin.ldap.discover;
 
+import static org.codice.ddf.admin.ldap.commons.LdapMessages.md5NeedsEncryptedError;
+import static org.codice.ddf.admin.ldap.fields.connection.LdapBindMethod.DigestMd5Sasl.DIGEST_MD5_SASL;
+import static org.codice.ddf.admin.ldap.fields.connection.LdapEncryptionMethodField.LdapsEncryption.LDAPS;
+import static org.codice.ddf.admin.ldap.fields.connection.LdapEncryptionMethodField.StartTlsEncryption.START_TLS;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -72,6 +77,24 @@ public class LdapTestBind extends TestFunctionField {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new LdapTestBind();
+    }
+
+    @Override
+    public void validate() {
+        super.validate();
+
+        if (containsErrorMsgs()) {
+            return;
+        }
+
+        if (DIGEST_MD5_SASL.equals(creds.bindMethod())) {
+            // To use MD5, we require an encrypted connection
+            if (!(START_TLS.equals(conn.encryptionMethod()) //
+                    || LDAPS.equals(conn.encryptionMethod()))) {
+                addArgumentMessage(md5NeedsEncryptedError(creds.bindMethodField()
+                        .path()));
+            }
+        }
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapBindUserInfo.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/connection/LdapBindUserInfo.java
@@ -71,6 +71,10 @@ public class LdapBindUserInfo extends BaseObjectField {
         return creds;
     }
 
+    public LdapBindMethod bindMethodField() {
+        return bindMethod;
+    }
+
     // Value getters
     public String bindMethod() {
         return bindMethod.getValue();

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestBindSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestBindSpec.groovy
@@ -133,20 +133,20 @@ class LdapTestBindSpec extends Specification {
         report.result().getValue()
     }
 
-    @Ignore
-    // TODO: tbatie - 5/4/17 - Need to make in memory ldap support DigestMD5
-    def 'Successfully bind user with no encryption using bind method "DigestMD5SASL"'() {
+    def 'Fail to bind user with no encryption using bind method "DigestMD5SASL"'() {
         setup:
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().getValue(),
-                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().getValue()]
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : digestBindInfo().getValue()]
         ldapBindFunction.setValue(args)
 
         when:
         FunctionReport report = ldapBindFunction.getValue()
 
         then:
-        report.messages().empty
-        report.result().getValue()
+        report.messages().size() == 1
+        report.messages().get(0).getCode() == LdapMessages.MD5_NEEDS_ENCRYPTED
+        report.messages().get(0).getPath() == [LdapTestBind.FIELD_NAME, FunctionField.ARGUMENT,
+                                               LdapBindUserInfo.DEFAULT_FIELD_NAME, LdapBindMethod.DEFAULT_FIELD_NAME]
     }
 
     @Ignore
@@ -154,7 +154,7 @@ class LdapTestBindSpec extends Specification {
     def 'Successfully bind user with LDAPS encryption using bind method "DigestMD5SASL"'() {
         setup:
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME): ldapsLdapConnectionInfo().getValue(),
-                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().getValue()]
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : digestBindInfo().getValue()]
         ldapBindFunction.setValue(args)
         ldapBindFunction.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
 
@@ -166,12 +166,14 @@ class LdapTestBindSpec extends Specification {
         report.result().getValue()
     }
 
-
+    @Ignore
+    // TODO RAP 10 Jul 17: Need o make in-memory ldap support DigestMD5
     def 'Fail to bind user using bind method "DigestMD5SASL" with bad realm'() {
         setup:
         args = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().getValue(),
                 (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : digestBindInfo().getValue()]
         ldapBindFunction.setValue(args)
+        ldapBindFunction.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
 
         when:
         FunctionReport report = ldapBindFunction.getValue()

--- a/ui/src/main/webapp/lib/graphql-errors/index.js
+++ b/ui/src/main/webapp/lib/graphql-errors/index.js
@@ -16,6 +16,7 @@ const friendlyMessage = {
   NO_EXISTING_CONFIG: 'The configuration does not exist on the server.',
   INVALID_URI_ERROR: 'Invalid URI.',
   UNAUTHORIZED: 'Unauthorized. A valid username & password may be required to connect.',
+  MD5_NEEDS_ENCRYPTED: 'Cannot bind using MD5 over an unencrypted connection.',
   CANNOT_BIND: 'Cannot authenticate user.',
   INVALID_DN: 'The distinguished name has an invalid format.',
   INVALID_QUERY: 'The provided query is invalid.',


### PR DESCRIPTION
#### What does this PR do?
Limits MD5 to be over encrypted LDAP connections.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)
Install KAR and then attempt to create an MD5 binding over an unencrypted LDAP connection. It should fail to pass.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
