### PR TITLE
DDF-2773 Adds a utility ConfiguratorSuite service.

### DIFF
--- a/query/api/pom.xml
+++ b/query/api/pom.xml
@@ -26,6 +26,19 @@
     <artifactId>admin-query-api</artifactId>
     <packaging>bundle</packaging>
 
+    <dependencies>
+        <dependency>
+            <groupId>ddf.admin</groupId>
+            <artifactId>admin-configurator-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin</groupId>
+            <artifactId>admin-configurator-actions-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/query/api/src/main/java/org/codice/ddf/admin/api/ConfiguratorSuite.java
+++ b/query/api/src/main/java/org/codice/ddf/admin/api/ConfiguratorSuite.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.api;
+
+import org.codice.ddf.admin.configurator.ConfiguratorFactory;
+import org.codice.ddf.internal.admin.configurator.actions.BundleActions;
+import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
+import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
+import org.codice.ddf.internal.admin.configurator.actions.PropertyActions;
+import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
+import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
+
+public interface ConfiguratorSuite {
+    ConfiguratorFactory getConfiguratorFactory();
+
+    BundleActions getBundleActions();
+
+    FeatureActions getFeatureActions();
+
+    ManagedServiceActions getManagedServiceActions();
+
+    PropertyActions getPropertyActions();
+
+    ServiceActions getServiceActions();
+
+    ServiceReader getServiceReader();
+}

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/services/ServiceCommonsSpec.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/services/ServiceCommonsSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.common.services
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.common.fields.common.PidField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -25,7 +26,8 @@ import spock.lang.Specification
 
 import static org.codice.ddf.admin.common.services.ServiceCommons.validateServiceConfigurationExists
 
