### PR TITLE
DDF-2773 Fix ldap directory settings

### DIFF
--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
@@ -201,7 +201,7 @@ public class ExtendedOsgiGraphQLServlet extends OsgiGraphQLServlet implements Ev
     }
 
     public void unbindFieldProvider(FieldProvider fieldProvider) {
-        triggerSchemaRefresh(String.format(UNBINDING_FIELD_PROVIDER, fieldProvider.fieldTypeName()));
+        triggerSchemaRefresh(String.format(UNBINDING_FIELD_PROVIDER, fieldProvider == null ? "" : fieldProvider.fieldTypeName()));
     }
 
     public void setFieldProviders(List<FieldProvider> fieldProviders) {

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/ldap/LdapUseCase.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/ldap/LdapUseCase.java
@@ -39,6 +39,18 @@ public class LdapUseCase extends BaseEnumField<String> {
                 bindMethod);
     }
 
+    public boolean isAuthentication() {
+        return Authentication.AUTHENTICATION.equals(getValue())
+                || AuthenticationAndAttributeStore.AUTHENTICATION_AND_ATTRIBUTE_STORE.equals(
+                getValue());
+    }
+
+    public boolean isAttributeStore() {
+        return AttributeStore.ATTRIBUTE_STORE.equals(getValue())
+                || AuthenticationAndAttributeStore.AUTHENTICATION_AND_ATTRIBUTE_STORE.equals(
+                getValue());
+    }
+
     public static final class Authentication implements EnumValue<String> {
 
         public static final String DESCRIPTION =

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
@@ -392,4 +392,44 @@ class LdapTestDirectorySettingsSpec extends Specification {
         report.result().getValue()
         ldapConnectionIsClosed
     }
+
+    def 'When useCase = AttributeStore, checkGroupObjectClass, checkGroup, and checkReferencedUser should be applied'() {
+        setup:
+        def ldapSettings = initLdapSettings(ATTRIBUTE_STORE, true)
+        args = [(LdapConnectionField.DEFAULT_FIELD_NAME)       : noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)          : simpleBindInfo().getValue(),
+                (LdapDirectorySettingsField.DEFAULT_FIELD_NAME): ldapSettings.getValue()]
+        def action = Spy(LdapTestDirectorySettings)
+        action.setValue(args)
+        action.setTestingUtils(utilsMock)
+
+        when:
+        FunctionReport report = action.getValue()
+
+        then:
+        1 * action.checkUsersInDir(_)
+        1 * action.checkGroupObjectClass(_)
+        1 * action.checkGroup(_)
+        1 * action.checkReferencedUser(_, _)
+    }
+
+    def 'When useCase = Authentication, checkGroupObjectClass, checkGroup, and checkReferencedUser should be applied'() {
+        setup:
+        def ldapSettings = initLdapSettings(AUTHENTICATION, true)
+        args = [(LdapConnectionField.DEFAULT_FIELD_NAME)       : noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)          : simpleBindInfo().getValue(),
+                (LdapDirectorySettingsField.DEFAULT_FIELD_NAME): ldapSettings.getValue()]
+        def action = Spy(LdapTestDirectorySettings)
+        action.setValue(args)
+        action.setTestingUtils(utilsMock)
+
+        when:
+        action.getValue()
+
+        then:
+        1 * action.checkUsersInDir(_)
+        0 * action.checkGroupObjectClass(_)
+        0 * action.checkGroup(_)
+        0 * action.checkReferencedUser(_, _)
+    }
 }

--- a/ui/src/main/webapp/wizards/ldap/stages/confirm.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/confirm.js
@@ -17,9 +17,9 @@ import Navigation, { Back, Finish } from 'components/wizard/Navigation'
 import { confirmationInfo } from './styles.less'
 
 const useCaseMapping = {
-  authentication: 'Authentication source',
-  attributeStore: 'Attribute store',
-  authenticationAndAttributeStore: 'Authentication and attribute store'
+  Authentication: 'Authentication',
+  AttributeStore: 'Attribute Store',
+  AuthenticationAndAttributeStore: 'Authentication and Attribute Store'
 }
 
 const createLdapConfig = (conn, info, settings, mapping) => ({
@@ -81,7 +81,7 @@ const ConfirmStage = (props) => {
     useCase: configs.ldapUseCase
   }
 
-  const mapping = Object.keys(configs.attributeMappings).map((key) => ({ key, value: configs.attributeMappings[key] }))
+  const mapping = Object.keys(configs.attributeMappings || {}).map((key) => ({ key, value: configs.attributeMappings[key] }))
 
   return (
     <Stage submitting={submitting}>
@@ -114,9 +114,9 @@ const ConfirmStage = (props) => {
               value={configs.memberAttributeReferencedInGroup} />
           </Flexbox>
         </Flexbox>
-        <MapDisplay visible={configs.ldapUseCase !== 'authentication'}
+        <MapDisplay visible={configs.ldapUseCase !== 'Authentication'}
           label='Attribute Mappings'
-          mapping={configs.attributeMappings} />
+          mapping={configs.attributeMappings || {}} />
       </Flexbox>
 
       <Body>


### PR DESCRIPTION
#### What does this PR do?

Fixes LDAP directory settings test.

#### Who is reviewing it?

@garrettfreibott 
@tbatie 
@peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)

Unit tests and also run through the LDAP wizard making sure to hit the Authentication use case branch.

#### Any background context you want to provide?

Previously the LDAP directory settings test was performing all checks 
independently of the use case, it has been updated to perform less checks 
when the use case is Authentication.

#### What are the relevant tickets?

[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