-class ServiceCommonsTest extends Specification {
+class ServiceCommonsSpec extends Specification {
+    ConfiguratorSuite configuratorSuite
 
     ConfiguratorFactory configuratorFactory
 
@@ -46,7 +48,14 @@ class ServiceCommonsTest extends Specification {
         configuratorFactory = Mock(ConfiguratorFactory)
         serviceReader = Mock(ServiceReader)
         configuratorFactory.getConfigurator() >> configurator
-        serviceCommons = new ServiceCommons(managedServiceActions, serviceActions, serviceReader, configuratorFactory)
+
+        configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.getConfiguratorFactory() >> configuratorFactory
+        configuratorSuite.getManagedServiceActions() >> managedServiceActions
+        configuratorSuite.getServiceActions() >> serviceActions
+        configuratorSuite.getServiceReader() >> serviceReader
+
+        serviceCommons = new ServiceCommons(configuratorSuite)
     }
 
     def 'Create managed service success'() {

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/SecurityValidation.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/SecurityValidation.java
@@ -25,7 +25,8 @@ import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 public class SecurityValidation {
 
-    public static Report validateStsClaimsExist(List<StringField> claimArgs, ServiceActions serviceActions, StsServiceProperties stsServiceProps){
+    public static Report validateStsClaimsExist(List<StringField> claimArgs,
+            ServiceActions serviceActions, StsServiceProperties stsServiceProps) {
         ReportImpl report = new ReportImpl();
         List<String> supportedClaims = stsServiceProps.getConfiguredStsClaims(serviceActions);
 

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/AuthType.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/AuthType.java
@@ -39,9 +39,7 @@ public class AuthType extends BaseEnumField<String> {
     private final ServiceReader serviceReader;
 
     public AuthType(ServiceReader serviceReader) {
-        super(DEFAULT_FIELD_NAME,
-                FIELD_TYPE_NAME,
-                DESCRIPTION);
+        super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
         this.serviceReader = serviceReader;
     }
 
@@ -52,7 +50,8 @@ public class AuthType extends BaseEnumField<String> {
 
     @Override
     public List<EnumValue<String>> getEnumValues() {
-        Set<EnumValuePoller> authTypes = serviceReader.getServices(EnumValuePoller.class, AUTH_TYPE_POLLER_FILTER);
+        Set<EnumValuePoller> authTypes = serviceReader.getServices(EnumValuePoller.class,
+                AUTH_TYPE_POLLER_FILTER);
 
         return authTypes.stream()
                 .findFirst()
@@ -80,8 +79,8 @@ public class AuthType extends BaseEnumField<String> {
         }
 
         @Override
-        public ListImpl useDefaultRequired(){
-            newAuthType =  () -> {
+        public ListImpl useDefaultRequired() {
+            newAuthType = () -> {
                 AuthType authType = new AuthType(serviceReader);
                 authType.isRequired(true);
                 return authType;

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapClaimsHandlerServiceProperties.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapClaimsHandlerServiceProperties.java
@@ -15,7 +15,7 @@ package org.codice.ddf.admin.security.common.services;
 
 import java.util.Map;
 
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 
 public class LdapClaimsHandlerServiceProperties {
 
@@ -50,13 +50,14 @@ public class LdapClaimsHandlerServiceProperties {
     public static final String PROPERTY_FILE_LOCATION = "propertyFileLocation";
     // ---
 
-    private ManagedServiceActions managedServiceActions;
+    private final ConfiguratorSuite configuratorSuite;
 
-    public LdapClaimsHandlerServiceProperties(ManagedServiceActions managedServiceActions) {
-        this.managedServiceActions = managedServiceActions;
+    public LdapClaimsHandlerServiceProperties(ConfiguratorSuite configuratorSuite) {
+        this.configuratorSuite = configuratorSuite;
     }
 
     public Map<String, Map<String, Object>> getLdapClaimsHandlerManagedServices() {
-        return managedServiceActions.read(LDAP_CLAIMS_HANDLER_MANAGED_SERVICE_FACTORY_PID);
+        return configuratorSuite.getManagedServiceActions()
+                .read(LDAP_CLAIMS_HANDLER_MANAGED_SERVICE_FACTORY_PID);
     }
 }

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
@@ -15,7 +15,7 @@ package org.codice.ddf.admin.security.common.services;
 
 import java.util.Map;
 
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 
 public class LdapLoginServiceProperties {
 
@@ -44,13 +44,14 @@ public class LdapLoginServiceProperties {
     public static final String START_TLS = "startTls";
     // ---
 
-    private ManagedServiceActions managedServiceActions;
+    private final ConfiguratorSuite configuratorSuite;
 
-    public LdapLoginServiceProperties(ManagedServiceActions configuratorFactory) {
-        this.managedServiceActions = configuratorFactory;
+    public LdapLoginServiceProperties(ConfiguratorSuite configuratorSuite) {
+        this.configuratorSuite = configuratorSuite;
     }
 
     public Map<String, Map<String, Object>> getLdapLoginManagedServices() {
-        return managedServiceActions.read(LDAP_LOGIN_MANAGED_SERVICE_FACTORY_PID);
+        return configuratorSuite.getManagedServiceActions()
+                .read(LDAP_LOGIN_MANAGED_SERVICE_FACTORY_PID);
     }
 }

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/PolicyManagerServiceProperties.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/PolicyManagerServiceProperties.java
@@ -20,10 +20,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.collections.ListUtils;
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.common.fields.common.ContextPath;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.security.common.fields.wcpm.ContextPolicyBin;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 import org.codice.ddf.security.policy.context.ContextPolicy;
 import org.codice.ddf.security.policy.context.ContextPolicyManager;
@@ -148,12 +148,13 @@ public class PolicyManagerServiceProperties {
         return ImmutableMap.of(WHITE_LIST_CONTEXT, serviceContexts);
     }
 
-    public static List<String> getWhitelistContexts(ServiceActions serviceActions) {
-        Object whitelistProp = serviceActions.read(POLICY_MANAGER_PID)
+    public static List<String> getWhitelistContexts(ConfiguratorSuite configuratorSuite) {
+        Object whitelistProp = configuratorSuite.getServiceActions()
+                .read(POLICY_MANAGER_PID)
                 .get(WHITE_LIST_CONTEXT);
 
         if (whitelistProp != null && whitelistProp instanceof String[]) {
-            return new ServiceCommons().resolveProperties((String[]) whitelistProp);
+            return new ServiceCommons(configuratorSuite).resolveProperties((String[]) whitelistProp);
         }
 
         return new ArrayList<>();

--- a/query/security/embeddedldap/src/main/java/org/codice/ddf/admin/ldap/embedded/InstallEmbeddedLdap.java
+++ b/query/security/embeddedldap/src/main/java/org/codice/ddf/admin/ldap/embedded/InstallEmbeddedLdap.java
@@ -22,6 +22,7 @@ import static org.codice.ddf.admin.security.common.services.LdapLoginServiceProp
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
@@ -44,15 +45,17 @@ public class InstallEmbeddedLdap extends BaseFunctionField<BooleanField> {
 
     private LdapUseCase useCase;
 
+    private final ConfiguratorSuite configuratorSuite;
+
     private final ConfiguratorFactory configuratorFactory;
 
     private final FeatureActions featureActions;
 
-    public InstallEmbeddedLdap(ConfiguratorFactory configuratorFactory,
-            FeatureActions featureActions) {
+    public InstallEmbeddedLdap(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.featureActions = featureActions;
+        this.configuratorSuite = configuratorSuite;
+        this.configuratorFactory = configuratorSuite.getConfiguratorFactory();
+        this.featureActions = configuratorSuite.getFeatureActions();
         useCase = new LdapUseCase();
         useCase.isRequired(true);
         updateArgumentPaths();
@@ -100,6 +103,6 @@ public class InstallEmbeddedLdap extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new InstallEmbeddedLdap(configuratorFactory, featureActions);
+        return new InstallEmbeddedLdap(configuratorSuite);
     }
 }

--- a/query/security/embeddedldap/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/query/security/embeddedldap/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,8 +14,7 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <bean id="installEmbeddedLdap" class="org.codice.ddf.admin.ldap.embedded.InstallEmbeddedLdap">
-        <argument ref="configuratorFactory"/>
-        <argument ref="featureActions"/>
+        <argument ref="configuratorSuite"/>
     </bean>
 
     <service ref="installEmbeddedLdap" interface="org.codice.ddf.admin.api.fields.FunctionField">
@@ -24,12 +23,8 @@
         </service-properties>
     </service>
 
-    <reference id="configuratorFactory"
-               interface="org.codice.ddf.admin.configurator.ConfiguratorFactory"
-               availability="mandatory" filter="(type=txact)"/>
-
-    <reference id="featureActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.FeatureActions"
+    <reference id="configuratorSuite"
+               interface="org.codice.ddf.admin.api.ConfiguratorSuite"
                availability="mandatory"/>
 
 </blueprint>

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/LdapFieldProvider.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/LdapFieldProvider.java
@@ -16,10 +16,10 @@ package org.codice.ddf.admin.ldap;
 import java.util.Collections;
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.BaseFieldProvider;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.ldap.discover.GetLdapConfigurations;
 import org.codice.ddf.admin.ldap.discover.LdapQuery;
 import org.codice.ddf.admin.ldap.discover.LdapRecommendedSettings;
@@ -30,10 +30,6 @@ import org.codice.ddf.admin.ldap.discover.LdapTestDirectorySettings;
 import org.codice.ddf.admin.ldap.discover.LdapUserAttributes;
 import org.codice.ddf.admin.ldap.persist.CreateLdapConfiguration;
 import org.codice.ddf.admin.ldap.persist.DeleteLdapConfiguration;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.PropertyActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 import com.google.common.collect.ImmutableList;
 
@@ -70,28 +66,20 @@ public class LdapFieldProvider extends BaseFieldProvider {
 
     private List<FunctionField> ldapMutationFields = Collections.emptyList();
 
-    public LdapFieldProvider(ConfiguratorFactory configuratorFactory, FeatureActions featureActions,
-            ManagedServiceActions managedServiceActions, PropertyActions propertyActions,
-            ServiceActions serviceActions) {
+    public LdapFieldProvider(ConfiguratorSuite configuratorSuite) {
         super(NAME, TYPE_NAME, DESCRIPTION);
         testConnection = new LdapTestConnection();
         testBind = new LdapTestBind();
         testSettings = new LdapTestDirectorySettings();
         recommendedSettings = new LdapRecommendedSettings();
-        claimMappings = new LdapTestClaimMappings(serviceActions);
+        claimMappings = new LdapTestClaimMappings(configuratorSuite);
 
         ldapQuery = new LdapQuery();
         getUserAttris = new LdapUserAttributes();
-        getConfigs = new GetLdapConfigurations(managedServiceActions, propertyActions);
+        getConfigs = new GetLdapConfigurations(configuratorSuite);
 
-        createConfig = new CreateLdapConfiguration(configuratorFactory,
-                featureActions,
-                managedServiceActions,
-                propertyActions);
-        deleteConfig = new DeleteLdapConfiguration(configuratorFactory,
-                managedServiceActions,
-                propertyActions,
-                serviceActions);
+        createConfig = new CreateLdapConfiguration(configuratorSuite);
+        deleteConfig = new DeleteLdapConfiguration(configuratorSuite);
     }
 
     @Override

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.api.report.Report;
 import org.codice.ddf.admin.common.report.ReportImpl;
@@ -46,32 +47,26 @@ import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField;
 import org.codice.ddf.admin.security.common.services.LdapClaimsHandlerServiceProperties;
 import org.codice.ddf.admin.security.common.services.LdapLoginServiceProperties;
 import org.codice.ddf.configuration.PropertyResolver;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.PropertyActions;
 
 public class LdapServiceCommons {
     private static final Pattern URI_MATCHER = Pattern.compile("\\w*://.*");
 
-    private final PropertyActions propertyActions;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ManagedServiceActions managedServiceActions;
-
-    public LdapServiceCommons(PropertyActions propertyActions,
-            ManagedServiceActions managedServiceActions) {
-        this.propertyActions = propertyActions;
-        this.managedServiceActions = managedServiceActions;
+    public LdapServiceCommons(ConfiguratorSuite configuratorSuite) {
+        this.configuratorSuite = configuratorSuite;
     }
 
     public ListField<LdapConfigurationField> getLdapConfigurations() {
         List<LdapConfigurationField> ldapLoginConfigs = new LdapLoginServiceProperties(
-                managedServiceActions).getLdapLoginManagedServices()
+                configuratorSuite).getLdapLoginManagedServices()
                 .values()
                 .stream()
                 .map(this::ldapLoginServiceToLdapConfiguration)
                 .collect(Collectors.toList());
 
         List<LdapConfigurationField> ldapClaimsHandlerConfigs =
-                new LdapClaimsHandlerServiceProperties(managedServiceActions).getLdapClaimsHandlerManagedServices()
+                new LdapClaimsHandlerServiceProperties(configuratorSuite).getLdapClaimsHandlerManagedServices()
                         .values()
                         .stream()
                         .map(this::ldapClaimsHandlerServiceToLdapConfig)
@@ -227,7 +222,8 @@ public class LdapServiceCommons {
             Path path = Paths.get(attributeMappingsPath)
                     .toAbsolutePath();
             if (Files.exists(path)) {
-                claimMappings = new HashMap<>(propertyActions.getProperties(path));
+                claimMappings = new HashMap<>(configuratorSuite.getPropertyActions()
+                        .getProperties(path));
             }
         }
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/GetLdapConfigurations.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/GetLdapConfigurations.java
@@ -13,13 +13,12 @@
  **/
 package org.codice.ddf.admin.ldap.discover;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.ldap.commons.LdapServiceCommons;
 import org.codice.ddf.admin.ldap.fields.config.LdapConfigurationField;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.PropertyActions;
 
 public class GetLdapConfigurations extends GetFunctionField<ListField<LdapConfigurationField>> {
 
@@ -27,22 +26,19 @@ public class GetLdapConfigurations extends GetFunctionField<ListField<LdapConfig
 
     public static final String DESCRIPTION = "Retrieves all currently configured LDAP settings.";
 
-    public static final LdapConfigurationField.ListImpl
-            RETURN_TYPE = new LdapConfigurationField.ListImpl();
+    public static final LdapConfigurationField.ListImpl RETURN_TYPE =
+            new LdapConfigurationField.ListImpl();
 
-    private final ManagedServiceActions managedServiceActions;
-
-    private final PropertyActions propertyActions;
+    private final ConfiguratorSuite configuratorSuite;
 
     private LdapServiceCommons serviceCommons;
 
-    public GetLdapConfigurations(ManagedServiceActions managedServiceActions, PropertyActions propertyActions) {
+    public GetLdapConfigurations(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.managedServiceActions = managedServiceActions;
-        this.propertyActions = propertyActions;
+        this.configuratorSuite = configuratorSuite;
         updateArgumentPaths();
 
-        serviceCommons = new LdapServiceCommons(this.propertyActions, this.managedServiceActions);
+        serviceCommons = new LdapServiceCommons(configuratorSuite);
     }
 
     @Override
@@ -57,6 +53,6 @@ public class GetLdapConfigurations extends GetFunctionField<ListField<LdapConfig
 
     @Override
     public FunctionField<ListField<LdapConfigurationField>> newInstance() {
-        return new GetLdapConfigurations(managedServiceActions, propertyActions);
+        return new GetLdapConfigurations(configuratorSuite);
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.TestFunctionField;
@@ -33,7 +34,6 @@ import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField;
 import org.codice.ddf.admin.security.common.SecurityValidation;
 import org.codice.ddf.admin.security.common.fields.wcpm.ClaimsMapEntry;
 import org.codice.ddf.admin.security.common.services.StsServiceProperties;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 import org.forgerock.opendj.ldap.Connection;
 import org.forgerock.opendj.ldap.Filter;
 import org.forgerock.opendj.ldap.SearchScope;
@@ -68,11 +68,11 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
     private LdapTestingUtils utils;
 
-    private final ServiceActions serviceActions;
+    private final ConfiguratorSuite configuratorSuite;
 
-    public LdapTestClaimMappings(ServiceActions serviceActions) {
+    public LdapTestClaimMappings(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.serviceActions = serviceActions;
+        this.configuratorSuite = configuratorSuite;
 
         conn = new LdapConnectionField().useDefaultRequired();
         bindInfo = new LdapBindUserInfo().useDefaultRequired();
@@ -96,7 +96,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new LdapTestClaimMappings(serviceActions);
+        return new LdapTestClaimMappings(configuratorSuite);
     }
 
     @Override
@@ -113,7 +113,7 @@ public class LdapTestClaimMappings extends TestFunctionField {
                 .collect(Collectors.toList());
 
         addMessages(SecurityValidation.validateStsClaimsExist(claimArgs,
-                serviceActions,
+                configuratorSuite.getServiceActions(),
                 stsServiceProperties));
 
         // TODO: 7/7/17 - tbatie - Currently the ClaimsMapEntry contains a StringField as a value. It really should be a LdapAttributeName. Fix this once there is a generic way to create MapField objects that contain different value field.

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/DeleteLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/DeleteLdapConfiguration.java
@@ -15,16 +15,13 @@ package org.codice.ddf.admin.ldap.persist;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.PropertyActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 import com.google.common.collect.ImmutableList;
 
@@ -37,33 +34,19 @@ public class DeleteLdapConfiguration extends BaseFunctionField<BooleanField> {
 
     private PidField pid;
 
-    private final ConfiguratorFactory configuratorFactory;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final PropertyActions propertyActions;
-
-    private final ServiceActions serviceActions;
+    private final ConfiguratorSuite configuratorSuite;
 
     private ServiceCommons serviceCommons;
 
-    public DeleteLdapConfiguration(ConfiguratorFactory configuratorFactory,
-            ManagedServiceActions managedServiceActions, PropertyActions propertyActions,
-            ServiceActions serviceActions) {
+    public DeleteLdapConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.managedServiceActions = managedServiceActions;
-        this.propertyActions = propertyActions;
-        this.serviceActions = serviceActions;
+        this.configuratorSuite = configuratorSuite;
 
         pid = new PidField();
         pid.isRequired(true);
 
         updateArgumentPaths();
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                null,
-                configuratorFactory);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
@@ -94,9 +77,6 @@ public class DeleteLdapConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new DeleteLdapConfiguration(configuratorFactory,
-                managedServiceActions,
-                propertyActions,
-                serviceActions);
+        return new DeleteLdapConfiguration(configuratorSuite);
     }
 }

--- a/query/security/ldap/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/query/security/ldap/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -29,35 +29,15 @@
     </reference-list>
 
     <bean id="ldapFieldProvider" class="org.codice.ddf.admin.ldap.LdapFieldProvider">
-        <argument ref="configuratorFactory"/>
-        <argument ref="featureActions"/>
-        <argument ref="managedServiceActions"/>
-        <argument ref="propertyActions"/>
-        <argument ref="serviceActions"/>
+        <argument ref="configuratorSuite"/>
         <property name="ldapDiscoveryFields" ref="ldapDiscoveryFields"/>
         <property name="ldapMutationFields" ref="ldapMutationFields"/>
     </bean>
 
     <service ref="ldapFieldProvider" interface="org.codice.ddf.admin.api.FieldProvider" />
 
-    <reference id="configuratorFactory"
-               interface="org.codice.ddf.admin.configurator.ConfiguratorFactory"
-               availability="mandatory" filter="(type=txact)"/>
-
-    <reference id="featureActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.FeatureActions"
-               availability="mandatory"/>
-
-    <reference id="managedServiceActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions"
-               availability="mandatory"/>
-
-    <reference id="propertyActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.PropertyActions"
-               availability="mandatory"/>
-
-    <reference id="serviceActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.ServiceActions"
+    <reference id="configuratorSuite"
+               interface="org.codice.ddf.admin.api.ConfiguratorSuite"
                availability="mandatory"/>
 
 </blueprint>

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/CreateLdapConfigurationSpec.groovy
@@ -67,7 +67,7 @@ class CreateLdapConfigurationSpec extends Specification {
 
     def 'fail on missing required fields for authentication'() {
         setup:
-        createConfigFunc = new CreateLdapConfiguration(null, null, null, null)
+        createConfigFunc = new CreateLdapConfiguration(null)
 
         when:
         FunctionReport report = createConfigFunc.getValue()
@@ -92,7 +92,7 @@ class CreateLdapConfigurationSpec extends Specification {
 
     def 'fail on missing required fields for attribute store'() {
         setup:
-        createConfigFunc = new CreateLdapConfiguration(null, null, null, null)
+        createConfigFunc = new CreateLdapConfiguration(null)
 
         def configArg = new LdapConfigurationField().settings(new LdapDirectorySettingsField().useCase(LdapUseCase.AttributeStore.ATTRIBUTE_STORE))
         def args = [

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.ldap.discover
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.ListField
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField
 import org.codice.ddf.admin.common.services.ServiceCommons
@@ -33,10 +34,15 @@ class GetLdapConfigurationsSpec extends Specification {
 
     PropertyActions propertyActions
 
+    ConfiguratorSuite configuratorSuite
+
     def setup() {
         propertyActions = Mock(PropertyActions)
         managedServiceActions = Mock(ManagedServiceActions)
-        getLdapConfigurations = new GetLdapConfigurations(managedServiceActions, propertyActions)
+        configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.propertyActions >> propertyActions
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        getLdapConfigurations = new GetLdapConfigurations(configuratorSuite)
     }
 
     def 'Retrieved LDAP configurations have flag password'() {
@@ -61,7 +67,7 @@ class GetLdapConfigurationsSpec extends Specification {
                 .connection(LdapTestingCommons.noEncryptionLdapConnectionInfo())
 
         return [
-                'somePid': new LdapServiceCommons(propertyActions, managedServiceActions).ldapConfigToLdapClaimsHandlerService(config, "/some/path")
+                'somePid': new LdapServiceCommons(configuratorSuite).ldapConfigToLdapClaimsHandlerService(config, "/some/path")
         ]
     }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappingsSpec.groovy
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.ldap.discover
 
 import com.google.common.collect.ImmutableMap
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.api.fields.ListField
 import org.codice.ddf.admin.api.report.FunctionReport
@@ -72,8 +73,10 @@ class LdapTestClaimMappingsSpec extends Specification {
         serviceActions = Mock(ServiceActions)
         stsServiceProperties = Mock(StsServiceProperties)
         stsServiceProperties.getConfiguredStsClaims(_) >> ['claim1', 'claim2', 'claim3', 'claim4', 'claim5']
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.serviceActions >> serviceActions
 
-        action = new LdapTestClaimMappings(serviceActions)
+        action = new LdapTestClaimMappings(configuratorSuite)
         action.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
         action.setStsServiceProperties(stsServiceProperties)
 

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/WcpmFieldProvider.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/WcpmFieldProvider.java
@@ -15,18 +15,16 @@ package org.codice.ddf.admin.security.wcpm;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.BaseFieldProvider;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.security.wcpm.discover.GetAuthTypes;
 import org.codice.ddf.admin.security.wcpm.discover.GetContextPolicies;
 import org.codice.ddf.admin.security.wcpm.discover.GetRealms;
 import org.codice.ddf.admin.security.wcpm.discover.GetWhiteListContexts;
 import org.codice.ddf.admin.security.wcpm.persist.SaveContextPolices;
 import org.codice.ddf.admin.security.wcpm.persist.SaveWhitelistContexts;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -52,16 +50,15 @@ public class WcpmFieldProvider extends BaseFieldProvider {
 
     private SaveWhitelistContexts saveWhitelistContexts;
 
-    public WcpmFieldProvider(ConfiguratorFactory configuratorFactory, ServiceActions serviceActions,
-            ServiceReader serviceReader) {
+    public WcpmFieldProvider(ConfiguratorSuite configuratorSuite) {
         super(NAME, TYPE_NAME, DESCRIPTION);
-        getAuthTypes = new GetAuthTypes(serviceReader);
-        getRealms = new GetRealms(serviceReader);
-        getWhiteListContexts = new GetWhiteListContexts(serviceActions);
-        getContextPolicies = new GetContextPolicies(serviceReader);
+        getAuthTypes = new GetAuthTypes(configuratorSuite.getServiceReader());
+        getRealms = new GetRealms(configuratorSuite.getServiceReader());
+        getWhiteListContexts = new GetWhiteListContexts(configuratorSuite);
+        getContextPolicies = new GetContextPolicies(configuratorSuite.getServiceReader());
 
-        saveContextPolices = new SaveContextPolices(configuratorFactory, serviceActions, serviceReader);
-        saveWhitelistContexts = new SaveWhitelistContexts(configuratorFactory, serviceActions);
+        saveContextPolices = new SaveContextPolices(configuratorSuite);
+        saveWhitelistContexts = new SaveWhitelistContexts(configuratorSuite);
         updateInnerFieldPaths();
     }
 

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetWhiteListContexts.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetWhiteListContexts.java
@@ -17,10 +17,10 @@ import static org.codice.ddf.admin.security.common.services.PolicyManagerService
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.common.fields.common.ContextPath;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 public class GetWhiteListContexts extends GetFunctionField<ContextPath.ListImpl> {
 
@@ -29,20 +29,19 @@ public class GetWhiteListContexts extends GetFunctionField<ContextPath.ListImpl>
     public static final String DESCRIPTION =
             "Returns all white listed contexts. Any contexts that are white listed have no security policy applied to them.";
 
-    public static final ContextPath.ListImpl RETURN_TYPE =
-            new ContextPath.ListImpl();
+    public static final ContextPath.ListImpl RETURN_TYPE = new ContextPath.ListImpl();
 
-    private final ServiceActions serviceActions;
+    private final ConfiguratorSuite configuratorSuite;
 
-    public GetWhiteListContexts(ServiceActions serviceActions) {
+    public GetWhiteListContexts(ConfiguratorSuite configuratorSuite) {
         super(DEFAULT_FIELD_NAME, DESCRIPTION);
 
-        this.serviceActions = serviceActions;
+        this.configuratorSuite = configuratorSuite;
     }
 
     @Override
     public ContextPath.ListImpl performFunction() {
-        List<String> whiteListStrs = getWhitelistContexts(serviceActions);
+        List<String> whiteListStrs = getWhitelistContexts(configuratorSuite);
         ContextPath.ListImpl whiteListedField = new ContextPath.ListImpl();
         for (String whiteListStr : whiteListStrs) {
             ContextPath newContextPath = new ContextPath();
@@ -59,6 +58,6 @@ public class GetWhiteListContexts extends GetFunctionField<ContextPath.ListImpl>
 
     @Override
     public FunctionField<ContextPath.ListImpl> newInstance() {
-        return new GetWhiteListContexts(serviceActions);
+        return new GetWhiteListContexts(configuratorSuite);
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContexts.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContexts.java
@@ -17,14 +17,13 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.failedP
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.ContextPath;
 import org.codice.ddf.admin.configurator.Configurator;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.security.common.services.PolicyManagerServiceProperties;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 import com.google.common.collect.ImmutableList;
 
@@ -35,20 +34,15 @@ public class SaveWhitelistContexts extends BaseFunctionField<ContextPath.ListImp
     public static final String DESCRIPTION =
             "Persists the given contexts paths as white listed contexts. White listing a context path will result in no security being applied to the given paths.";
 
-    public static final ContextPath.ListImpl RETURN_TYPE =
-            new ContextPath.ListImpl();
+    public static final ContextPath.ListImpl RETURN_TYPE = new ContextPath.ListImpl();
 
     private ContextPath.ListImpl contexts;
 
-    private ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    public SaveWhitelistContexts(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions) {
+    public SaveWhitelistContexts(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
+        this.configuratorSuite = configuratorSuite;
 
         contexts = new ContextPath.ListImpl();
         updateArgumentPaths();
@@ -56,10 +50,12 @@ public class SaveWhitelistContexts extends BaseFunctionField<ContextPath.ListImp
 
     @Override
     public ContextPath.ListImpl performFunction() {
-        Configurator configurator = configuratorFactory.getConfigurator();
-        configurator.add(serviceActions.build(PolicyManagerServiceProperties.POLICY_MANAGER_PID,
-                new PolicyManagerServiceProperties().whiteListToPolicyManagerProps(contexts),
-                true));
+        Configurator configurator = configuratorSuite.getConfiguratorFactory()
+                .getConfigurator();
+        configurator.add(configuratorSuite.getServiceActions()
+                .build(PolicyManagerServiceProperties.POLICY_MANAGER_PID,
+                        new PolicyManagerServiceProperties().whiteListToPolicyManagerProps(contexts),
+                        true));
 
         OperationReport configReport = configurator.commit(
                 "Whitelist Contexts saved with details: {}",
@@ -84,6 +80,6 @@ public class SaveWhitelistContexts extends BaseFunctionField<ContextPath.ListImp
 
     @Override
     public SaveWhitelistContexts newInstance() {
-        return new SaveWhitelistContexts(configuratorFactory, serviceActions);
+        return new SaveWhitelistContexts(configuratorSuite);
     }
 }

--- a/query/security/wcpm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/query/security/wcpm/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -103,23 +103,13 @@
     
     <service id="wcpmFieldProvider" interface="org.codice.ddf.admin.api.FieldProvider">
         <bean class="org.codice.ddf.admin.security.wcpm.WcpmFieldProvider">
-            <argument ref="configuratorFactory" />
-            <argument ref="serviceActions"/>
-            <argument ref="serviceReader"/>
+            <argument ref="configuratorSuite"/>
         </bean>
     </service>
 
 
-    <reference id="configuratorFactory"
-               interface="org.codice.ddf.admin.configurator.ConfiguratorFactory"
-               availability="mandatory" filter="(type=txact)"/>
-
-    <reference id="serviceActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.ServiceActions"
-               availability="mandatory"/>
-
-    <reference id="serviceReader"
-               interface="org.codice.ddf.internal.admin.configurator.actions.ServiceReader"
+    <reference id="configuratorSuite"
+               interface="org.codice.ddf.admin.api.ConfiguratorSuite"
                availability="mandatory"/>
 
 </blueprint>

--- a/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveContextPoliciesSpec.groovy
+++ b/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveContextPoliciesSpec.groovy
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.admin.security.wcpm.persist
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.FieldProvider
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.api.poller.EnumValuePoller
@@ -39,7 +40,7 @@ import spock.lang.Specification
 
 import static groovy.org.codice.ddf.admin.security.wcpm.persist.WcpmTestingCommons.*
 
-class SaveContextPoliciesTest extends Specification {
+class SaveContextPoliciesSpec extends Specification {
 
     FieldProvider queryProvider
     ConfiguratorFactory configuratorFactory
@@ -117,7 +118,11 @@ class SaveContextPoliciesTest extends Specification {
         contextPolicies.setValue(testData.policies)
         policyManager.setPolicies(new PolicyManagerServiceProperties().contextPoliciesToPolicyManagerProps(contextPolicies.getList()))
 
-        queryProvider = new WcpmFieldProvider(configuratorFactory, serviceActions, serviceReader)
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        queryProvider = new WcpmFieldProvider(configuratorSuite)
         saveContextPoliciesFunction = queryProvider.getMutationFunction(SaveContextPolices.FUNCTION_FIELD_NAME)
     }
 

--- a/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContextsTest.groovy
+++ b/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContextsTest.groovy
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.admin.security.wcpm.persist
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.api.report.ReportWithResult
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField
@@ -52,10 +53,12 @@ class SaveWhitelistContextsTest extends Specification {
             [(PolicyManagerServiceProperties.WHITE_LIST_CONTEXT): policyManager.getWhiteListContexts()]
         }
 
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> Mock(ServiceReader)
 
-        wcpmFieldProvider = new WcpmFieldProvider(configuratorFactory,
-                serviceActions,
-                Mock(ServiceReader))
+        wcpmFieldProvider = new WcpmFieldProvider(configuratorSuite)
 
         saveWhitelistContextsFunction = wcpmFieldProvider.getMutationFunction(SaveWhitelistContexts.FIELD_NAME)
     }

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/SourceValidationUtils.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/SourceValidationUtils.java
@@ -15,16 +15,13 @@ package org.codice.ddf.admin.sources.utils;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.report.Report;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.report.ReportImpl;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.SourceMessages;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import ddf.catalog.service.ConfiguredService;
 import ddf.catalog.source.Source;
@@ -36,17 +33,9 @@ public class SourceValidationUtils {
 
     private ServiceCommons serviceCommons;
 
-    public SourceValidationUtils(ServiceReader serviceReader,
-            ManagedServiceActions managedServiceActions, ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions) {
-        sourceUtilCommons = new SourceUtilCommons(managedServiceActions,
-                serviceActions,
-                serviceReader);
-
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                serviceReader,
-                configuratorFactory);
+    public SourceValidationUtils(ConfiguratorSuite configuratorSuite) {
+        sourceUtilCommons = new SourceUtilCommons(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     private boolean findSourceNameMatch(String servicePid, String sourceName) {

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswFieldProvider.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswFieldProvider.java
@@ -15,19 +15,15 @@ package org.codice.ddf.admin.sources.csw;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.BaseFieldProvider;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.csw.discover.DiscoverCswSource;
 import org.codice.ddf.admin.sources.csw.discover.GetCswConfigurations;
 import org.codice.ddf.admin.sources.csw.persist.CreateCswConfiguration;
 import org.codice.ddf.admin.sources.csw.persist.DeleteCswConfiguration;
 import org.codice.ddf.admin.sources.csw.persist.UpdateCswConfiguration;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -51,28 +47,13 @@ public class CswFieldProvider extends BaseFieldProvider {
 
     private DeleteCswConfiguration deleteCswConfiguration;
 
-    public CswFieldProvider(ConfiguratorFactory configuratorFactory, ServiceActions serviceActions,
-            ManagedServiceActions managedServiceActions, ServiceReader serviceReader,
-            FeatureActions featureActions) {
+    public CswFieldProvider(ConfiguratorSuite configuratorSuite) {
         super(ID, TYPE_NAME, DESCRIPTION);
-        discoverCswSource = new DiscoverCswSource();
-        getCswConfigurations = new GetCswConfigurations(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader);
-        createCswConfiguration = new CreateCswConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
-        updateCswConfiguration = new UpdateCswConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
-        deleteCswConfiguration = new DeleteCswConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions);
+        discoverCswSource = new DiscoverCswSource(configuratorSuite);
+        getCswConfigurations = new GetCswConfigurations(configuratorSuite);
+        createCswConfiguration = new CreateCswConfiguration(configuratorSuite);
+        updateCswConfiguration = new UpdateCswConfiguration(configuratorSuite);
+        deleteCswConfiguration = new DeleteCswConfiguration(configuratorSuite);
         updateInnerFieldPaths();
     }
 

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceUtils.java
@@ -28,6 +28,7 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathFactory;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.report.ReportWithResult;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.common.fields.common.HostField;
@@ -75,9 +76,9 @@ public class CswSourceUtils {
 
     private RequestUtils requestUtils;
 
-    public CswSourceUtils() {
+    public CswSourceUtils(ConfiguratorSuite configuratorSuite) {
         this.requestUtils = new RequestUtils();
-        this.sourceUtilCommons = new SourceUtilCommons();
+        this.sourceUtilCommons = new SourceUtilCommons(configuratorSuite);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
@@ -15,6 +15,7 @@ package org.codice.ddf.admin.sources.csw.discover;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.report.ReportWithResult;
@@ -44,14 +45,18 @@ public class DiscoverCswSource extends BaseFunctionField<CswSourceConfigurationF
 
     private CswSourceUtils cswSourceUtils;
 
-    public DiscoverCswSource() {
+    private final ConfiguratorSuite configuratorSuite;
+
+    public DiscoverCswSource(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
+        this.configuratorSuite = configuratorSuite;
+
         credentials = new CredentialsField();
         address = new AddressField();
         address.isRequired(true);
         updateArgumentPaths();
 
-        cswSourceUtils = new CswSourceUtils();
+        cswSourceUtils = new CswSourceUtils(configuratorSuite);
     }
 
     @Override
@@ -87,7 +92,7 @@ public class DiscoverCswSource extends BaseFunctionField<CswSourceConfigurationF
 
     @Override
     public FunctionField<CswSourceConfigurationField> newInstance() {
-        return new DiscoverCswSource();
+        return new DiscoverCswSource(configuratorSuite);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/GetCswConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/GetCswConfigurations.java
@@ -18,20 +18,17 @@ import static org.codice.ddf.admin.sources.services.CswServiceProperties.SERVICE
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.csw.CswSourceInfoField;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 import org.codice.ddf.admin.sources.fields.type.SourceConfigField;
 import org.codice.ddf.admin.sources.utils.SourceUtilCommons;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -51,31 +48,18 @@ public class GetCswConfigurations extends BaseFunctionField<ListField<CswSourceI
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    public GetCswConfigurations(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader) {
+    public GetCswConfigurations(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
+        this.configuratorSuite = configuratorSuite;
 
         pid = new PidField();
         updateArgumentPaths();
 
-        sourceUtilCommons = new SourceUtilCommons(managedServiceActions,
-                serviceActions,
-                serviceReader);
+        sourceUtilCommons = new SourceUtilCommons(configuratorSuite);
 
-        serviceCommons = new ServiceCommons(null, serviceActions, null, null);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
@@ -122,9 +106,6 @@ public class GetCswConfigurations extends BaseFunctionField<ListField<CswSourceI
 
     @Override
     public FunctionField<ListField<CswSourceInfoField>> newInstance() {
-        return new GetCswConfigurations(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader);
+        return new GetCswConfigurations(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswConfiguration.java
@@ -20,20 +20,16 @@ import static org.codice.ddf.admin.sources.services.CswServiceProperties.cswProf
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -41,8 +37,7 @@ public class CreateCswConfiguration extends BaseFunctionField<BooleanField> {
 
     public static final String FIELD_NAME = "createCswSource";
 
-    public static final String DESCRIPTION =
-            "Creates a CSW source configuration.";
+    public static final String DESCRIPTION = "Creates a CSW source configuration.";
 
     public static final BooleanField RETURN_TYPE = new BooleanField();
 
@@ -52,44 +47,26 @@ public class CreateCswConfiguration extends BaseFunctionField<BooleanField> {
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    private final FeatureActions featureActions;
-
-    public CreateCswConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader, FeatureActions featureActions) {
+    public CreateCswConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
-        this.featureActions = featureActions;
+        this.configuratorSuite = configuratorSuite;
 
         config = new CswSourceConfigurationField();
         config.useDefaultRequired();
         updateArgumentPaths();
 
-        sourceValidationUtils = new SourceValidationUtils(serviceReader,
-                managedServiceActions,
-                configuratorFactory,
-                serviceActions);
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                serviceReader,
-                configuratorFactory);
+        sourceValidationUtils = new SourceValidationUtils(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
     public BooleanField performFunction() {
-        Configurator configurator = configuratorFactory.getConfigurator();
-        configurator.add(featureActions.start(CSW_FEATURE));
+        Configurator configurator = configuratorSuite.getConfiguratorFactory()
+                .getConfigurator();
+        configurator.add(configuratorSuite.getFeatureActions()
+                .start(CSW_FEATURE));
         OperationReport report = configurator.commit("Starting feature [{}]", CSW_FEATURE);
 
         if (report.containsFailedResults()) {
@@ -123,10 +100,6 @@ public class CreateCswConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new CreateCswConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
+        return new CreateCswConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfiguration.java
@@ -15,15 +15,13 @@ package org.codice.ddf.admin.sources.csw.persist;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 import com.google.common.collect.ImmutableList;
 
@@ -40,27 +38,17 @@ public class DeleteCswConfiguration extends BaseFunctionField<BooleanField> {
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    public DeleteCswConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions) {
+    public DeleteCswConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
+        this.configuratorSuite = configuratorSuite;
 
         pid = new PidField();
         pid.isRequired(true);
         updateArgumentPaths();
 
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                null,
-                configuratorFactory);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
@@ -90,8 +78,6 @@ public class DeleteCswConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new DeleteCswConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions);
+        return new DeleteCswConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfiguration.java
@@ -20,20 +20,16 @@ import static org.codice.ddf.admin.sources.services.CswServiceProperties.cswConf
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -53,26 +49,11 @@ public class UpdateCswConfiguration extends BaseFunctionField<BooleanField> {
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    private final FeatureActions featureActions;
-
-    public UpdateCswConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader, FeatureActions featureActions) {
-
+    public UpdateCswConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
-        this.featureActions = featureActions;
+        this.configuratorSuite = configuratorSuite;
 
         config = new CswSourceConfigurationField();
         config.useDefaultRequired();
@@ -80,20 +61,16 @@ public class UpdateCswConfiguration extends BaseFunctionField<BooleanField> {
                 .isRequired(true);
         updateArgumentPaths();
 
-        sourceValidationUtils = new SourceValidationUtils(serviceReader,
-                managedServiceActions,
-                configuratorFactory,
-                serviceActions);
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                serviceReader,
-                configuratorFactory);
+        sourceValidationUtils = new SourceValidationUtils(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
     public BooleanField performFunction() {
-        Configurator configurator = configuratorFactory.getConfigurator();
-        configurator.add(featureActions.start(CSW_FEATURE));
+        Configurator configurator = configuratorSuite.getConfiguratorFactory()
+                .getConfigurator();
+        configurator.add(configuratorSuite.getFeatureActions()
+                .start(CSW_FEATURE));
         OperationReport report = configurator.commit("Starting feature [{}]", CSW_FEATURE);
 
         if (report.containsFailedResults()) {
@@ -128,10 +105,6 @@ public class UpdateCswConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new UpdateCswConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
+        return new UpdateCswConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchFieldProvider.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchFieldProvider.java
@@ -15,19 +15,15 @@ package org.codice.ddf.admin.sources.opensearch;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.BaseFieldProvider;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.opensearch.discover.DiscoverOpenSearchSource;
 import org.codice.ddf.admin.sources.opensearch.discover.GetOpenSearchConfigurations;
 import org.codice.ddf.admin.sources.opensearch.persist.CreateOpenSearchConfiguration;
 import org.codice.ddf.admin.sources.opensearch.persist.DeleteOpenSearchConfiguration;
 import org.codice.ddf.admin.sources.opensearch.persist.UpdateOpenSearchConfiguration;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -50,29 +46,13 @@ public class OpenSearchFieldProvider extends BaseFieldProvider {
 
     private DeleteOpenSearchConfiguration deleteOpenSearchConfig;
 
-    public OpenSearchFieldProvider(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader, FeatureActions featureActions) {
+    public OpenSearchFieldProvider(ConfiguratorSuite configuratorSuite) {
         super(ID, TYPE_NAME, DESCRIPTION);
-        discoverOpenSearchSource = new DiscoverOpenSearchSource();
-        getOpenSearchConfigs = new GetOpenSearchConfigurations(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader);
-
-        createOpenSearchConfigs = new CreateOpenSearchConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
-        updateOpenSearchConfigs = new UpdateOpenSearchConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
-        deleteOpenSearchConfig = new DeleteOpenSearchConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions);
+        discoverOpenSearchSource = new DiscoverOpenSearchSource(configuratorSuite);
+        getOpenSearchConfigs = new GetOpenSearchConfigurations(configuratorSuite);
+        createOpenSearchConfigs = new CreateOpenSearchConfiguration(configuratorSuite);
+        updateOpenSearchConfigs = new UpdateOpenSearchConfiguration(configuratorSuite);
+        deleteOpenSearchConfig = new DeleteOpenSearchConfiguration(configuratorSuite);
         updateInnerFieldPaths();
     }
 

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceUtils.java
@@ -26,6 +26,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.common.fields.common.HostField;
 import org.codice.ddf.admin.common.fields.common.ResponseField;
@@ -62,9 +63,9 @@ public class OpenSearchSourceUtils {
 
     private RequestUtils requestUtils;
 
-    public OpenSearchSourceUtils() {
+    public OpenSearchSourceUtils(ConfiguratorSuite configuratorSuite) {
         this.requestUtils = new RequestUtils();
-        this.sourceUtilCommons = new SourceUtilCommons();
+        this.sourceUtilCommons = new SourceUtilCommons(configuratorSuite);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
@@ -15,6 +15,7 @@ package org.codice.ddf.admin.sources.opensearch.discover;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.report.ReportWithResult;
@@ -45,14 +46,18 @@ public class DiscoverOpenSearchSource
 
     private OpenSearchSourceUtils openSearchSourceUtils;
 
-    public DiscoverOpenSearchSource() {
+    private final ConfiguratorSuite configuratorSuite;
+
+    public DiscoverOpenSearchSource(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
+        this.configuratorSuite = configuratorSuite;
+
         credentials = new CredentialsField();
         address = new AddressField();
         address.isRequired(true);
         updateArgumentPaths();
 
-        openSearchSourceUtils = new OpenSearchSourceUtils();
+        openSearchSourceUtils = new OpenSearchSourceUtils(configuratorSuite);
     }
 
     @Override
@@ -89,7 +94,7 @@ public class DiscoverOpenSearchSource
 
     @Override
     public FunctionField<OpenSearchSourceConfigurationField> newInstance() {
-        return new DiscoverOpenSearchSource();
+        return new DiscoverOpenSearchSource(configuratorSuite);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigurations.java
@@ -18,20 +18,17 @@ import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationField;
 import org.codice.ddf.admin.sources.fields.type.SourceConfigField;
 import org.codice.ddf.admin.sources.opensearch.OpenSearchSourceInfoField;
 import org.codice.ddf.admin.sources.utils.SourceUtilCommons;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -52,30 +49,17 @@ public class GetOpenSearchConfigurations
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    public GetOpenSearchConfigurations(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader) {
+    public GetOpenSearchConfigurations(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
+        this.configuratorSuite = configuratorSuite;
 
         pid = new PidField();
         updateArgumentPaths();
 
-        sourceUtilCommons = new SourceUtilCommons(managedServiceActions,
-                serviceActions,
-                serviceReader);
-        serviceCommons = new ServiceCommons(null, serviceActions, null, null);
+        sourceUtilCommons = new SourceUtilCommons(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
 
     }
 
@@ -126,9 +110,6 @@ public class GetOpenSearchConfigurations
 
     @Override
     public FunctionField<ListField<OpenSearchSourceInfoField>> newInstance() {
-        return new GetOpenSearchConfigurations(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader);
+        return new GetOpenSearchConfigurations(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfiguration.java
@@ -20,20 +20,16 @@ import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -41,8 +37,7 @@ public class CreateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     public static final String FIELD_NAME = "createOpenSearchSource";
 
-    public static final String DESCRIPTION =
-            "Creates an OpenSearch source configuration.";
+    public static final String DESCRIPTION = "Creates an OpenSearch source configuration.";
 
     public static final BooleanField RETURN_TYPE = new BooleanField();
 
@@ -52,44 +47,26 @@ public class CreateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    private final FeatureActions featureActions;
-
-    public CreateOpenSearchConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader, FeatureActions featureActions) {
+    public CreateOpenSearchConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
-        this.featureActions = featureActions;
+        this.configuratorSuite = configuratorSuite;
 
         config = new OpenSearchSourceConfigurationField();
         config.useDefaultRequired();
         updateArgumentPaths();
 
-        sourceValidationUtils = new SourceValidationUtils(serviceReader,
-                managedServiceActions,
-                configuratorFactory,
-                serviceActions);
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                serviceReader,
-                configuratorFactory);
+        sourceValidationUtils = new SourceValidationUtils(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
     public BooleanField performFunction() {
-        Configurator configurator = configuratorFactory.getConfigurator();
-        configurator.add(featureActions.start(OPENSEARCH_FEATURE));
+        Configurator configurator = configuratorSuite.getConfiguratorFactory()
+                .getConfigurator();
+        configurator.add(configuratorSuite.getFeatureActions()
+                .start(OPENSEARCH_FEATURE));
         OperationReport report = configurator.commit("Starting feature [{}]", OPENSEARCH_FEATURE);
 
         if (report.containsFailedResults()) {
@@ -122,10 +99,6 @@ public class CreateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new CreateOpenSearchConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
+        return new CreateOpenSearchConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfiguration.java
@@ -15,15 +15,13 @@ package org.codice.ddf.admin.sources.opensearch.persist;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 import com.google.common.collect.ImmutableList;
 
@@ -39,27 +37,17 @@ public class DeleteOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    public DeleteOpenSearchConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions) {
+    public DeleteOpenSearchConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
+        this.configuratorSuite = configuratorSuite;
 
         pid = new PidField();
         pid.isRequired(true);
         updateArgumentPaths();
 
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                null,
-                configuratorFactory);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
@@ -89,8 +77,6 @@ public class DeleteOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new DeleteOpenSearchConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions);
+        return new DeleteOpenSearchConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfiguration.java
@@ -20,20 +20,16 @@ import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -53,26 +49,11 @@ public class UpdateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    private final FeatureActions featureActions;
-
-    public UpdateOpenSearchConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader, FeatureActions featureActions) {
-
+    public UpdateOpenSearchConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
-        this.featureActions = featureActions;
+        this.configuratorSuite = configuratorSuite;
 
         config = new OpenSearchSourceConfigurationField();
         config.useDefaultRequired();
@@ -80,20 +61,16 @@ public class UpdateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
                 .isRequired(true);
         updateArgumentPaths();
 
-        sourceValidationUtils = new SourceValidationUtils(serviceReader,
-                managedServiceActions,
-                configuratorFactory,
-                serviceActions);
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                serviceReader,
-                configuratorFactory);
+        sourceValidationUtils = new SourceValidationUtils(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
     public BooleanField performFunction() {
-        Configurator configurator = configuratorFactory.getConfigurator();
-        configurator.add(featureActions.start(OPENSEARCH_FEATURE));
+        Configurator configurator = configuratorSuite.getConfiguratorFactory()
+                .getConfigurator();
+        configurator.add(configuratorSuite.getFeatureActions()
+                .start(OPENSEARCH_FEATURE));
         OperationReport report = configurator.commit("Starting feature [{}]", OPENSEARCH_FEATURE);
 
         if (report.containsFailedResults()) {
@@ -127,10 +104,6 @@ public class UpdateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new UpdateOpenSearchConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
+        return new UpdateOpenSearchConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsFieldProvider.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsFieldProvider.java
@@ -15,19 +15,15 @@ package org.codice.ddf.admin.sources.wfs;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.BaseFieldProvider;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.wfs.discover.DiscoverWfsSource;
 import org.codice.ddf.admin.sources.wfs.discover.GetWfsConfigurations;
 import org.codice.ddf.admin.sources.wfs.persist.CreateWfsConfiguration;
 import org.codice.ddf.admin.sources.wfs.persist.DeleteWfsConfiguration;
 import org.codice.ddf.admin.sources.wfs.persist.UpdateWfsConfiguration;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -51,29 +47,13 @@ public class WfsFieldProvider extends BaseFieldProvider {
 
     private DeleteWfsConfiguration deleteWfsConfig;
 
-    public WfsFieldProvider(ConfiguratorFactory configuratorFactory, ServiceActions serviceActions,
-            ManagedServiceActions managedServiceActions, ServiceReader serviceReader,
-            FeatureActions featureActions) {
+    public WfsFieldProvider(ConfiguratorSuite configuratorSuite) {
         super(NAME, TYPE_NAME, DESCRIPTION);
-        discoverWfsSource = new DiscoverWfsSource();
-        getWfsConfigs = new GetWfsConfigurations(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader);
-
-        createWfsConfig = new CreateWfsConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
-        updateWfsConfig = new UpdateWfsConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
-        deleteWfsConfig = new DeleteWfsConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions);
+        discoverWfsSource = new DiscoverWfsSource(configuratorSuite);
+        getWfsConfigs = new GetWfsConfigurations(configuratorSuite);
+        createWfsConfig = new CreateWfsConfiguration(configuratorSuite);
+        updateWfsConfig = new UpdateWfsConfiguration(configuratorSuite);
+        deleteWfsConfig = new DeleteWfsConfiguration(configuratorSuite);
         updateInnerFieldPaths();
     }
 

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceUtils.java
@@ -25,6 +25,7 @@ import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.common.fields.common.HostField;
 import org.codice.ddf.admin.common.fields.common.ResponseField;
@@ -62,9 +63,9 @@ public class WfsSourceUtils {
 
     private RequestUtils requestUtils;
 
-    public WfsSourceUtils() {
+    public WfsSourceUtils(ConfiguratorSuite configuratorSuite) {
         this.requestUtils = new RequestUtils();
-        this.sourceUtilCommons = new SourceUtilCommons();
+        this.sourceUtilCommons = new SourceUtilCommons(configuratorSuite);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
@@ -15,6 +15,7 @@ package org.codice.ddf.admin.sources.wfs.discover;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
@@ -43,14 +44,18 @@ public class DiscoverWfsSource extends BaseFunctionField<WfsSourceConfigurationF
 
     private WfsSourceUtils wfsSourceUtils;
 
-    public DiscoverWfsSource() {
+    private final ConfiguratorSuite configuratorSuite;
+
+    public DiscoverWfsSource(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
+        this.configuratorSuite = configuratorSuite;
+
         credentials = new CredentialsField();
         address = new AddressField();
         address.isRequired(true);
         updateArgumentPaths();
 
-        wfsSourceUtils = new WfsSourceUtils();
+        wfsSourceUtils = new WfsSourceUtils(configuratorSuite);
     }
 
     @Override
@@ -68,8 +73,7 @@ public class DiscoverWfsSource extends BaseFunctionField<WfsSourceConfigurationF
         }
 
         ReportWithResultImpl<WfsSourceConfigurationField> configResult =
-                wfsSourceUtils.getPreferredWfsConfig(responseResult.result(),
-                        credentials);
+                wfsSourceUtils.getPreferredWfsConfig(responseResult.result(), credentials);
 
         addMessages(configResult);
         return configResult.isResultPresent() ? configResult.result() : null;
@@ -87,7 +91,7 @@ public class DiscoverWfsSource extends BaseFunctionField<WfsSourceConfigurationF
 
     @Override
     public FunctionField<WfsSourceConfigurationField> newInstance() {
-        return new DiscoverWfsSource();
+        return new DiscoverWfsSource(configuratorSuite);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigurations.java
@@ -18,19 +18,16 @@ import static org.codice.ddf.admin.sources.services.WfsServiceProperties.WFS_FAC
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.sources.fields.type.SourceConfigField;
 import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceUtilCommons;
 import org.codice.ddf.admin.sources.wfs.WfsSourceInfoField;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -49,30 +46,17 @@ public class GetWfsConfigurations extends BaseFunctionField<ListField<WfsSourceI
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    public GetWfsConfigurations(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader) {
+    public GetWfsConfigurations(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
+        this.configuratorSuite = configuratorSuite;
 
         pid = new PidField();
         updateArgumentPaths();
 
-        sourceUtilCommons = new SourceUtilCommons(managedServiceActions,
-                serviceActions,
-                serviceReader);
-        serviceCommons = new ServiceCommons(null, serviceActions, null, null);
+        sourceUtilCommons = new SourceUtilCommons(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
@@ -116,10 +100,7 @@ public class GetWfsConfigurations extends BaseFunctionField<ListField<WfsSourceI
 
     @Override
     public FunctionField<ListField<WfsSourceInfoField>> newInstance() {
-        return new GetWfsConfigurations(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader);
+        return new GetWfsConfigurations(configuratorSuite);
     }
 
     @Override

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfiguration.java
@@ -21,21 +21,17 @@ import static org.codice.ddf.admin.sources.services.WfsServiceProperties.wfsVers
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.sources.fields.WfsVersion;
 import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -43,8 +39,7 @@ public class CreateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     public static final String FIELD_NAME = "createWfsSource";
 
-    private static final String DESCRIPTION =
-            "Creates a WFS source configuration.";
+    private static final String DESCRIPTION = "Creates a WFS source configuration.";
 
     public static final BooleanField RETURN_TYPE = new BooleanField();
 
@@ -54,51 +49,34 @@ public class CreateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    private final FeatureActions featureActions;
-
-    public CreateWfsConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader, FeatureActions featureActions) {
+    public CreateWfsConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
-        this.featureActions = featureActions;
+        this.configuratorSuite = configuratorSuite;
 
         config = new WfsSourceConfigurationField();
         config.useDefaultRequired();
         updateArgumentPaths();
 
-        sourceValidationUtils = new SourceValidationUtils(serviceReader,
-                managedServiceActions,
-                configuratorFactory,
-                serviceActions);
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                serviceReader,
-                configuratorFactory);
+        sourceValidationUtils = new SourceValidationUtils(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
     public BooleanField performFunction() {
-        Configurator configurator = configuratorFactory.getConfigurator();
+        Configurator configurator = configuratorSuite.getConfiguratorFactory()
+                .getConfigurator();
         OperationReport report = null;
         if (config.wfsVersion()
                 .equals(WfsVersion.Wfs2.WFS_VERSION_2)) {
-            configurator.add(featureActions.start(WFS2_FEATURE));
+            configurator.add(configuratorSuite.getFeatureActions()
+                    .start(WFS2_FEATURE));
             report = configurator.commit("Starting feature [{}].", WFS2_FEATURE);
         } else if (config.wfsVersion()
                 .equals(WfsVersion.Wfs1.WFS_VERSION_1)) {
-            configurator.add(featureActions.start(WFS1_FEATURE));
+            configurator.add(configuratorSuite.getFeatureActions()
+                    .start(WFS1_FEATURE));
             report = configurator.commit("Starting feature [{}].", WFS1_FEATURE);
         }
 
@@ -133,10 +111,6 @@ public class CreateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new CreateWfsConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
+        return new CreateWfsConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfiguration.java
@@ -15,15 +15,13 @@ package org.codice.ddf.admin.sources.wfs.persist;
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
 
 import com.google.common.collect.ImmutableList;
 
@@ -40,27 +38,17 @@ public class DeleteWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    public DeleteWfsConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions) {
+    public DeleteWfsConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
+        this.configuratorSuite = configuratorSuite;
 
         pid = new PidField();
         pid.isRequired(true);
         updateArgumentPaths();
 
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                null,
-                configuratorFactory);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
@@ -90,8 +78,6 @@ public class DeleteWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new DeleteWfsConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions);
+        return new DeleteWfsConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfiguration.java
@@ -21,21 +21,17 @@ import static org.codice.ddf.admin.sources.services.WfsServiceProperties.wfsConf
 
 import java.util.List;
 
+import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
-import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.sources.fields.WfsVersion;
 import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
-import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
-import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
 
 import com.google.common.collect.ImmutableList;
 
@@ -55,26 +51,11 @@ public class UpdateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     private ServiceCommons serviceCommons;
 
-    private final ConfiguratorFactory configuratorFactory;
+    private final ConfiguratorSuite configuratorSuite;
 
-    private final ServiceActions serviceActions;
-
-    private final ManagedServiceActions managedServiceActions;
-
-    private final ServiceReader serviceReader;
-
-    private final FeatureActions featureActions;
-
-    public UpdateWfsConfiguration(ConfiguratorFactory configuratorFactory,
-            ServiceActions serviceActions, ManagedServiceActions managedServiceActions,
-            ServiceReader serviceReader, FeatureActions featureActions) {
-
+    public UpdateWfsConfiguration(ConfiguratorSuite configuratorSuite) {
         super(FIELD_NAME, DESCRIPTION);
-        this.configuratorFactory = configuratorFactory;
-        this.serviceActions = serviceActions;
-        this.managedServiceActions = managedServiceActions;
-        this.serviceReader = serviceReader;
-        this.featureActions = featureActions;
+        this.configuratorSuite = configuratorSuite;
 
         config = new WfsSourceConfigurationField();
         config.useDefaultRequired();
@@ -82,27 +63,24 @@ public class UpdateWfsConfiguration extends BaseFunctionField<BooleanField> {
                 .isRequired(true);
         updateArgumentPaths();
 
-        sourceValidationUtils = new SourceValidationUtils(serviceReader,
-                managedServiceActions,
-                configuratorFactory,
-                serviceActions);
-        serviceCommons = new ServiceCommons(managedServiceActions,
-                serviceActions,
-                serviceReader,
-                configuratorFactory);
+        sourceValidationUtils = new SourceValidationUtils(configuratorSuite);
+        serviceCommons = new ServiceCommons(configuratorSuite);
     }
 
     @Override
     public BooleanField performFunction() {
-        Configurator configurator = configuratorFactory.getConfigurator();
+        Configurator configurator = configuratorSuite.getConfiguratorFactory()
+                .getConfigurator();
         OperationReport report = null;
         if (config.wfsVersion()
                 .equals(WfsVersion.Wfs2.WFS_VERSION_2)) {
-            configurator.add(featureActions.start(WFS2_FEATURE));
+            configurator.add(configuratorSuite.getFeatureActions()
+                    .start(WFS2_FEATURE));
             report = configurator.commit("Starting feature [{}].", WFS2_FEATURE);
         } else if (config.wfsVersion()
                 .equals(WfsVersion.Wfs1.WFS_VERSION_1)) {
-            configurator.add(featureActions.start(WFS1_FEATURE));
+            configurator.add(configuratorSuite.getFeatureActions()
+                    .start(WFS1_FEATURE));
             report = configurator.commit("Starting feature [{}].", WFS1_FEATURE);
         }
 
@@ -137,10 +115,6 @@ public class UpdateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public FunctionField<BooleanField> newInstance() {
-        return new UpdateWfsConfiguration(configuratorFactory,
-                serviceActions,
-                managedServiceActions,
-                serviceReader,
-                featureActions);
+        return new UpdateWfsConfiguration(configuratorSuite);
     }
 }

--- a/query/sources/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/query/sources/impl/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -14,52 +14,24 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
     <service id="cswFieldProvider" interface="org.codice.ddf.admin.api.FieldProvider">
         <bean class="org.codice.ddf.admin.sources.csw.CswFieldProvider">
-            <argument ref="configuratorFactory"/>
-            <argument ref="serviceActions"/>
-            <argument ref="managedServiceActions"/>
-            <argument ref="serviceReader"/>
-            <argument ref="featureActions"/>
+            <argument ref="configuratorSuite"/>
         </bean>
     </service>
 
     <service id="openSearchFieldProvider" interface="org.codice.ddf.admin.api.FieldProvider">
         <bean class="org.codice.ddf.admin.sources.opensearch.OpenSearchFieldProvider">
-            <argument ref="configuratorFactory"/>
-            <argument ref="serviceActions"/>
-            <argument ref="managedServiceActions"/>
-            <argument ref="serviceReader"/>
-            <argument ref="featureActions"/>
+            <argument ref="configuratorSuite"/>
         </bean>
     </service>
 
     <service id="wfsFieldProvider" interface="org.codice.ddf.admin.api.FieldProvider">
         <bean class="org.codice.ddf.admin.sources.wfs.WfsFieldProvider">
-            <argument ref="configuratorFactory"/>
-            <argument ref="serviceActions"/>
-            <argument ref="managedServiceActions"/>
-            <argument ref="serviceReader"/>
-            <argument ref="featureActions"/>
+            <argument ref="configuratorSuite"/>
         </bean>
     </service>
 
-    <reference id="configuratorFactory"
-               interface="org.codice.ddf.admin.configurator.ConfiguratorFactory"
-               availability="mandatory" filter="(type=txact)"/>
-
-    <reference id="serviceActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.ServiceActions"
-               availability="mandatory"/>
-
-    <reference id="managedServiceActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions"
-               availability="mandatory"/>
-
-    <reference id="serviceReader"
-               interface="org.codice.ddf.internal.admin.configurator.actions.ServiceReader"
-               availability="mandatory"/>
-
-    <reference id="featureActions"
-               interface="org.codice.ddf.internal.admin.configurator.actions.FeatureActions"
+    <reference id="configuratorSuite"
+               interface="org.codice.ddf.admin.api.ConfiguratorSuite"
                availability="mandatory"/>
 
 </blueprint>

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/CswFieldProviderSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/CswFieldProviderSpec.groovy
@@ -13,10 +13,10 @@
  **/
 package org.codice.ddf.admin.sources.csw
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.FieldProvider
 import org.codice.ddf.admin.configurator.ConfiguratorFactory
 import org.codice.ddf.internal.admin.configurator.actions.FeatureActions
-import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions
 import org.codice.ddf.internal.admin.configurator.actions.ServiceActions
 import org.codice.ddf.internal.admin.configurator.actions.ServiceReader
 import spock.lang.Specification
@@ -26,11 +26,12 @@ class CswFieldProviderSpec extends Specification {
     CswFieldProvider cswFieldProvider
 
     def setup() {
-        cswFieldProvider = new CswFieldProvider(Mock(ConfiguratorFactory),
-                Mock(ServiceActions),
-                Mock(ManagedServiceActions),
-                Mock(ServiceReader),
-                Mock(FeatureActions))
+        ConfiguratorSuite configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.getConfiguratorFactory() >> Mock(ConfiguratorFactory)
+        configuratorSuite.getServiceActions() >> Mock(ServiceActions)
+        configuratorSuite.getServiceReader() >> Mock(ServiceReader)
+        configuratorSuite.getFeatureActions() >> Mock(FeatureActions)
+        cswFieldProvider = new CswFieldProvider(configuratorSuite)
     }
 
     def 'Verify discovery fields immutability'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpecSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpecSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.csw.discover
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.fields.common.HostField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
@@ -55,7 +56,7 @@ class DiscoverCswSourceSpecSpec extends SourceCommonsSpec {
     static URL_FIELD_PATH = [ADDRESS_FIELD_PATH, URL_NAME].flatten()
 
     def setup() {
-        discoverCsw = new DiscoverCswSource()
+        discoverCsw = new DiscoverCswSource(Mock(ConfiguratorSuite))
     }
 
     def 'Successfully discover DDF federation profile with URL'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.admin.sources.csw.discover
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.Field
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.api.fields.ListField
@@ -48,6 +49,8 @@ class GetCswConfigsSpec extends SourceCommonsSpec {
 
     ManagedServiceActions managedServiceActions
 
+    ConfiguratorSuite configuratorSuite
+
     def functionArgs = [
             (PID): S_PID_2
     ]
@@ -60,8 +63,13 @@ class GetCswConfigsSpec extends SourceCommonsSpec {
         managedServiceActions = Mock(ManagedServiceActions)
         serviceReader = Mock(ServiceReader)
 
-        getCswConfigsFunction = new GetCswConfigurations(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader)
+        configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.managedServiceActions >> managedServiceActions
+
+        getCswConfigsFunction = new GetCswConfigurations(configuratorSuite)
     }
 
     def 'No pid argument returns all configs'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/CreateCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/CreateCswConfigurationSpec.groovy
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.csw.persist
 
 import ddf.catalog.source.Source
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -62,6 +63,8 @@ class CreateCswConfigurationSpec extends SourceCommonsSpec {
 
     FeatureActions featureActions
 
+    ConfiguratorSuite configuratorSuite
+
     Source federatedSource
 
     def federatedSources = []
@@ -77,8 +80,15 @@ class CreateCswConfigurationSpec extends SourceCommonsSpec {
         federatedSource = new TestSource(S_PID, TEST_SOURCENAME, false)
         federatedSources.add(federatedSource)
         configuratorFactory.getConfigurator() >> configurator
-        createCswConfiguration = new CreateCswConfiguration(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader, featureActions)
+
+        configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.featureActions >> featureActions
+        configuratorSuite.managedServiceActions >> managedServiceActions
+
+        createCswConfiguration = new CreateCswConfiguration(configuratorSuite)
     }
 
     def 'Successfully create new CSW configuration'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfigurationSpec.groovy
@@ -13,6 +13,7 @@
  */
 package org.codice.ddf.admin.sources.csw.persist
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -31,6 +32,8 @@ class DeleteCswConfigurationSpec extends SourceCommonsSpec {
     Configurator configurator
 
     ServiceActions serviceActions
+
+    ConfiguratorSuite configuratorSuite
 
     static TEST_CSW_URL = "testCswUrl"
 
@@ -58,7 +61,12 @@ class DeleteCswConfigurationSpec extends SourceCommonsSpec {
         configuratorFactory = Mock(ConfiguratorFactory) {
             getConfigurator() >> configurator
         }
-        deleteCswConfiguration = new DeleteCswConfiguration(configuratorFactory, this.serviceActions, managedServiceActions)
+
+        configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        deleteCswConfiguration = new DeleteCswConfiguration(configuratorSuite)
     }
 
     def 'Successfully deleting CSW configuration returns true'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.csw.persist
 
 import ddf.catalog.source.Source
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -67,6 +68,8 @@ class UpdateCswConfigurationSpec extends SourceCommonsSpec {
 
     FeatureActions featureActions
 
+    ConfiguratorSuite configuratorSuite
+
     Source federatedSource
 
     def federatedSources = []
@@ -82,8 +85,14 @@ class UpdateCswConfigurationSpec extends SourceCommonsSpec {
         federatedSource = new TestSource(S_PID, TEST_SOURCENAME, false)
         federatedSources.add(federatedSource)
         configuratorFactory.getConfigurator() >> configurator
-        updateCswConfiguration = new UpdateCswConfiguration(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader, featureActions)
+
+        configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.featureActions >> featureActions
+        updateCswConfiguration = new UpdateCswConfiguration(configuratorSuite)
     }
 
     def 'Successfully update CSW configuration'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/OpenSearchFieldProviderSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/OpenSearchFieldProviderSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.opensearch
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.FieldProvider
 import org.codice.ddf.admin.configurator.ConfiguratorFactory
 import org.codice.ddf.internal.admin.configurator.actions.FeatureActions
@@ -26,11 +27,14 @@ class OpenSearchFieldProviderSpec extends Specification {
     OpenSearchFieldProvider openSearchFieldProvider
 
     def setup() {
-        openSearchFieldProvider = new OpenSearchFieldProvider(Mock(ConfiguratorFactory),
-                Mock(ServiceActions),
-                Mock(ManagedServiceActions),
-                Mock(ServiceReader),
-                Mock(FeatureActions))
+        ConfiguratorSuite configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> Mock(ConfiguratorFactory)
+        configuratorSuite.serviceActions >> Mock(ServiceActions)
+        configuratorSuite.managedServiceActions >> Mock(ManagedServiceActions)
+        configuratorSuite.serviceReader >> Mock(ServiceReader)
+        configuratorSuite.featureActions >> Mock(FeatureActions)
+
+        openSearchFieldProvider = new OpenSearchFieldProvider(configuratorSuite)
     }
 
     def 'Verify discovery fields immutability'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.opensearch.discover
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.fields.common.HostField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
@@ -40,7 +41,7 @@ class DiscoverOpenSearchSpec extends SourceCommonsSpec {
     static URL_FIELD_PATH = [ADDRESS_FIELD_PATH, URL_NAME].flatten()
 
     def setup() {
-        discoverOpenSearch = new DiscoverOpenSearchSource()
+        discoverOpenSearch = new DiscoverOpenSearchSource(Mock(ConfiguratorSuite))
     }
 
     def 'Successfully discover OpenSearch configuration using URL'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.opensearch.discover
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.Field
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.api.fields.ListField
@@ -57,8 +58,13 @@ class GetOpenSearchConfigsSpec extends SourceCommonsSpec {
         serviceActions = Mock(ServiceActions)
         serviceReader = Mock(ServiceReader)
         managedServiceActions = Mock(ManagedServiceActions)
-        getOpenSearchConfigsFunction = new GetOpenSearchConfigurations(configuratorFactory, serviceActions,
-                this.managedServiceActions, serviceReader)
+        ConfiguratorSuite configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.managedServiceActions >> managedServiceActions
+
+        getOpenSearchConfigsFunction = new GetOpenSearchConfigurations(configuratorSuite)
     }
 
     def 'No pid argument returns all configs'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfigurationSpec.groovy
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.opensearch.persist
 
 import ddf.catalog.source.FederatedSource
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -70,8 +71,14 @@ class CreateOpenSearchConfigurationSpec extends SourceCommonsSpec {
         configuratorFactory = Mock(ConfiguratorFactory)
         configuratorFactory.getConfigurator() >> configurator
 
-        createOpenSearchConfiguration = new CreateOpenSearchConfiguration(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader, featureActions)
+        ConfiguratorSuite configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        configuratorSuite.featureActions >> featureActions
+
+        createOpenSearchConfiguration = new CreateOpenSearchConfiguration(configuratorSuite)
     }
 
     def 'Successfully create new OpenSearch configuration'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfigurationSpec.groovy
@@ -1,5 +1,6 @@
 package org.codice.ddf.admin.sources.opensearch.persist
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -35,8 +36,12 @@ class DeleteOpenSearchConfigurationSpec extends SourceCommonsSpec {
         serviceActions = Mock(ServiceActions)
         def managedServiceActions = Mock(ManagedServiceActions)
 
-        deleteOpenSearchConfigurationFunction = new DeleteOpenSearchConfiguration(configuratorFactory,
-                serviceActions, managedServiceActions)
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.managedServiceActions >> managedServiceActions
+
+        deleteOpenSearchConfigurationFunction = new DeleteOpenSearchConfiguration(configuratorSuite)
     }
 
     def 'Successfully deleting WFS config returns true'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.opensearch.persist
 
 import ddf.catalog.source.FederatedSource
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -73,8 +74,14 @@ class UpdateOpenSearchConfigurationSpec extends SourceCommonsSpec {
         configuratorFactory = Mock(ConfiguratorFactory)
         configuratorFactory.getConfigurator() >> configurator
 
-        updateOpenSearchConfiguration = new UpdateOpenSearchConfiguration(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader, featureActions)
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        configuratorSuite.featureActions >> featureActions
+
+        updateOpenSearchConfiguration = new UpdateOpenSearchConfiguration(configuratorSuite)
     }
 
     def 'Successfully update existing OpenSearch configuration'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/WfsFieldProviderSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/WfsFieldProviderSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.wfs
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.FieldProvider
 import org.codice.ddf.admin.configurator.ConfiguratorFactory
 import org.codice.ddf.internal.admin.configurator.actions.FeatureActions
@@ -26,11 +27,14 @@ class WfsFieldProviderSpec extends Specification {
     WfsFieldProvider wfsFieldProvider
 
     def setup() {
-        wfsFieldProvider = new WfsFieldProvider(Mock(ConfiguratorFactory),
-                Mock(ServiceActions),
-                Mock(ManagedServiceActions),
-                Mock(ServiceReader),
-                Mock(FeatureActions))
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> Mock(ConfiguratorFactory)
+        configuratorSuite.serviceActions >> Mock(ServiceActions)
+        configuratorSuite.managedServiceActions >> Mock(ManagedServiceActions)
+        configuratorSuite.serviceReader >> Mock(ServiceReader)
+        configuratorSuite.featureActions >> Mock(FeatureActions)
+
+        wfsFieldProvider = new WfsFieldProvider(configuratorSuite)
     }
 
     def 'Verify discovery fields immutability'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.wfs.discover
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.fields.common.HostField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
@@ -47,7 +48,7 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
     static URL_FIELD_PATH = [ADDRESS_FIELD_PATH, URL_NAME].flatten()
 
     def setup() {
-        discoverWfs = new DiscoverWfsSource()
+        discoverWfs = new DiscoverWfsSource(Mock(ConfiguratorSuite))
     }
 
     def 'Successfully discover WFS 1.0.0 configuration using URL'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.wfs.discover
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.Field
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.api.fields.ListField
@@ -62,9 +63,13 @@ class GetWfsConfigsSpec extends SourceCommonsSpec {
         serviceActions = Mock(ServiceActions)
         managedServiceActions = Mock(ManagedServiceActions)
         serviceReader = Mock(ServiceReader)
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.managedServiceActions >> managedServiceActions
 
-        getWfsConfigsFunction = new GetWfsConfigurations(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader)
+        getWfsConfigsFunction = new GetWfsConfigurations(configuratorSuite)
     }
 
     def 'No pid argument returns all configs'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfigurationSpec.groovy
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.wfs.persist
 
 import ddf.catalog.source.FederatedSource
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -77,8 +78,13 @@ class CreateWfsConfigurationSpec extends SourceCommonsSpec {
             getConfigurator() >> configurator
         }
 
-        createWfsConfiguration = new CreateWfsConfiguration(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader, featureActions)
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        configuratorSuite.featureActions >> featureActions
+        createWfsConfiguration = new CreateWfsConfiguration(configuratorSuite)
     }
 
     def 'Successfully create new WFS configuration'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfigurationSpec.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.sources.wfs.persist
 
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -49,8 +50,11 @@ class DeleteWfsConfigurationSpec extends SourceCommonsSpec {
         serviceActions = Mock(ServiceActions)
         def managedServiceActions = Mock(ManagedServiceActions)
 
-        deleteWfsConfiguration = new DeleteWfsConfiguration(configuratorFactory, serviceActions,
-                managedServiceActions)
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        deleteWfsConfiguration = new DeleteWfsConfiguration(configuratorSuite)
     }
 
     def 'Successfully delete WFS configuration'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.wfs.persist
 
 import ddf.catalog.source.FederatedSource
+import org.codice.ddf.admin.api.ConfiguratorSuite
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.report.message.DefaultMessages
 import org.codice.ddf.admin.configurator.Configurator
@@ -80,8 +81,13 @@ class UpdateWfsConfigurationSpec extends SourceCommonsSpec {
             getConfigurator() >> configurator
         }
 
-        updateWfsConfiguration = new UpdateWfsConfiguration(configuratorFactory, serviceActions,
-                managedServiceActions, serviceReader, featureActions)
+        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite.configuratorFactory >> configuratorFactory
+        configuratorSuite.serviceActions >> serviceActions
+        configuratorSuite.serviceReader >> serviceReader
+        configuratorSuite.managedServiceActions >> managedServiceActions
+        configuratorSuite.featureActions >> featureActions
+        updateWfsConfiguration = new UpdateWfsConfiguration(configuratorSuite)
     }
 
     def 'Successfully update WFS configuration'() {

--- a/query/utils/pom.xml
+++ b/query/utils/pom.xml
@@ -31,6 +31,16 @@
             <artifactId>admin-query-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>ddf.admin</groupId>
+            <artifactId>admin-configurator-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ddf.admin</groupId>
+            <artifactId>admin-configurator-actions-api</artifactId>
+            <version>${ddf.version}</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/query/utils/src/main/java/org/codice/ddf/admin/utils/configurator/ConfiguratorSuiteImpl.java
+++ b/query/utils/src/main/java/org/codice/ddf/admin/utils/configurator/ConfiguratorSuiteImpl.java
@@ -1,0 +1,87 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.utils.configurator;
+
+import org.codice.ddf.admin.api.ConfiguratorSuite;
+import org.codice.ddf.admin.configurator.ConfiguratorFactory;
+import org.codice.ddf.internal.admin.configurator.actions.BundleActions;
+import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
+import org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions;
+import org.codice.ddf.internal.admin.configurator.actions.PropertyActions;
+import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
+import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
+
+public class ConfiguratorSuiteImpl implements ConfiguratorSuite {
+    private final ConfiguratorFactory configuratorFactory;
+
+    private final BundleActions bundleActions;
+
+    private final FeatureActions featureActions;
+
+    private final ManagedServiceActions managedServiceActions;
+
+    private final PropertyActions propertyActions;
+
+    private final ServiceActions serviceActions;
+
+    private final ServiceReader serviceReader;
+
+    public ConfiguratorSuiteImpl(ConfiguratorFactory configuratorFactory,
+            BundleActions bundleActions, FeatureActions featureActions,
+            ManagedServiceActions managedServiceActions, PropertyActions propertyActions,
+            ServiceActions serviceActions, ServiceReader serviceReader) {
+        this.configuratorFactory = configuratorFactory;
+        this.bundleActions = bundleActions;
+        this.featureActions = featureActions;
+        this.managedServiceActions = managedServiceActions;
+        this.propertyActions = propertyActions;
+        this.serviceActions = serviceActions;
+        this.serviceReader = serviceReader;
+    }
+
+    @Override
+    public ConfiguratorFactory getConfiguratorFactory() {
+        return configuratorFactory;
+    }
+
+    @Override
+    public BundleActions getBundleActions() {
+        return bundleActions;
+    }
+
+    @Override
+    public FeatureActions getFeatureActions() {
+        return featureActions;
+    }
+
+    @Override
+    public ManagedServiceActions getManagedServiceActions() {
+        return managedServiceActions;
+    }
+
+    @Override
+    public PropertyActions getPropertyActions() {
+        return propertyActions;
+    }
+
+    @Override
+    public ServiceActions getServiceActions() {
+        return serviceActions;
+    }
+
+    @Override
+    public ServiceReader getServiceReader() {
+        return serviceReader;
+    }
+}

--- a/query/utils/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/query/utils/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -15,4 +15,45 @@
     <service id="connFieldProvider" interface="org.codice.ddf.admin.api.FieldProvider">
         <bean class="org.codice.ddf.admin.utils.conn.ConnectionFieldProvider" />
     </service>
+
+    <service id="configuratorSuite" interface="org.codice.ddf.admin.api.ConfiguratorSuite">
+        <bean class="org.codice.ddf.admin.utils.configurator.ConfiguratorSuiteImpl">
+            <argument ref="configuratorFactory"/>
+            <argument ref="bundleActions"/>
+            <argument ref="featureActions"/>
+            <argument ref="managedServiceActions"/>
+            <argument ref="propertyActions"/>
+            <argument ref="serviceActions"/>
+            <argument ref="serviceReader"/>
+        </bean>
+    </service>
+
+    <reference id="configuratorFactory"
+               interface="org.codice.ddf.admin.configurator.ConfiguratorFactory"
+               availability="mandatory" filter="(type=txact)"/>
+
+    <reference id="bundleActions"
+               interface="org.codice.ddf.internal.admin.configurator.actions.BundleActions"
+               availability="mandatory"/>
+
+    <reference id="featureActions"
+               interface="org.codice.ddf.internal.admin.configurator.actions.FeatureActions"
+               availability="mandatory"/>
+
+    <reference id="managedServiceActions"
+               interface="org.codice.ddf.internal.admin.configurator.actions.ManagedServiceActions"
+               availability="mandatory"/>
+
+    <reference id="propertyActions"
+               interface="org.codice.ddf.internal.admin.configurator.actions.PropertyActions"
+               availability="mandatory"/>
+
+    <reference id="serviceActions"
+               interface="org.codice.ddf.internal.admin.configurator.actions.ServiceActions"
+               availability="mandatory"/>
+
+    <reference id="serviceReader"
+               interface="org.codice.ddf.internal.admin.configurator.actions.ServiceReader"
+               availability="mandatory"/>
+
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?
This service wraps all the configurator api and internal-api services into
a single service that can be injected and passed around in order to reduce
complexity and diversity of constructor and method signatures.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @peterhuffer @blen-desta 

#### How should this be tested? (List steps with links to updated documentation)
Full build and test. Then, a complete manual regression test pass.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)
N/A

#### Checklist:
- [x] Update / Add Unit Tests
