### PR TITLE
DDF-2773 Adding error codes to the schema

### DIFF
--- a/query/api/src/main/java/org/codice/ddf/admin/api/Field.java
+++ b/query/api/src/main/java/org/codice/ddf/admin/api/Field.java
@@ -68,7 +68,7 @@ public interface Field<S, G> {
     void updatePath(List<String> subPath);
 
     /**
-     * Returns the possible errors that could aries while validating the {@code Field}.
+     * Returns the possible errors that could arise while validating the {@code Field}.
      *
      * @return a {@code Set} of Strings containing the errors.
      */

--- a/query/api/src/main/java/org/codice/ddf/admin/api/Field.java
+++ b/query/api/src/main/java/org/codice/ddf/admin/api/Field.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.api;
 
 import java.util.List;
+import java.util.Set;
 
 /**
  * Defines a container for setting and retrieving values.
@@ -66,4 +67,10 @@ public interface Field<S, G> {
      */
     void updatePath(List<String> subPath);
 
+    /**
+     * Returns the possible errors that could aries while validating the {@code Field}.
+     *
+     * @return a {@code Set} of Strings containing the errors.
+     */
+    Set<String> getErrorCodes();
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseDataType.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseDataType.java
@@ -16,10 +16,13 @@ package org.codice.ddf.admin.common.fields.base;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.missingRequiredFieldError;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.report.ErrorMessage;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public class BaseDataType<T> extends BaseField<T, T> implements DataType<T> {
 
@@ -73,6 +76,13 @@ public class BaseDataType<T> extends BaseField<T, T> implements DataType<T> {
             }
         }
 
+        return errors;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = new HashSet<>();
+        errors.add(DefaultMessages.MISSING_REQUIRED_FIELD);
         return errors;
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseDataType.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseDataType.java
@@ -16,13 +16,14 @@ package org.codice.ddf.admin.common.fields.base;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.missingRequiredFieldError;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
+
+import com.google.common.collect.ImmutableSet;
 
 public class BaseDataType<T> extends BaseField<T, T> implements DataType<T> {
 
@@ -81,8 +82,6 @@ public class BaseDataType<T> extends BaseField<T, T> implements DataType<T> {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = new HashSet<>();
-        errors.add(DefaultMessages.MISSING_REQUIRED_FIELD);
-        return errors;
+        return ImmutableSet.of(DefaultMessages.MISSING_REQUIRED_FIELD);
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseEnumField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseEnumField.java
@@ -16,10 +16,12 @@ package org.codice.ddf.admin.common.fields.base;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.unsupportedEnum;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.fields.EnumField;
 import org.codice.ddf.admin.api.fields.EnumValue;
 import org.codice.ddf.admin.api.report.ErrorMessage;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public abstract class BaseEnumField<S> extends BaseDataType<S>
         implements EnumField<S, EnumValue<S>> {
@@ -84,5 +86,12 @@ public abstract class BaseEnumField<S> extends BaseDataType<S>
             }
         }
         return validationMsgs;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.UNSUPPORTED_ENUM);
+        return errors;
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseEnumField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseEnumField.java
@@ -23,6 +23,8 @@ import org.codice.ddf.admin.api.fields.EnumValue;
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 public abstract class BaseEnumField<S> extends BaseDataType<S>
         implements EnumField<S, EnumValue<S>> {
 
@@ -90,8 +92,9 @@ public abstract class BaseEnumField<S> extends BaseDataType<S>
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.UNSUPPORTED_ENUM);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.UNSUPPORTED_ENUM)
+                .build();
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseListField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseListField.java
@@ -17,6 +17,7 @@ package org.codice.ddf.admin.common.fields.base;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -122,6 +123,13 @@ public abstract class BaseListField<T extends DataType> extends BaseDataType<Lis
     public void pathName(String pathName) {
         super.pathName(pathName);
         getList().forEach(field -> field.updatePath(path()));
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.addAll(createListEntry().getErrorCodes());
+        return errors;
     }
 
     public BaseListField<T> useDefaultRequired() {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseListField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseListField.java
@@ -27,6 +27,8 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableSet;
+
 public abstract class BaseListField<T extends DataType> extends BaseDataType<List>
         implements ListField<T> {
 
@@ -127,9 +129,10 @@ public abstract class BaseListField<T extends DataType> extends BaseDataType<Lis
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.addAll(createListEntry().getErrorCodes());
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .addAll(createListEntry().getErrorCodes())
+                .build();
     }
 
     public BaseListField<T> useDefaultRequired() {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
@@ -27,6 +27,8 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ObjectField;
 import org.codice.ddf.admin.api.report.ErrorMessage;
 
+import com.google.common.collect.ImmutableSet;
+
 public abstract class BaseObjectField extends BaseDataType<Map<String, Object>>
         implements ObjectField {
 
@@ -103,13 +105,14 @@ public abstract class BaseObjectField extends BaseDataType<Map<String, Object>>
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.addAll(getFields().stream()
-                .filter(field -> field instanceof DataType)
-                .map(field -> field.getErrorCodes())
-                .flatMap(Collection<String>::stream)
-                .collect(Collectors.toList()));
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .addAll(getFields().stream()
+                        .filter(field -> field instanceof DataType)
+                        .map(field -> field.getErrorCodes())
+                        .flatMap(Collection<String>::stream)
+                        .collect(Collectors.toList()))
+                .build();
     }
 
     public void updateInnerFieldPaths() {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.DataType;
@@ -98,6 +99,17 @@ public abstract class BaseObjectField extends BaseDataType<Map<String, Object>>
     public void pathName(String pathName) {
         super.pathName(pathName);
         updateInnerFieldPaths();
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.addAll(getFields().stream()
+                .filter(field -> field instanceof DataType)
+                .map(field -> field.getErrorCodes())
+                .flatMap(Collection<String>::stream)
+                .collect(Collectors.toList()));
+        return errors;
     }
 
     public void updateInnerFieldPaths() {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/StringField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/StringField.java
@@ -24,6 +24,8 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.BaseListField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 public class StringField extends BaseScalarField<String> {
 
     public static final String DEFAULT_FIELD_NAME  = "string";
@@ -63,9 +65,10 @@ public class StringField extends BaseScalarField<String> {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.EMPTY_FIELD);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.EMPTY_FIELD)
+                .build();
     }
 
     public static class ListImpl extends BaseListField<StringField> {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/StringField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/StringField.java
@@ -17,10 +17,12 @@ import static org.codice.ddf.admin.api.fields.ScalarField.ScalarType.STRING;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.emptyFieldError;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.BaseListField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public class StringField extends BaseScalarField<String> {
 
@@ -57,6 +59,13 @@ public class StringField extends BaseScalarField<String> {
     public StringField isRequired(boolean required) {
         super.isRequired(required);
         return this;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.EMPTY_FIELD);
+        return errors;
     }
 
     public static class ListImpl extends BaseListField<StringField> {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/ContextPath.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/ContextPath.java
@@ -27,6 +27,8 @@ import org.codice.ddf.admin.common.fields.base.BaseListField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 public class ContextPath extends StringField {
 
     public static final String DEFAULT_FIELD_NAME = "path";
@@ -73,9 +75,10 @@ public class ContextPath extends StringField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.INVALID_CONTEXT_PATH);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.INVALID_CONTEXT_PATH)
+                .build();
     }
 
     private static class UriPathValidator {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/ContextPath.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/ContextPath.java
@@ -18,12 +18,14 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.invalid
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.regex.Pattern;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.BaseListField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public class ContextPath extends StringField {
 
@@ -67,6 +69,13 @@ public class ContextPath extends StringField {
     public ContextPath isRequired(boolean required) {
         super.isRequired(required);
         return this;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.INVALID_CONTEXT_PATH);
+        return errors;
     }
 
     private static class UriPathValidator {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/HostnameField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/HostnameField.java
@@ -16,10 +16,12 @@ package org.codice.ddf.admin.common.fields.common;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.invalidHostnameError;
 
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public class HostnameField extends StringField {
 
@@ -57,5 +59,12 @@ public class HostnameField extends StringField {
 
     public boolean validHostname(String hostname) {
         return HOST_NAME_PATTERN.matcher(hostname).matches();
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.INVALID_HOSTNAME);
+        return errors;
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/HostnameField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/HostnameField.java
@@ -23,6 +23,8 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 public class HostnameField extends StringField {
 
     public static final String DEFAULT_FIELD_NAME = "hostname";
@@ -63,8 +65,9 @@ public class HostnameField extends StringField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.INVALID_HOSTNAME);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.INVALID_HOSTNAME)
+                .build();
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
@@ -18,6 +18,7 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.duplica
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 
@@ -25,6 +26,7 @@ import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.BaseListField;
 import org.codice.ddf.admin.common.fields.base.BaseObjectField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 import com.google.common.collect.ImmutableList;
 
@@ -112,6 +114,13 @@ public class MapField extends BaseObjectField {
             }
         }
         return validationMsgs;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.DUPLICATE_MAP_KEY);
+        return errors;
     }
 
     public static class ListImpl extends BaseListField<MapField> {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/MapField.java
@@ -29,6 +29,7 @@ import org.codice.ddf.admin.common.fields.base.BaseObjectField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class MapField extends BaseObjectField {
 
@@ -118,9 +119,10 @@ public class MapField extends BaseObjectField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.DUPLICATE_MAP_KEY);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.DUPLICATE_MAP_KEY)
+                .build();
     }
 
     public static class ListImpl extends BaseListField<MapField> {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PortField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PortField.java
@@ -16,9 +16,11 @@ package org.codice.ddf.admin.common.fields.common;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.invalidPortRangeError;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.IntegerField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public class PortField extends IntegerField {
 
@@ -46,6 +48,13 @@ public class PortField extends IntegerField {
         }
 
         return validationMsgs;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.INVALID_PORT_RANGE);
+        return errors;
     }
 
     public boolean validPortRange(int port) {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PortField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PortField.java
@@ -22,6 +22,8 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.IntegerField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 public class PortField extends IntegerField {
 
     public static final String DEFAULT_FIELD_NAME = "port";
@@ -52,9 +54,10 @@ public class PortField extends IntegerField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.INVALID_PORT_RANGE);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.INVALID_PORT_RANGE)
+                .build();
     }
 
     public boolean validPortRange(int port) {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UriField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UriField.java
@@ -18,9 +18,11 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.invalid
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public class UriField extends StringField {
 
@@ -63,5 +65,12 @@ public class UriField extends StringField {
             }
         }
         return validationMsgs;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.INVALID_URI);
+        return errors;
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UriField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UriField.java
@@ -24,6 +24,8 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 public class UriField extends StringField {
 
     public static final String DEFAULT_FIELD_NAME = "uri";
@@ -69,8 +71,9 @@ public class UriField extends StringField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.INVALID_URI);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.INVALID_URI)
+                .build();
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UrlField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UrlField.java
@@ -25,6 +25,8 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 public class UrlField extends StringField {
 
     public static final String DEFAULT_FIELD_NAME = "url";
@@ -66,8 +68,9 @@ public class UrlField extends StringField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.INVALID_URL);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.INVALID_URL)
+                .build();
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UrlField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/UrlField.java
@@ -19,9 +19,11 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 public class UrlField extends StringField {
 
@@ -60,5 +62,12 @@ public class UrlField extends StringField {
             }
         }
         return validationMsgs;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.INVALID_URL);
+        return errors;
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/report/message/DefaultMessages.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/report/message/DefaultMessages.java
@@ -51,7 +51,7 @@ public class DefaultMessages {
 
     public static final String DUPLICATE_MAP_KEY = "DUPLICATE_MAP_KEY";
 
-    private static final String SIMILAR_SERVICE_EXISTS = "SIMILAR_SERVICE_EXISTS";
+    public static final String SIMILAR_SERVICE_EXISTS = "SIMILAR_SERVICE_EXISTS";
 
     public static ErrorMessage failedTestSetup() {
         return new ErrorMessageImpl(FAILED_TEST_SETUP);

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseDataTypeTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseDataTypeTest.groovy
@@ -69,7 +69,6 @@ class BaseDataTypeTest extends Specification {
         setup:
         TestDataType missingTestField = new TestDataType<String>()
         missingTestField.isRequired(true)
-        missingTestField.setValue([])
 
         when:
         def errorCodes = missingTestField.getErrorCodes()

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseDataTypeTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseDataTypeTest.groovy
@@ -64,4 +64,19 @@ class BaseDataTypeTest extends Specification {
         then:
         testField.path() == ['updatedName']
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        TestDataType missingTestField = new TestDataType<String>()
+        missingTestField.isRequired(true)
+        missingTestField.setValue([])
+
+        when:
+        def errorCodes = missingTestField.getErrorCodes()
+        def validationMsgs = missingTestField.validate()
+
+        then:
+        errorCodes.size() == 1
+        errorCodes.contains(validationMsgs.get(0).getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseEnumFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseEnumFieldTest.groovy
@@ -49,4 +49,23 @@ class BaseEnumFieldTest extends Specification {
         validationMsgs.get(0).getCode() == DefaultMessages.UNSUPPORTED_ENUM
         validationMsgs.get(0).getPath() == [TestEnumField.DEFAULT_FIELD_NAME]
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        Field invalidEnumField = new TestEnumField()
+        invalidEnumField.setValue('notValidEnum')
+
+        Field missingEnumField = new TestEnumField()
+        missingEnumField.isRequired(true)
+
+        when:
+        def errorCodes = invalidEnumField.getErrorCodes()
+        def invalidEnumFieldValidation = invalidEnumField.validate()
+        def missingEnumFieldValidation = missingEnumField.validate()
+
+        then:
+        errorCodes.size() == 2
+        errorCodes.contains(invalidEnumFieldValidation.get(0).getCode())
+        errorCodes.contains(missingEnumFieldValidation.get(0).getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFunctionFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFunctionFieldTest.groovy
@@ -13,6 +13,7 @@
  **/
 package org.codice.ddf.admin.common.fields.base
 
+import com.google.common.collect.ImmutableSet
 import org.codice.ddf.admin.api.DataType
 import org.codice.ddf.admin.api.fields.FunctionField
 import org.codice.ddf.admin.common.fields.base.scalar.StringField
@@ -111,6 +112,14 @@ class BaseFunctionFieldTest extends Specification {
 
         then:
         errorCodes.size() == 6
+
+        errorCodes.contains(DefaultMessages.EMPTY_FIELD)
+        errorCodes.contains(DefaultMessages.UNSUPPORTED_ENUM)
+        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
+        errorCodes.contains(TestBaseFunctionField.FUNCTION_TEST_ERROR)
+        errorCodes.contains(TestObjectField.OBJECT_FIELD_TEST_ERROR)
+        errorCodes.contains(TestObjectField.InnerTestObjectField.INNER_OBJECT_FIELD_TEST_ERROR)
+
         errorCodes.containsAll(arg1Errors)
         errorCodes.containsAll(arg2Errors)
         errorCodes.containsAll(functionError)
@@ -168,9 +177,9 @@ class BaseFunctionFieldTest extends Specification {
 
         @Override
         Set<String> getFunctionErrorCodes() {
-            Set<String> errorCodes = super.getFunctionErrorCodes()
-            errorCodes.add(FUNCTION_TEST_ERROR)
-            return errorCodes
+            return new ImmutableSet.Builder<String>()
+                    .add(FUNCTION_TEST_ERROR)
+                    .build()
         }
     }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFunctionFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseFunctionFieldTest.groovy
@@ -99,11 +99,30 @@ class BaseFunctionFieldTest extends Specification {
         functionField.getArguments()[0].path() == ['test', TestBaseFunctionField.DEFAULT_NAME, FunctionField.ARGUMENT, StringField.DEFAULT_FIELD_NAME]
     }
 
+    def 'Returns all the possible error codes correctly from all arguments'(){
+        setup:
+        functionField = new TestBaseFunctionField(false)
+
+        when:
+        def errorCodes = functionField.getErrorCodes()
+        def arg1Errors = functionField.getArguments()[0].getErrorCodes()
+        def arg2Errors = functionField.getArguments()[1].getErrorCodes()
+        def functionError = functionField.getFunctionErrorCodes()
+
+        then:
+        errorCodes.size() == 6
+        errorCodes.containsAll(arg1Errors)
+        errorCodes.containsAll(arg2Errors)
+        errorCodes.containsAll(functionError)
+    }
+
     class TestBaseFunctionField extends BaseFunctionField<StringField> {
 
         static String DEFAULT_NAME = 'testBaseFunctionField'
 
         static String ARG_VALUE = 'valid'
+
+        static String FUNCTION_TEST_ERROR = 'FUNCTION_TEST_ERROR'
 
         public static final StringField RETURN_TYPE = new StringField()
 
@@ -145,6 +164,13 @@ class BaseFunctionFieldTest extends Specification {
         @Override
         StringField performFunction() {
             return new StringField('result')
+        }
+
+        @Override
+        Set<String> getFunctionErrorCodes() {
+            Set<String> errorCodes = super.getFunctionErrorCodes()
+            errorCodes.add(FUNCTION_TEST_ERROR)
+            return errorCodes
         }
     }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseListFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseListFieldTest.groovy
@@ -140,4 +140,24 @@ class BaseListFieldTest extends Specification {
         listField.getList()[1].getValue() == 'string2'
         listField.getList()[1].path() == [TEST_LIST_FIELD_NAME, '1']
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        def emptyFieldElement = new StringField('emptyFieldElement')
+        emptyFieldElement.setValue('')
+
+        def missingFieldElement = new StringField('missingFieldElement')
+
+        StringField.ListImpl listField = new StringField.ListImpl(TEST_LIST_FIELD_NAME).useDefaultRequired()
+        listField.addAll([emptyFieldElement, missingFieldElement])
+
+        when:
+        def errorCodes = listField.getErrorCodes()
+        def validationMsgs = listField.validate()
+
+        then:
+        errorCodes.size() == 2
+        errorCodes.contains(validationMsgs[0].getCode())
+        errorCodes.contains(validationMsgs[1].getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseObjectFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseObjectFieldTest.groovy
@@ -118,4 +118,25 @@ class BaseObjectFieldTest extends Specification {
         then:
         subFieldOfInnerField.getValue() == 'valueChange'
     }
+
+    def 'Returns all the possible error codes correctly from inner fields'(){
+        when:
+        def errorCodes = topLevelField.getErrorCodes()
+        def field1 = topLevelField.getFields()[0].getErrorCodes()
+        def field2 = topLevelField.getFields()[1].getErrorCodes()
+        def field3 = topLevelField.getFields()[2].getErrorCodes()
+        def field4 = topLevelField.getFields()[3].getErrorCodes()
+        def field5 = topLevelField.getFields()[4].getErrorCodes()
+        def field6 = topLevelField.getFields()[5].getErrorCodes()
+
+        then:
+        errorCodes.size() == 5
+        errorCodes.containsAll(field1)
+        errorCodes.containsAll(field2)
+        errorCodes.containsAll(field3)
+        errorCodes.containsAll(field4)
+        errorCodes.containsAll(field5)
+        errorCodes.containsAll(field6)
+        errorCodes.contains(topLevelField.OBJECT_FIELD_TEST_ERROR)
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseObjectFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/BaseObjectFieldTest.groovy
@@ -131,12 +131,18 @@ class BaseObjectFieldTest extends Specification {
 
         then:
         errorCodes.size() == 5
+
+        errorCodes.contains(DefaultMessages.EMPTY_FIELD)
+        errorCodes.contains(DefaultMessages.UNSUPPORTED_ENUM)
+        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
+        errorCodes.contains(TestObjectField.OBJECT_FIELD_TEST_ERROR)
+        errorCodes.contains(TestObjectField.InnerTestObjectField.INNER_OBJECT_FIELD_TEST_ERROR)
+
         errorCodes.containsAll(field1)
         errorCodes.containsAll(field2)
         errorCodes.containsAll(field3)
         errorCodes.containsAll(field4)
         errorCodes.containsAll(field5)
         errorCodes.containsAll(field6)
-        errorCodes.contains(topLevelField.OBJECT_FIELD_TEST_ERROR)
     }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/scalar/StringFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/base/scalar/StringFieldTest.groovy
@@ -31,4 +31,23 @@ class StringFieldTest extends Specification {
         validationMsgs[0].getCode() == DefaultMessages.EMPTY_FIELD
         validationMsgs[0].getPath() == [StringField.DEFAULT_FIELD_NAME]
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        def emptyStringField = new StringField()
+        emptyStringField.setValue('')
+
+        def missingStringField = new StringField()
+        missingStringField.isRequired(true)
+
+        when:
+        def errorCodes = emptyStringField.getErrorCodes()
+        def emptyStringFieldValidation = emptyStringField.validate()
+        def missingStringFieldValidation = missingStringField.validate()
+
+        then:
+        errorCodes.size() == 2
+        errorCodes.contains(emptyStringFieldValidation[0].getCode())
+        errorCodes.contains(missingStringFieldValidation[0].getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/ContextPathTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/ContextPathTest.groovy
@@ -67,4 +67,27 @@ class ContextPathTest extends Specification {
         validationMsgs.get(0).getCode() == DefaultMessages.EMPTY_FIELD
         validationMsgs.get(0).getPath() == [ContextPath.DEFAULT_FIELD_NAME]
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        ContextPath emptyContextPath = new ContextPath()
+        emptyContextPath.setValue('')
+
+        ContextPath missingContextPath = new ContextPath().isRequired(true)
+
+        ContextPath invalidContextPath = new ContextPath()
+        invalidContextPath.setValue('/..')
+
+        when:
+        def errorCodes = contextPath.getErrorCodes()
+        def emptyContextPathValidation = emptyContextPath.validate()
+        def missingContextPathValidation = missingContextPath.validate()
+        def invalidContextPathValidation = invalidContextPath.validate()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(emptyContextPathValidation.get(0).getCode())
+        errorCodes.contains(missingContextPathValidation.get(0).getCode())
+        errorCodes.contains(invalidContextPathValidation.get(0).getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/HostnameFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/HostnameFieldTest.groovy
@@ -103,20 +103,21 @@ class HostnameFieldTest extends Specification {
         HostnameField emptyHostnameField = new HostnameField()
         emptyHostnameField.setValue('')
 
-        HostnameField missingHostnameField = new HostnameField().isRequired(true)
+        HostnameField missingHostnameField = new HostnameField()
+        missingHostnameField.isRequired(true)
 
         HostnameField invalidHostnameField = new HostnameField()
         invalidHostnameField.setValue('invalid host')
 
         when:
         def errorCodes = hostnameField.getErrorCodes()
-        def emptyHostnameFieldValidtion = emptyHostnameField.validate()
+        def emptyHostnameFieldValidation = emptyHostnameField.validate()
         def missingHostnameFieldValidation = missingHostnameField.validate()
         def invalidHostnameFieldValidation = invalidHostnameField.validate()
 
         then:
         errorCodes.size() == 3
-        errorCodes.contains(emptyHostnameFieldValidtion.get(0).getCode())
+        errorCodes.contains(emptyHostnameFieldValidation.get(0).getCode())
         errorCodes.contains(missingHostnameFieldValidation.get(0).getCode())
         errorCodes.contains(invalidHostnameFieldValidation.get(0).getCode())
     }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/HostnameFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/HostnameFieldTest.groovy
@@ -97,4 +97,27 @@ class HostnameFieldTest extends Specification {
         validationMsgs.get(0).getCode() == DefaultMessages.MISSING_REQUIRED_FIELD
         validationMsgs.get(0).getPath() == HOSTNAME_FIELD_PATH
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        HostnameField emptyHostnameField = new HostnameField()
+        emptyHostnameField.setValue('')
+
+        HostnameField missingHostnameField = new HostnameField().isRequired(true)
+
+        HostnameField invalidHostnameField = new HostnameField()
+        invalidHostnameField.setValue('invalid host')
+
+        when:
+        def errorCodes = hostnameField.getErrorCodes()
+        def emptyHostnameFieldValidtion = emptyHostnameField.validate()
+        def missingHostnameFieldValidation = missingHostnameField.validate()
+        def invalidHostnameFieldValidation = invalidHostnameField.validate()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(emptyHostnameFieldValidtion.get(0).getCode())
+        errorCodes.contains(missingHostnameFieldValidation.get(0).getCode())
+        errorCodes.contains(invalidHostnameFieldValidation.get(0).getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/MapFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/MapFieldTest.groovy
@@ -80,6 +80,34 @@ class MapFieldTest extends Specification {
         validationMsgs.get(0).getPath() == [MapField.DEFAULT_FIELD_NAME, ENTRIES, '2']
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        def duplicateValue = [(ENTRIES): [createEntry('key1', 'value1'),
+                                          createEntry('key1', 'value2')]]
+        MapField duplicateValueMapField = new MapField()
+        duplicateValueMapField.setValue(duplicateValue)
+
+        def emptyValue = [(ENTRIES): [createEntry('', '')]]
+        MapField emptyValueMapField = new MapField()
+        emptyValueMapField.setValue(emptyValue)
+
+        def missingValue = [(ENTRIES): [createEntry('', null)]]
+        MapField missingValueMapField = new MapField().isRequired(true)
+        missingValueMapField.setValue(missingValue)
+
+        when:
+        def errorCodes = mapField.getErrorCodes()
+        def duplicateValueValidation = duplicateValueMapField.validate()
+        def emptyValueValidation = emptyValueMapField.validate()
+        def missingValueValidation = missingValueMapField.validate()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(duplicateValueValidation.get(0).getCode())
+        errorCodes.contains(emptyValueValidation.get(0).getCode())
+        errorCodes.contains(missingValueValidation.get(0).getCode())
+    }
+
     def createEntry(String key, String value) {
         return [(PairField.KEY_FIELD_NAME): key, (PairField.VALUE_FIELD_NAME): value]
     }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/PortFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/PortFieldTest.groovy
@@ -54,4 +54,21 @@ class PortFieldTest extends Specification {
         port << [0, 65536]
 
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        PortField invalidPortField = new PortField()
+        invalidPortField.setValue(0)
+
+        PortField missingPortField = new PortField().isRequired(true)
+
+        when:
+        def errorCodes = invalidPortField.getErrorCodes()
+        def invalidPortFieldValidation = invalidPortField.validate()
+        def missingPortFieldValidation = missingPortField.validate()
+
+        then:
+        errorCodes.size() == 2
+        errorCodes.contains(invalidPortFieldValidation.get(0).getCode())
+        errorCodes.contains(missingPortFieldValidation.get(0).getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/UriFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/UriFieldTest.groovy
@@ -68,4 +68,27 @@ class UriFieldTest extends Specification {
                 'emptyPathWithScheme:',
                 'schemeWithEmptyPathCantStartWithDoubleSlash://']
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        UriField invalidUriField = new UriField()
+        invalidUriField.setValue('Inv@!id:U&i')
+
+        UriField emptyUriField = new UriField()
+        emptyUriField.setValue('')
+
+        UriField missingUriField = new UriField().isRequired(true)
+
+        when:
+        def errorCodes = uriField.getErrorCodes()
+        def invalidUriValidation = invalidUriField.validate()
+        def emptyUriValidation = emptyUriField.validate()
+        def missingUriValidation= missingUriField.validate()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(invalidUriValidation.get(0).getCode())
+        errorCodes.contains(emptyUriValidation.get(0).getCode())
+        errorCodes.contains(missingUriValidation.get(0).getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/UrlFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/UrlFieldTest.groovy
@@ -71,4 +71,27 @@ class UrlFieldTest extends Specification {
         'http://localhost:8993  ' | DefaultMessages.INVALID_URL
         '  '                      | DefaultMessages.INVALID_URL
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        UrlField invalidUrlField = new UrlField()
+        invalidUrlField.setValue('http://')
+
+        UrlField emptyUrlField = new UrlField()
+        emptyUrlField.setValue('')
+
+        UrlField missingUrlField = new UrlField().isRequired(true)
+
+        when:
+        def errorCodes = urlField.getErrorCodes()
+        def invalidUrlValidation = invalidUrlField.validate()
+        def emptyUrlValidation = emptyUrlField.validate()
+        def missingUrlValidation = missingUrlField.validate()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(invalidUrlValidation.get(0).getCode())
+        errorCodes.contains(emptyUrlValidation.get(0).getCode())
+        errorCodes.contains(missingUrlValidation.get(0).getCode())
+    }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/UrlFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/UrlFieldTest.groovy
@@ -18,7 +18,7 @@ import spock.lang.Specification
 
 class UrlFieldTest extends Specification {
 
-    def urlField
+    UrlField urlField
 
     def setup() {
         urlField = new UrlField()

--- a/query/common/src/test/java/org/codice/ddf/admin/common/fields/test/TestFieldProvider.java
+++ b/query/common/src/test/java/org/codice/ddf/admin/common/fields/test/TestFieldProvider.java
@@ -15,6 +15,7 @@ package org.codice.ddf.admin.common.fields.test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.Field;
@@ -30,6 +31,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.report.message.ErrorMessageImpl;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class TestFieldProvider extends BaseFieldProvider {
 
@@ -138,6 +140,11 @@ public class TestFieldProvider extends BaseFieldProvider {
         public FunctionField<IntegerField> newInstance() {
             return new GetInt();
         }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return ImmutableSet.of();
+        }
     }
 
     public static class GetBoolean extends GetFunctionField<BooleanField> {
@@ -165,6 +172,11 @@ public class TestFieldProvider extends BaseFieldProvider {
         public FunctionField<BooleanField> newInstance() {
             return new GetBoolean();
         }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return ImmutableSet.of();
+        }
     }
 
     public static class GetString extends GetFunctionField<StringField> {
@@ -191,6 +203,11 @@ public class TestFieldProvider extends BaseFieldProvider {
         @Override
         public FunctionField<StringField> newInstance() {
             return new GetString();
+        }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return ImmutableSet.of();
         }
     }
 
@@ -228,6 +245,11 @@ public class TestFieldProvider extends BaseFieldProvider {
         public FunctionField<ListField<TestObjectField>> newInstance() {
             return new GetList();
         }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return ImmutableSet.of();
+        }
     }
 
     public static class GetEnum extends GetFunctionField<TestEnumField> {
@@ -253,6 +275,11 @@ public class TestFieldProvider extends BaseFieldProvider {
         @Override
         public FunctionField<TestEnumField> newInstance() {
             return new GetEnum();
+        }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return ImmutableSet.of();
         }
     }
 
@@ -290,6 +317,11 @@ public class TestFieldProvider extends BaseFieldProvider {
         @Override
         public FunctionField<TestObjectField> newInstance() {
             return new RequiredArgsFunction();
+        }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return ImmutableSet.of();
         }
     }
 
@@ -340,6 +372,11 @@ public class TestFieldProvider extends BaseFieldProvider {
         @Override
         public FunctionField<TestObjectField> newInstance() {
             return new MultiArgFunction();
+        }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return ImmutableSet.of();
         }
     }
 
@@ -455,6 +492,14 @@ public class TestFieldProvider extends BaseFieldProvider {
         public FunctionField<TestObjectField> newInstance() {
             return new ReturnErrorsFunction();
         }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return new ImmutableSet.Builder<String>()
+                    .add(ARGUMENT_MSG)
+                    .add(RETURN_VALUE_MSG)
+                    .build();
+        }
     }
 
     public static ErrorMessageImpl sampleArgumentError(List<String> path) {
@@ -499,6 +544,14 @@ public class TestFieldProvider extends BaseFieldProvider {
         @Override
         public FunctionField<TestObjectField> newInstance() {
             return new SampleMutation();
+        }
+
+        @Override
+        public Set<String> getFunctionErrorCodes() {
+            return new ImmutableSet.Builder<String>()
+                    .add(ARGUMENT_MSG)
+                    .add(RETURN_VALUE_MSG)
+                    .build();
         }
     }
 }

--- a/query/common/src/test/java/org/codice/ddf/admin/common/fields/test/TestObjectField.java
+++ b/query/common/src/test/java/org/codice/ddf/admin/common/fields/test/TestObjectField.java
@@ -31,6 +31,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 
 public class TestObjectField extends BaseObjectField {
 
@@ -154,9 +155,10 @@ public class TestObjectField extends BaseObjectField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errorCodes = super.getErrorCodes();
-        errorCodes.add(OBJECT_FIELD_TEST_ERROR);
-        return errorCodes;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(OBJECT_FIELD_TEST_ERROR)
+                .build();
     }
 
     public class InnerTestObjectField extends BaseObjectField {
@@ -193,9 +195,10 @@ public class TestObjectField extends BaseObjectField {
 
         @Override
         public Set<String> getErrorCodes() {
-            Set<String> errorCodes = super.getErrorCodes();
-            errorCodes.add(INNER_OBJECT_FIELD_TEST_ERROR);
-            return errorCodes;
+            return new ImmutableSet.Builder<String>()
+                    .addAll(super.getErrorCodes())
+                    .add(INNER_OBJECT_FIELD_TEST_ERROR)
+                    .build();
         }
     }
 

--- a/query/common/src/test/java/org/codice/ddf/admin/common/fields/test/TestObjectField.java
+++ b/query/common/src/test/java/org/codice/ddf/admin/common/fields/test/TestObjectField.java
@@ -18,6 +18,7 @@ import static org.codice.ddf.admin.common.fields.test.TestFieldProvider.LIST_FIE
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.codice.ddf.admin.api.Field;
@@ -50,6 +51,8 @@ public class TestObjectField extends BaseObjectField {
     public static final String SUB_FIELD_OF_INNER_FIELD_NAME = "testSubField";
 
     public static final String INNER_OBJECT_FIELD_NAME = "innerObjectField";
+
+    public static final String OBJECT_FIELD_TEST_ERROR = "OBJECT_FIELD_TEST_ERROR";
 
     private InnerTestObjectField innerTestObjectField;
 
@@ -149,6 +152,13 @@ public class TestObjectField extends BaseObjectField {
                 innerTestObjectField);
     }
 
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errorCodes = super.getErrorCodes();
+        errorCodes.add(OBJECT_FIELD_TEST_ERROR);
+        return errorCodes;
+    }
+
     public class InnerTestObjectField extends BaseObjectField {
 
         public static final String FIELD_TYPE_NAME = "InnerTestObjectField";
@@ -156,6 +166,8 @@ public class TestObjectField extends BaseObjectField {
         public static final String DESCRIPTION = "InnerTestObjectField Description";
 
         public static final String TEST_VALUE = "testValue";
+
+        public static final String INNER_OBJECT_FIELD_TEST_ERROR = "INNER_OBJECT_FIELD_TEST_ERROR";
 
         public StringField subFieldOfInnerField;
 
@@ -177,6 +189,13 @@ public class TestObjectField extends BaseObjectField {
         @Override
         public List<Field> getFields() {
             return ImmutableList.of(subFieldOfInnerField);
+        }
+
+        @Override
+        public Set<String> getErrorCodes() {
+            Set<String> errorCodes = super.getErrorCodes();
+            errorCodes.add(INNER_OBJECT_FIELD_TEST_ERROR);
+            return errorCodes;
         }
     }
 

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
@@ -75,6 +75,7 @@ public class ExtendedOsgiGraphQLServlet extends OsgiGraphQLServlet implements Ev
     private List<GraphQLProviderImpl> transformedProviders;
     private ExecutionStrategyProvider execStrategy;
     private GraphQLErrorHandler errorHandler;
+    private GraphQLQueryProvider errorCodeProvider;
 
     public ExtendedOsgiGraphQLServlet() {
         super();
@@ -185,13 +186,21 @@ public class ExtendedOsgiGraphQLServlet extends OsgiGraphQLServlet implements Ev
 
         transformedProviders.forEach(this::unbindProvider);
 
+        if(errorCodeProvider != null){
+            unbindProvider(errorCodeProvider);
+        }
+
         GraphQLTransformCommons transformer = new GraphQLTransformCommons();
 
         transformedProviders = fieldProviders.stream()
                 .map(fieldProvider -> new GraphQLProviderImpl(fieldProvider, transformer))
                 .collect(Collectors.toList());
 
+        errorCodeProvider = transformer.getErrorCodesQueryProvider(fieldProviders);
+
         transformedProviders.forEach(this::bindProvider);
+
+        bindProvider(errorCodeProvider);
 
         LOGGER.debug("Finished refreshing GraphQL schema.");
     }

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformCommons.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformCommons.java
@@ -70,7 +70,7 @@ public class GraphQLTransformCommons {
 
         return () -> Collections.singletonList(GraphQLFieldDefinition.newFieldDefinition()
                 .name("errorCodes")
-                .description("Returns all the possible error codes from the graphql schema.")
+                .description("Returns all the possible error codes from the graphQL schema.")
                 .type(GraphQLList.list(errorCodeEnumType))
                 .dataFetcher((dataFetchingEnvironment) -> errorCodes)
                 .build());

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformCommons.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformCommons.java
@@ -14,12 +14,20 @@
 package org.codice.ddf.admin.graphql.transform;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.commons.lang.StringUtils;
+import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.FieldProvider;
+import org.codice.ddf.admin.api.fields.FunctionField;
 
+import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLList;
+import graphql.servlet.GraphQLQueryProvider;
 import graphql.servlet.GraphQLTypesProvider;
 
 public class GraphQLTransformCommons {
@@ -36,6 +44,36 @@ public class GraphQLTransformCommons {
 
     public List<GraphQLFieldDefinition> fieldProviderToQueries(FieldProvider provider) {
         return transformOutput.fieldsToGraphQLFieldDefinition(Arrays.asList(provider));
+    }
+
+    public GraphQLQueryProvider getErrorCodesQueryProvider(List<FieldProvider> fieldProviders) {
+        Set<String> errorCodes = new TreeSet<>();
+
+        for (FieldProvider fieldProvider : fieldProviders) {
+            List<FunctionField> mutations = fieldProvider.getMutationFunctions();
+            List<Field> queryFields = fieldProvider.getDiscoveryFields();
+
+            for (FunctionField mutation : mutations) {
+                errorCodes.addAll(mutation.getErrorCodes());
+            }
+
+            for (Field field : queryFields) {
+                errorCodes.addAll(field.getErrorCodes());
+            }
+        }
+
+        GraphQLEnumType.Builder enumTypeBuilder = GraphQLEnumType.newEnum()
+                .name("ErrorCode")
+                .description("All possible error codes.");
+        errorCodes.forEach(enumTypeBuilder::value);
+        GraphQLEnumType errorCodeEnumType = enumTypeBuilder.build();
+
+        return () -> Collections.singletonList(GraphQLFieldDefinition.newFieldDefinition()
+                .name("errorCodes")
+                .description("Returns all the possible error codes from the graphql schema.")
+                .type(GraphQLList.list(errorCodeEnumType))
+                .dataFetcher((dataFetchingEnvironment) -> errorCodes)
+                .build());
     }
 
     public static String capitalize(String str) {

--- a/query/graphql/src/test/groovy/org/codice/ddf/admin/graphql/test/GraphQLTransformationTest.groovy
+++ b/query/graphql/src/test/groovy/org/codice/ddf/admin/graphql/test/GraphQLTransformationTest.groovy
@@ -339,6 +339,18 @@ class GraphQLTransformationTest extends Specification {
         ]
     }
 
+    def 'successfully retrieve error codes without any errors'() {
+        setup:
+        request.addParameter(GRAPHQL_QUERY, getQuery('GetErrorCodes'))
+
+        when:
+        servlet.doGet(request, response)
+
+        then:
+        response.getStatus() == STATUS_OK
+        getResponseContentAsMap().errors == null
+    }
+
     def getResponseContentAsMap() {
         mapper.readValue(response.getContentAsByteArray(), Map)
     }

--- a/query/graphql/src/test/java/org/codice/ddf/admin/graphql/test/RunTestServlet.java
+++ b/query/graphql/src/test/java/org/codice/ddf/admin/graphql/test/RunTestServlet.java
@@ -13,6 +13,8 @@
  **/
 package org.codice.ddf.admin.graphql.test;
 
+import java.util.Arrays;
+
 import org.codice.ddf.admin.common.fields.test.TestFieldProvider;
 import org.codice.ddf.admin.graphql.servlet.ExtendedOsgiGraphQLServlet;
 import org.eclipse.jetty.server.Server;
@@ -35,6 +37,7 @@ public class RunTestServlet {
     public static class TestServlet extends ExtendedOsgiGraphQLServlet {
         public TestServlet() {
             super();
+            setFieldProviders(Arrays.asList(new TestFieldProvider()));
             bindFieldProvider(new TestFieldProvider());
         }
     }

--- a/query/graphql/src/test/resources/queries/GetErrorCodes
+++ b/query/graphql/src/test/resources/queries/GetErrorCodes
@@ -1,0 +1,3 @@
+query getErrorCodes{
+  errorCodes
+}

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ClaimsMapEntry.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ClaimsMapEntry.java
@@ -27,6 +27,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class ClaimsMapEntry extends BaseObjectField {
 
@@ -103,9 +104,10 @@ public class ClaimsMapEntry extends BaseObjectField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(DefaultMessages.MISSING_KEY_VALUE);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.MISSING_KEY_VALUE)
+                .build();
     }
 
     @Override

--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ClaimsMapEntry.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/fields/wcpm/ClaimsMapEntry.java
@@ -16,6 +16,7 @@ package org.codice.ddf.admin.security.common.fields.wcpm;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.missingKeyValue;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.codice.ddf.admin.api.Field;
@@ -23,6 +24,7 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.BaseListField;
 import org.codice.ddf.admin.common.fields.base.BaseObjectField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 
 import com.google.common.collect.ImmutableList;
 
@@ -97,6 +99,13 @@ public class ClaimsMapEntry extends BaseObjectField {
         }
 
         return validationMsgs;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(DefaultMessages.MISSING_KEY_VALUE);
+        return errors;
     }
 
     @Override

--- a/query/security/embeddedldap/src/main/java/org/codice/ddf/admin/ldap/embedded/InstallEmbeddedLdap.java
+++ b/query/security/embeddedldap/src/main/java/org/codice/ddf/admin/ldap/embedded/InstallEmbeddedLdap.java
@@ -21,12 +21,14 @@ import static org.codice.ddf.admin.security.common.services.LdapClaimsHandlerSer
 import static org.codice.ddf.admin.security.common.services.LdapLoginServiceProperties.LDAP_LOGIN_FEATURE;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.ConfiguratorFactory;
 import org.codice.ddf.admin.configurator.OperationReport;
@@ -104,5 +106,12 @@ public class InstallEmbeddedLdap extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new InstallEmbeddedLdap(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        return errorMessages;
     }
 }

--- a/query/security/embeddedldap/src/main/java/org/codice/ddf/admin/ldap/embedded/InstallEmbeddedLdap.java
+++ b/query/security/embeddedldap/src/main/java/org/codice/ddf/admin/ldap/embedded/InstallEmbeddedLdap.java
@@ -36,6 +36,7 @@ import org.codice.ddf.admin.security.common.fields.ldap.LdapUseCase;
 import org.codice.ddf.internal.admin.configurator.actions.FeatureActions;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class InstallEmbeddedLdap extends BaseFunctionField<BooleanField> {
     public static final String FIELD_NAME = "installEmbeddedLdap";
@@ -110,8 +111,6 @@ public class InstallEmbeddedLdap extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST);
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/GetLdapConfigurations.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/GetLdapConfigurations.java
@@ -13,12 +13,16 @@
  **/
 package org.codice.ddf.admin.ldap.discover;
 
+import java.util.Set;
+
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.ldap.commons.LdapServiceCommons;
 import org.codice.ddf.admin.ldap.fields.config.LdapConfigurationField;
+
+import com.google.common.collect.ImmutableSet;
 
 public class GetLdapConfigurations extends GetFunctionField<ListField<LdapConfigurationField>> {
 
@@ -54,5 +58,10 @@ public class GetLdapConfigurations extends GetFunctionField<ListField<LdapConfig
     @Override
     public FunctionField<ListField<LdapConfigurationField>> newInstance() {
         return new GetLdapConfigurations(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        return ImmutableSet.of();
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapQuery.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapQuery.java
@@ -40,6 +40,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LdapQuery extends BaseFunctionField<MapField.ListImpl> {
 
@@ -148,11 +149,9 @@ public class LdapQuery extends BaseFunctionField<MapField.ListImpl> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(LdapMessages.CANNOT_BIND);
-        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        return errorMessages;
+        return ImmutableSet.of(LdapMessages.CANNOT_BIND,
+                DefaultMessages.FAILED_TEST_SETUP,
+                DefaultMessages.CANNOT_CONNECT);
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapQuery.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapQuery.java
@@ -16,6 +16,7 @@ package org.codice.ddf.admin.ldap.discover;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.DataType;
@@ -23,7 +24,9 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.IntegerField;
 import org.codice.ddf.admin.common.fields.common.MapField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
 import org.codice.ddf.admin.ldap.fields.LdapDistinguishedName;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
@@ -141,6 +144,15 @@ public class LdapQuery extends BaseFunctionField<MapField.ListImpl> {
     @Override
     public MapField.ListImpl getReturnType() {
         return RETURN_TYPE;
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(LdapMessages.CANNOT_BIND);
+        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        return errorMessages;
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
@@ -15,11 +15,14 @@ package org.codice.ddf.admin.ldap.discover;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
 import org.codice.ddf.admin.ldap.commons.ServerGuesser;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
@@ -101,6 +104,15 @@ public class LdapRecommendedSettings extends BaseFunctionField<LdapRecommendedSe
     @Override
     public LdapRecommendedSettingsField getReturnType() {
         return RETURN_TYPE;
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(LdapMessages.CANNOT_BIND);
+        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        return errorMessages;
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettings.java
@@ -33,6 +33,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LdapRecommendedSettings extends BaseFunctionField<LdapRecommendedSettingsField> {
 
@@ -108,11 +109,9 @@ public class LdapRecommendedSettings extends BaseFunctionField<LdapRecommendedSe
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(LdapMessages.CANNOT_BIND);
-        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        return errorMessages;
+        return ImmutableSet.of(LdapMessages.CANNOT_BIND,
+                DefaultMessages.FAILED_TEST_SETUP,
+                DefaultMessages.CANNOT_CONNECT);
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
@@ -36,6 +36,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LdapTestBind extends TestFunctionField {
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapTestBind.class);
@@ -102,12 +103,10 @@ public class LdapTestBind extends TestFunctionField {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(LdapMessages.CANNOT_BIND);
-        errorMessages.add(LdapMessages.MD5_NEEDS_ENCRYPTED);
-        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        return errorMessages;
+        return ImmutableSet.of(LdapMessages.CANNOT_BIND,
+                LdapMessages.MD5_NEEDS_ENCRYPTED,
+                DefaultMessages.FAILED_TEST_SETUP,
+                DefaultMessages.CANNOT_CONNECT);
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestBind.java
@@ -20,12 +20,15 @@ import static org.codice.ddf.admin.ldap.fields.connection.LdapEncryptionMethodFi
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.TestFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
 import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField;
@@ -95,6 +98,16 @@ public class LdapTestBind extends TestFunctionField {
                         .path()));
             }
         }
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(LdapMessages.CANNOT_BIND);
+        errorMessages.add(LdapMessages.MD5_NEEDS_ENCRYPTED);
+        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        return errorMessages;
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
@@ -17,6 +17,7 @@ import static org.codice.ddf.admin.ldap.commons.LdapMessages.userAttributeNotFou
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
@@ -25,12 +26,15 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.TestFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
 import org.codice.ddf.admin.ldap.fields.LdapAttributeName;
 import org.codice.ddf.admin.ldap.fields.LdapDistinguishedName;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
 import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField;
+import org.codice.ddf.admin.security.common.SecurityMessages;
 import org.codice.ddf.admin.security.common.SecurityValidation;
 import org.codice.ddf.admin.security.common.fields.wcpm.ClaimsMapEntry;
 import org.codice.ddf.admin.security.common.services.StsServiceProperties;
@@ -154,6 +158,18 @@ public class LdapTestClaimMappings extends TestFunctionField {
         }
 
         return new BooleanField(!containsErrorMsgs());
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(SecurityMessages.INVALID_CLAIM_TYPE);
+        errorMessages.add(LdapMessages.CANNOT_BIND);
+        errorMessages.add(LdapMessages.DN_DOES_NOT_EXIST);
+        errorMessages.add(LdapMessages.USER_ATTRIBUTE_NOT_FOUND);
+        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        return errorMessages;
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappings.java
@@ -45,6 +45,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LdapTestClaimMappings extends TestFunctionField {
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapTestClaimMappings.class);
@@ -162,14 +163,12 @@ public class LdapTestClaimMappings extends TestFunctionField {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(SecurityMessages.INVALID_CLAIM_TYPE);
-        errorMessages.add(LdapMessages.CANNOT_BIND);
-        errorMessages.add(LdapMessages.DN_DOES_NOT_EXIST);
-        errorMessages.add(LdapMessages.USER_ATTRIBUTE_NOT_FOUND);
-        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        return errorMessages;
+        return ImmutableSet.of(SecurityMessages.INVALID_CLAIM_TYPE,
+                LdapMessages.CANNOT_BIND,
+                LdapMessages.DN_DOES_NOT_EXIST,
+                LdapMessages.USER_ATTRIBUTE_NOT_FOUND,
+                DefaultMessages.FAILED_TEST_SETUP,
+                DefaultMessages.CANNOT_CONNECT);
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestConnection.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestConnection.java
@@ -15,11 +15,13 @@ package org.codice.ddf.admin.ldap.discover;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.TestFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
 import org.codice.ddf.admin.ldap.fields.connection.LdapConnectionField;
@@ -67,6 +69,14 @@ public class LdapTestConnection extends TestFunctionField {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new LdapTestConnection();
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        return errorMessages;
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestConnection.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestConnection.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LdapTestConnection extends TestFunctionField {
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapTestConnection.class);
@@ -73,10 +74,8 @@ public class LdapTestConnection extends TestFunctionField {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_TEST_SETUP,
+                DefaultMessages.CANNOT_CONNECT);
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettings.java
@@ -43,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LdapTestDirectorySettings extends TestFunctionField {
     private static final Logger LOGGER = LoggerFactory.getLogger(LdapTestDirectorySettings.class);
@@ -138,17 +139,15 @@ public class LdapTestDirectorySettings extends TestFunctionField {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(LdapMessages.CANNOT_BIND);
-        errorMessages.add(LdapMessages.DN_DOES_NOT_EXIST);
-        errorMessages.add(LdapMessages.NO_USERS_IN_BASE_USER_DN);
-        errorMessages.add(LdapMessages.USER_ATTRIBUTE_NOT_FOUND);
-        errorMessages.add(LdapMessages.NO_GROUPS_IN_BASE_GROUP_DN);
-        errorMessages.add(LdapMessages.NO_GROUPS_WITH_MEMBERS);
-        errorMessages.add(LdapMessages.NO_REFERENCED_MEMBER);
-        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        return errorMessages;
+        return ImmutableSet.of(LdapMessages.CANNOT_BIND,
+                LdapMessages.DN_DOES_NOT_EXIST,
+                LdapMessages.NO_USERS_IN_BASE_USER_DN,
+                LdapMessages.USER_ATTRIBUTE_NOT_FOUND,
+                LdapMessages.NO_GROUPS_IN_BASE_GROUP_DN,
+                LdapMessages.NO_GROUPS_WITH_MEMBERS,
+                LdapMessages.NO_REFERENCED_MEMBER,
+                DefaultMessages.FAILED_TEST_SETUP,
+                DefaultMessages.CANNOT_CONNECT);
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettings.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettings.java
@@ -22,12 +22,15 @@ import static org.codice.ddf.admin.ldap.commons.LdapMessages.userAttributeNotFou
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.TestFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
 import org.codice.ddf.admin.ldap.fields.config.LdapDirectorySettingsField;
 import org.codice.ddf.admin.ldap.fields.connection.LdapBindUserInfo;
@@ -131,6 +134,21 @@ public class LdapTestDirectorySettings extends TestFunctionField {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new LdapTestDirectorySettings();
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(LdapMessages.CANNOT_BIND);
+        errorMessages.add(LdapMessages.DN_DOES_NOT_EXIST);
+        errorMessages.add(LdapMessages.NO_USERS_IN_BASE_USER_DN);
+        errorMessages.add(LdapMessages.USER_ATTRIBUTE_NOT_FOUND);
+        errorMessages.add(LdapMessages.NO_GROUPS_IN_BASE_GROUP_DN);
+        errorMessages.add(LdapMessages.NO_GROUPS_WITH_MEMBERS);
+        errorMessages.add(LdapMessages.NO_REFERENCED_MEMBER);
+        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        return errorMessages;
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapUserAttributes.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapUserAttributes.java
@@ -23,7 +23,9 @@ import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.ldap.commons.LdapConnectionAttempt;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.codice.ddf.admin.ldap.commons.LdapTestingUtils;
 import org.codice.ddf.admin.ldap.commons.ServerGuesser;
 import org.codice.ddf.admin.ldap.fields.LdapDistinguishedName;
@@ -113,6 +115,15 @@ public class LdapUserAttributes extends BaseFunctionField<StringField.ListImpl> 
     @Override
     public FunctionField<StringField.ListImpl> newInstance() {
         return new LdapUserAttributes();
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(LdapMessages.CANNOT_BIND);
+        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        return errorMessages;
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapUserAttributes.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/discover/LdapUserAttributes.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class LdapUserAttributes extends BaseFunctionField<StringField.ListImpl> {
 
@@ -119,11 +120,9 @@ public class LdapUserAttributes extends BaseFunctionField<StringField.ListImpl> 
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(LdapMessages.CANNOT_BIND);
-        errorMessages.add(DefaultMessages.FAILED_TEST_SETUP);
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        return errorMessages;
+        return ImmutableSet.of(LdapMessages.CANNOT_BIND,
+                DefaultMessages.FAILED_TEST_SETUP,
+                DefaultMessages.CANNOT_CONNECT);
     }
 
     /**

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapAttributeName.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapAttributeName.java
@@ -24,6 +24,8 @@ import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.ldap.commons.LdapMessages;
 
+import com.google.common.collect.ImmutableSet;
+
 /**
  * The description of an attribute names and the logic for validating them are defined in RFC 4512.
  * @see <a href="https://www.ietf.org/rfc/rfc4512.txt"> RFC 4512 </a>
@@ -81,8 +83,9 @@ public class LdapAttributeName extends StringField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(LdapMessages.INVALID_USER_ATTRIBUTE);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(LdapMessages.INVALID_USER_ATTRIBUTE)
+                .build();
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapAttributeName.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapAttributeName.java
@@ -17,10 +17,12 @@ import static org.codice.ddf.admin.ldap.commons.LdapMessages.invalidUserAttribut
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 
 /**
  * The description of an attribute names and the logic for validating them are defined in RFC 4512.
@@ -75,5 +77,12 @@ public class LdapAttributeName extends StringField {
     public LdapAttributeName isRequired(boolean required) {
         super.isRequired(required);
         return this;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(LdapMessages.INVALID_USER_ATTRIBUTE);
+        return errors;
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapDistinguishedName.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapDistinguishedName.java
@@ -16,11 +16,13 @@ package org.codice.ddf.admin.ldap.fields;
 import static org.codice.ddf.admin.ldap.commons.LdapMessages.invalidDnFormatError;
 
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.BaseListField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.forgerock.opendj.ldap.DN;
 
 public class LdapDistinguishedName extends StringField {
@@ -56,6 +58,13 @@ public class LdapDistinguishedName extends StringField {
         }
 
         return validationMsgs;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(LdapMessages.INVALID_DN);
+        return errors;
     }
 
     private boolean isValidDN(String dn) {

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapDistinguishedName.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/LdapDistinguishedName.java
@@ -25,6 +25,8 @@ import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.forgerock.opendj.ldap.DN;
 
+import com.google.common.collect.ImmutableSet;
+
 public class LdapDistinguishedName extends StringField {
     public static final String DEFAULT_FIELD_NAME = "dn";
 
@@ -62,9 +64,10 @@ public class LdapDistinguishedName extends StringField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(LdapMessages.INVALID_DN);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(LdapMessages.INVALID_DN)
+                .build();
     }
 
     private boolean isValidDN(String dn) {

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapQueryField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapQueryField.java
@@ -16,9 +16,11 @@ package org.codice.ddf.admin.ldap.fields.query;
 import static org.codice.ddf.admin.ldap.commons.LdapMessages.invalidQueryError;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.forgerock.opendj.ldap.Filter;
 
 public class LdapQueryField extends StringField {
@@ -59,5 +61,12 @@ public class LdapQueryField extends StringField {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        Set<String> errors = super.getErrorCodes();
+        errors.add(LdapMessages.INVALID_QUERY);
+        return errors;
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapQueryField.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/fields/query/LdapQueryField.java
@@ -23,6 +23,8 @@ import org.codice.ddf.admin.common.fields.base.scalar.StringField;
 import org.codice.ddf.admin.ldap.commons.LdapMessages;
 import org.forgerock.opendj.ldap.Filter;
 
+import com.google.common.collect.ImmutableSet;
+
 public class LdapQueryField extends StringField {
     public static final String DEFAULT_FIELD_NAME = "query";
 
@@ -65,8 +67,9 @@ public class LdapQueryField extends StringField {
 
     @Override
     public Set<String> getErrorCodes() {
-        Set<String> errors = super.getErrorCodes();
-        errors.add(LdapMessages.INVALID_QUERY);
-        return errors;
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(LdapMessages.INVALID_QUERY)
+                .build();
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
@@ -29,6 +30,7 @@ import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.ldap.commons.LdapServiceCommons;
@@ -145,5 +147,13 @@ public class CreateLdapConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new CreateLdapConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.SIMILAR_SERVICE_EXISTS);
+        return errorMessages;
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
@@ -152,7 +152,7 @@ public class CreateLdapConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
-                DefaultMessages.SIMILAR_SERVICE_EXISTS);
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST);
+
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/CreateLdapConfiguration.java
@@ -39,6 +39,7 @@ import org.codice.ddf.admin.security.common.services.LdapClaimsHandlerServicePro
 import org.codice.ddf.admin.security.common.services.LdapLoginServiceProperties;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class CreateLdapConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -151,9 +152,7 @@ public class CreateLdapConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.SIMILAR_SERVICE_EXISTS);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                DefaultMessages.SIMILAR_SERVICE_EXISTS);
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/DeleteLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/DeleteLdapConfiguration.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.ldap.persist;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -21,6 +22,7 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
@@ -78,5 +80,13 @@ public class DeleteLdapConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new DeleteLdapConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        return errorMessages;
     }
 }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/DeleteLdapConfiguration.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/persist/DeleteLdapConfiguration.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class DeleteLdapConfiguration extends BaseFunctionField<BooleanField> {
     public static final String FIELD_NAME = "deleteLdapConfig";
@@ -84,9 +85,7 @@ public class DeleteLdapConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+            DefaultMessages.NO_EXISTING_CONFIG);
     }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapAttributeNameSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapAttributeNameSpec.groovy
@@ -62,4 +62,27 @@ class LdapAttributeNameSpec extends Specification {
                 '2017'
         ]
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        LdapAttributeName invalidAttributeName = new LdapAttributeName()
+        invalidAttributeName.setValue('no space')
+
+        LdapAttributeName emptyAttributeName = new LdapAttributeName()
+        emptyAttributeName.setValue('')
+
+        LdapAttributeName missingAttributeName = new LdapAttributeName().isRequired(true)
+
+        when:
+        def errorCodes = ldapAttributeName.getErrorCodes()
+        def invalidAttributeReport = invalidAttributeName.validate()
+        def emptyAttributeReport = emptyAttributeName.validate()
+        def missingAttributeReport = missingAttributeName.validate()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(invalidAttributeReport[0].getCode())
+        errorCodes.contains(emptyAttributeReport[0].getCode())
+        errorCodes.contains(missingAttributeReport[0].getCode())
+    }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapQuerySpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapQuerySpec.groovy
@@ -279,19 +279,15 @@ class LdapQuerySpec extends Specification {
         LdapQuery cannotBindQuery = new LdapQuery()
         cannotBindQuery.setValue(cannotBindArgs)
 
-        LdapQuery missingFieldsQuery = new LdapQuery()
-
         when:
         def errorCodes = ldapQueryFunction.getFunctionErrorCodes()
         def cannotConnectReport = cannotConnectQuery.getValue()
         def cannotBindReport = cannotBindQuery.getValue()
-        def missingFieldReport = missingFieldsQuery.getValue()
 
         then:
-        errorCodes.size() == 4
+        errorCodes.size() == 3
         errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
         errorCodes.contains(cannotBindReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
         errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
     }
 

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapQuerySpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapQuerySpec.groovy
@@ -262,6 +262,39 @@ class LdapQuerySpec extends Specification {
         ldapConnectionIsClosed
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        Map<String, Object> cannotConnectArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().port(666).getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().getValue(),
+                (LdapQuery.QUERY_BASE_FIELD_NAME)       : exampleQueryBase().getValue(),
+                (LdapQueryField.DEFAULT_FIELD_NAME)     : exampleLdapQuery().getValue()]
+        LdapQuery cannotConnectQuery = new LdapQuery()
+        cannotConnectQuery.setValue(cannotConnectArgs)
+
+
+        Map<String, Object> cannotBindArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().password("badPassword").getValue(),
+                (LdapQuery.QUERY_BASE_FIELD_NAME)       : exampleQueryBase().getValue(),
+                (LdapQueryField.DEFAULT_FIELD_NAME)     : exampleLdapQuery().getValue()]
+        LdapQuery cannotBindQuery = new LdapQuery()
+        cannotBindQuery.setValue(cannotBindArgs)
+
+        LdapQuery missingFieldsQuery = new LdapQuery()
+
+        when:
+        def errorCodes = ldapQueryFunction.getFunctionErrorCodes()
+        def cannotConnectReport = cannotConnectQuery.getValue()
+        def cannotBindReport = cannotBindQuery.getValue()
+        def missingFieldReport = missingFieldsQuery.getValue()
+
+        then:
+        errorCodes.size() == 4
+        errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
+        errorCodes.contains(cannotBindReport.messages().get(0).getCode())
+        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
+        errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
+    }
+
     LdapDistinguishedName exampleQueryBase() {
         return new LdapDistinguishedName().dn(server.getBaseDistinguishedName())
     }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
@@ -168,4 +168,36 @@ class LdapRecommendedSettingsSpec extends Specification {
 
         ldapConnectionIsClosed
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        LdapRecommendedSettings cannotBindSettings = new LdapRecommendedSettings()
+        Map<String, Object> cannotBindArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().password('badPassword').getValue(),
+                (LdapTypeField.DEFAULT_FIELD_NAME)      : LdapTypeField.Unknown.UNKNOWN]
+        cannotBindSettings.setValue(cannotBindArgs)
+        cannotBindSettings.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
+
+        LdapRecommendedSettings cannotConnectSettings = new LdapRecommendedSettings()
+        Map<String, Object> cannotConnectArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().port(666).getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().getValue(),
+                (LdapTypeField.DEFAULT_FIELD_NAME)      : LdapTypeField.Unknown.UNKNOWN]
+        cannotConnectSettings.setValue(cannotConnectArgs)
+        cannotConnectSettings.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
+
+        LdapRecommendedSettings missingFieldSettings = new LdapRecommendedSettings()
+
+        when:
+        def errorCodes = action.getFunctionErrorCodes()
+        def cannotBindReport = cannotBindSettings.getValue()
+        def cannotConnectReport = cannotConnectSettings.getValue()
+        def missingFieldReport = missingFieldSettings.getValue()
+
+        then:
+        errorCodes.size() == 4
+        errorCodes.contains(cannotBindReport.messages().get(0).getCode())
+        errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
+        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
+        errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
+    }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapRecommendedSettingsSpec.groovy
@@ -185,19 +185,15 @@ class LdapRecommendedSettingsSpec extends Specification {
         cannotConnectSettings.setValue(cannotConnectArgs)
         cannotConnectSettings.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
 
-        LdapRecommendedSettings missingFieldSettings = new LdapRecommendedSettings()
-
         when:
         def errorCodes = action.getFunctionErrorCodes()
         def cannotBindReport = cannotBindSettings.getValue()
         def cannotConnectReport = cannotConnectSettings.getValue()
-        def missingFieldReport = missingFieldSettings.getValue()
 
         then:
-        errorCodes.size() == 4
+        errorCodes.size() == 3
         errorCodes.contains(cannotBindReport.messages().get(0).getCode())
         errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
         errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
     }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestBindSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestBindSpec.groovy
@@ -258,21 +258,17 @@ class LdapTestBindSpec extends Specification {
         md5NeededBindFunc.setValue(cannotBindArgs)
         md5NeededBindFunc.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
 
-        LdapTestBind missingFieldBindFunc = new LdapTestBind()
-
         when:
         def errorCodes = ldapBindFunction.getFunctionErrorCodes()
         def cannotConnectReport = cannotConnectBindFunc.getValue()
         def cannotBindReport = cannotBindFunc.getValue()
         def md5NeededReport = md5NeededBindFunc.getValue()
-        def missingFieldReport = missingFieldBindFunc.getValue()
 
         then:
-        errorCodes.size() == 5
+        errorCodes.size() == 4
         errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
         errorCodes.contains(cannotBindReport.messages().get(0).getCode())
         errorCodes.contains(md5NeededReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
         errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
     }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestClaimMappingsSpec.groovy
@@ -353,6 +353,20 @@ class LdapTestClaimMappingsSpec extends Specification {
         ldapConnectionIsClosed
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        when:
+        def errorCodes = action.getFunctionErrorCodes()
+
+        then:
+        errorCodes.size() == 6
+        errorCodes.contains(DefaultMessages.CANNOT_CONNECT)
+        errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
+        errorCodes.contains(LdapMessages.USER_ATTRIBUTE_NOT_FOUND)
+        errorCodes.contains(LdapMessages.DN_DOES_NOT_EXIST)
+        errorCodes.contains(LdapMessages.CANNOT_BIND)
+        errorCodes.contains(SecurityMessages.INVALID_CLAIM_TYPE)
+    }
+
     private static ClaimsMapEntry.ListImpl createClaimsMapping(Map<String, String> claims) {
         def claimMappings = new ClaimsMapEntry.ListImpl()
         claims.each {

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestConnectionSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestConnectionSpec.groovy
@@ -196,6 +196,32 @@ class LdapTestConnectionSpec extends Specification {
         report.messages().get(0).getPath() == [LdapTestConnection.FIELD_NAME]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        LdapTestConnection cannotConnectLdapFunc = new LdapTestConnection()
+        Map<String, Object> cannotConnectArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): ldapsLdapConnectionInfo().hostname("badHostname").getValue()]
+        cannotConnectLdapFunc.setValue(cannotConnectArgs)
+
+        LdapTestConnection failedSetupLdapFunc = new LdapTestConnection()
+        Map<String, Object> failedSetupArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): ldapsLdapConnectionInfo().getValue()]
+        failedSetupLdapFunc.setValue(failedSetupArgs)
+        failedSetupLdapFunc.setTestingUtils(new LdapTestingUtilsMock(true))
+
+        LdapTestConnection missingFieldLdapFunc = new LdapTestConnection()
+
+        when:
+        def errorCodes = ldapConnectFunction.getFunctionErrorCodes()
+        def cannotConnectReport = cannotConnectLdapFunc.getValue()
+        def failedSetupReport = failedSetupLdapFunc.getValue()
+        def missingFieldReport = missingFieldLdapFunc.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
+        errorCodes.contains(failedSetupReport.messages().get(0).getCode())
+        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
+    }
+
     LdapConnectionField ldapsLdapConnectionInfo() {
         return new LdapConnectionField()
                 .hostname(server.getHostname())

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestConnectionSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestConnectionSpec.groovy
@@ -207,19 +207,15 @@ class LdapTestConnectionSpec extends Specification {
         failedSetupLdapFunc.setValue(failedSetupArgs)
         failedSetupLdapFunc.setTestingUtils(new LdapTestingUtilsMock(true))
 
-        LdapTestConnection missingFieldLdapFunc = new LdapTestConnection()
-
         when:
         def errorCodes = ldapConnectFunction.getFunctionErrorCodes()
         def cannotConnectReport = cannotConnectLdapFunc.getValue()
         def failedSetupReport = failedSetupLdapFunc.getValue()
-        def missingFieldReport = missingFieldLdapFunc.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
         errorCodes.contains(failedSetupReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
     }
 
     LdapConnectionField ldapsLdapConnectionInfo() {

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapTestDirectorySettingsSpec.groovy
@@ -432,4 +432,21 @@ class LdapTestDirectorySettingsSpec extends Specification {
         0 * action.checkGroup(_)
         0 * action.checkReferencedUser(_, _)
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        when:
+        def errorCodes = action.getFunctionErrorCodes()
+
+        then:
+        errorCodes.size() == 9
+        errorCodes.contains(DefaultMessages.CANNOT_CONNECT)
+        errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
+        errorCodes.contains(LdapMessages.USER_ATTRIBUTE_NOT_FOUND)
+        errorCodes.contains(LdapMessages.DN_DOES_NOT_EXIST)
+        errorCodes.contains(LdapMessages.CANNOT_BIND)
+        errorCodes.contains(LdapMessages.NO_USERS_IN_BASE_USER_DN)
+        errorCodes.contains(LdapMessages.NO_GROUPS_IN_BASE_GROUP_DN)
+        errorCodes.contains(LdapMessages.NO_GROUPS_WITH_MEMBERS)
+        errorCodes.contains(LdapMessages.NO_REFERENCED_MEMBER)
+    }
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapUserAttributesSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapUserAttributesSpec.groovy
@@ -148,4 +148,36 @@ class LdapUserAttributesSpec extends Specification {
         ldapConnectionIsClosed
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        LdapUserAttributes cannotConnectAction = new LdapUserAttributes()
+        Map<String, Object> cannotConnectArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().port(666).getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().getValue(),
+                (LdapUserAttributes.BASE_USER_DN)  : LdapTestingCommons.LDAP_SERVER_BASE_GROUP_DN]
+        cannotConnectAction.setValue(cannotConnectArgs)
+        cannotConnectAction.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
+
+        LdapUserAttributes cannotBindAction = new LdapUserAttributes()
+        Map<String, Object> cannotBindArgs = [(LdapConnectionField.DEFAULT_FIELD_NAME): noEncryptionLdapConnectionInfo().getValue(),
+                (LdapBindUserInfo.DEFAULT_FIELD_NAME)   : simpleBindInfo().password('badPassword').getValue(),
+                (LdapUserAttributes.BASE_USER_DN)  : LdapTestingCommons.LDAP_SERVER_BASE_GROUP_DN]
+        cannotBindAction.setValue(cannotBindArgs)
+        cannotBindAction.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
+
+        LdapUserAttributes missingFieldAction = new LdapUserAttributes()
+
+        when:
+        def errorCodes = action.getFunctionErrorCodes()
+        def cannotConnectReport = cannotConnectAction.getValue()
+        def cannotBindReport = cannotBindAction.getValue()
+        def missingFieldReport = missingFieldAction.getValue()
+
+        then:
+        errorCodes.size() == 4
+        errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
+        errorCodes.contains(cannotBindReport.messages().get(0).getCode())
+        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
+        errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
+    }
+
 }

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapUserAttributesSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/LdapUserAttributesSpec.groovy
@@ -164,19 +164,15 @@ class LdapUserAttributesSpec extends Specification {
         cannotBindAction.setValue(cannotBindArgs)
         cannotBindAction.setTestingUtils(new LdapTestConnectionSpec.LdapTestingUtilsMock())
 
-        LdapUserAttributes missingFieldAction = new LdapUserAttributes()
-
         when:
         def errorCodes = action.getFunctionErrorCodes()
         def cannotConnectReport = cannotConnectAction.getValue()
         def cannotBindReport = cannotBindAction.getValue()
-        def missingFieldReport = missingFieldAction.getValue()
 
         then:
-        errorCodes.size() == 4
+        errorCodes.size() == 3
         errorCodes.contains(cannotConnectReport.messages().get(0).getCode())
         errorCodes.contains(cannotBindReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
         errorCodes.contains(DefaultMessages.FAILED_TEST_SETUP)
     }
 

--- a/query/security/sts/src/main/java/org/codice/ddf/admin/security/sts/discover/GetStsClaimsFunctionField.java
+++ b/query/security/sts/src/main/java/org/codice/ddf/admin/security/sts/discover/GetStsClaimsFunctionField.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.security.sts.discover;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
@@ -21,6 +22,8 @@ import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.security.common.fields.sts.StsClaimField;
 import org.codice.ddf.admin.security.common.services.StsServiceProperties;
 import org.codice.ddf.internal.admin.configurator.actions.ServiceActions;
+
+import com.google.common.collect.ImmutableSet;
 
 public class GetStsClaimsFunctionField extends GetFunctionField<ListField<StsClaimField>> {
 
@@ -62,5 +65,10 @@ public class GetStsClaimsFunctionField extends GetFunctionField<ListField<StsCla
     @Override
     public FunctionField<ListField<StsClaimField>> newInstance() {
         return new GetStsClaimsFunctionField(serviceActions);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        return ImmutableSet.of();
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetAuthTypes.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetAuthTypes.java
@@ -14,12 +14,15 @@
 package org.codice.ddf.admin.security.wcpm.discover;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.security.common.fields.wcpm.AuthType;
 import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
+
+import com.google.common.collect.ImmutableSet;
 
 public class GetAuthTypes extends GetFunctionField<AuthType.ListImpl> {
 
@@ -56,5 +59,10 @@ public class GetAuthTypes extends GetFunctionField<AuthType.ListImpl> {
     @Override
     public FunctionField<AuthType.ListImpl> newInstance() {
         return new GetAuthTypes(serviceReader);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        return ImmutableSet.of();
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetContextPolicies.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetContextPolicies.java
@@ -13,11 +13,15 @@
  **/
 package org.codice.ddf.admin.security.wcpm.discover;
 
+import java.util.Set;
+
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.security.common.fields.wcpm.ContextPolicyBin;
 import org.codice.ddf.admin.security.common.services.PolicyManagerServiceProperties;
 import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
+
+import com.google.common.collect.ImmutableSet;
 
 public class GetContextPolicies extends GetFunctionField<ContextPolicyBin.ListImpl> {
 
@@ -51,5 +55,10 @@ public class GetContextPolicies extends GetFunctionField<ContextPolicyBin.ListIm
     @Override
     public FunctionField<ContextPolicyBin.ListImpl> newInstance() {
         return new GetContextPolicies(serviceReader);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        return ImmutableSet.of();
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetRealms.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetRealms.java
@@ -14,12 +14,15 @@
 package org.codice.ddf.admin.security.wcpm.discover;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.security.common.fields.wcpm.Realm;
 import org.codice.ddf.internal.admin.configurator.actions.ServiceReader;
+
+import com.google.common.collect.ImmutableSet;
 
 public class GetRealms extends GetFunctionField<Realm.ListImpl> {
 
@@ -52,5 +55,10 @@ public class GetRealms extends GetFunctionField<Realm.ListImpl> {
     @Override
     public FunctionField<Realm.ListImpl> newInstance() {
         return new GetRealms(serviceReader);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        return ImmutableSet.of();
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetWhiteListContexts.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/discover/GetWhiteListContexts.java
@@ -16,11 +16,14 @@ package org.codice.ddf.admin.security.wcpm.discover;
 import static org.codice.ddf.admin.security.common.services.PolicyManagerServiceProperties.getWhitelistContexts;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.function.GetFunctionField;
 import org.codice.ddf.admin.common.fields.common.ContextPath;
+
+import com.google.common.collect.ImmutableSet;
 
 public class GetWhiteListContexts extends GetFunctionField<ContextPath.ListImpl> {
 
@@ -59,5 +62,10 @@ public class GetWhiteListContexts extends GetFunctionField<ContextPath.ListImpl>
     @Override
     public FunctionField<ContextPath.ListImpl> newInstance() {
         return new GetWhiteListContexts(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        return ImmutableSet.of();
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveContextPolices.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveContextPolices.java
@@ -21,6 +21,7 @@ import static org.codice.ddf.admin.security.common.services.PolicyManagerService
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
@@ -28,8 +29,10 @@ import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.security.common.SecurityMessages;
 import org.codice.ddf.admin.security.common.SecurityValidation;
 import org.codice.ddf.admin.security.common.fields.wcpm.ClaimsMapEntry;
 import org.codice.ddf.admin.security.common.fields.wcpm.ContextPolicyBin;
@@ -132,5 +135,14 @@ public class SaveContextPolices extends BaseFunctionField<ContextPolicyBin.ListI
     @Override
     public FunctionField<ContextPolicyBin.ListImpl> newInstance() {
         return new SaveContextPolices(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(SecurityMessages.INVALID_CLAIM_TYPE);
+        errorMessages.add(SecurityMessages.NO_ROOT_CONTEXT);
+        return errorMessages;
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveContextPolices.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveContextPolices.java
@@ -40,6 +40,7 @@ import org.codice.ddf.admin.security.common.services.PolicyManagerServicePropert
 import org.codice.ddf.admin.security.common.services.StsServiceProperties;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class SaveContextPolices extends BaseFunctionField<ContextPolicyBin.ListImpl> {
 
@@ -139,10 +140,8 @@ public class SaveContextPolices extends BaseFunctionField<ContextPolicyBin.ListI
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(SecurityMessages.INVALID_CLAIM_TYPE);
-        errorMessages.add(SecurityMessages.NO_ROOT_CONTEXT);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                SecurityMessages.INVALID_CLAIM_TYPE,
+                SecurityMessages.NO_ROOT_CONTEXT);
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContexts.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContexts.java
@@ -28,6 +28,7 @@ import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.security.common.services.PolicyManagerServiceProperties;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class SaveWhitelistContexts extends BaseFunctionField<ContextPath.ListImpl> {
 
@@ -87,8 +88,6 @@ public class SaveWhitelistContexts extends BaseFunctionField<ContextPath.ListImp
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST);
     }
 }

--- a/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContexts.java
+++ b/query/security/wcpm/src/main/java/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContexts.java
@@ -16,11 +16,13 @@ package org.codice.ddf.admin.security.wcpm.persist;
 import static org.codice.ddf.admin.common.report.message.DefaultMessages.failedPersistError;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.ContextPath;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
 import org.codice.ddf.admin.security.common.services.PolicyManagerServiceProperties;
@@ -81,5 +83,12 @@ public class SaveWhitelistContexts extends BaseFunctionField<ContextPath.ListImp
     @Override
     public SaveWhitelistContexts newInstance() {
         return new SaveWhitelistContexts(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        return errorMessages;
     }
 }

--- a/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveContextPoliciesSpec.groovy
+++ b/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveContextPoliciesSpec.groovy
@@ -280,4 +280,20 @@ class SaveContextPoliciesSpec extends Specification {
         report.messages()[0].path == [WcpmFieldProvider.NAME, SaveContextPolices.FUNCTION_FIELD_NAME, BaseFunctionField.ARGUMENT, 'policies', '0', 'claimsMapping', '0', ClaimsMapEntry.KEY_FIELD_NAME]
         report.result() == null
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        when:
+        def errorCodes = saveContextPoliciesFunction.getErrorCodes()
+
+        then:
+        errorCodes.size() == 8
+        errorCodes.contains(DefaultMessages.FAILED_PERSIST)
+        errorCodes.contains(DefaultMessages.INVALID_CONTEXT_PATH)
+        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
+        errorCodes.contains(DefaultMessages.EMPTY_FIELD)
+        errorCodes.contains(DefaultMessages.MISSING_KEY_VALUE)
+        errorCodes.contains(DefaultMessages.UNSUPPORTED_ENUM)
+        errorCodes.contains(SecurityMessages.INVALID_CLAIM_TYPE)
+        errorCodes.contains(SecurityMessages.NO_ROOT_CONTEXT)
+    }
 }

--- a/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContextsTest.groovy
+++ b/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContextsTest.groovy
@@ -135,4 +135,16 @@ class SaveWhitelistContextsTest extends Specification {
         report.messages()[0].path == [wcpmFieldProvider.NAME, SaveWhitelistContexts.FIELD_NAME]
         report.result() == null
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        when:
+        def errorCodes = saveWhitelistContextsFunction.getErrorCodes()
+
+        then:
+        errorCodes.size() == 4
+        errorCodes.contains(DefaultMessages.FAILED_PERSIST)
+        errorCodes.contains(DefaultMessages.INVALID_CONTEXT_PATH)
+        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
+        errorCodes.contains(DefaultMessages.EMPTY_FIELD)
+    }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.csw.discover;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -23,6 +24,7 @@ import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.common.fields.common.ResponseField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.sources.csw.CswSourceUtils;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 
@@ -93,6 +95,14 @@ public class DiscoverCswSource extends BaseFunctionField<CswSourceConfigurationF
     @Override
     public FunctionField<CswSourceConfigurationField> newInstance() {
         return new DiscoverCswSource(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        errorMessages.add(DefaultMessages.UNKNOWN_ENDPOINT);
+        return errorMessages;
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSource.java
@@ -29,6 +29,7 @@ import org.codice.ddf.admin.sources.csw.CswSourceUtils;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class DiscoverCswSource extends BaseFunctionField<CswSourceConfigurationField> {
 
@@ -99,10 +100,8 @@ public class DiscoverCswSource extends BaseFunctionField<CswSourceConfigurationF
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        errorMessages.add(DefaultMessages.UNKNOWN_ENDPOINT);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.CANNOT_CONNECT,
+                DefaultMessages.UNKNOWN_ENDPOINT);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/GetCswConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/GetCswConfigurations.java
@@ -17,6 +17,7 @@ import static org.codice.ddf.admin.sources.services.CswServiceProperties.CSW_FAC
 import static org.codice.ddf.admin.sources.services.CswServiceProperties.SERVICE_PROPS_TO_CSW_CONFIG;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -24,6 +25,7 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.sources.csw.CswSourceInfoField;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
@@ -107,5 +109,12 @@ public class GetCswConfigurations extends BaseFunctionField<ListField<CswSourceI
     @Override
     public FunctionField<ListField<CswSourceInfoField>> newInstance() {
         return new GetCswConfigurations(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/GetCswConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/discover/GetCswConfigurations.java
@@ -33,6 +33,7 @@ import org.codice.ddf.admin.sources.fields.type.SourceConfigField;
 import org.codice.ddf.admin.sources.utils.SourceUtilCommons;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class GetCswConfigurations extends BaseFunctionField<ListField<CswSourceInfoField>> {
 
@@ -113,8 +114,6 @@ public class GetCswConfigurations extends BaseFunctionField<ListField<CswSourceI
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.NO_EXISTING_CONFIG);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswConfiguration.java
@@ -35,6 +35,7 @@ import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class CreateCswConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -108,9 +109,7 @@ public class CreateCswConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                SourceMessages.DUPLICATE_SOURCE_NAME);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/CreateCswConfiguration.java
@@ -19,15 +19,18 @@ import static org.codice.ddf.admin.sources.services.CswServiceProperties.cswConf
 import static org.codice.ddf.admin.sources.services.CswServiceProperties.cswProfileToFactoryPid;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.sources.SourceMessages;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
@@ -101,5 +104,13 @@ public class CreateCswConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new CreateCswConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfiguration.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.csw.persist;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -21,6 +22,7 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
@@ -79,5 +81,13 @@ public class DeleteCswConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new DeleteCswConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfiguration.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class DeleteCswConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -85,9 +86,7 @@ public class DeleteCswConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                DefaultMessages.NO_EXISTING_CONFIG);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfiguration.java
@@ -19,15 +19,18 @@ import static org.codice.ddf.admin.sources.services.CswServiceProperties.CSW_FEA
 import static org.codice.ddf.admin.sources.services.CswServiceProperties.cswConfigToServiceProps;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.sources.SourceMessages;
 import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
@@ -106,5 +109,14 @@ public class UpdateCswConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new UpdateCswConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfiguration.java
@@ -35,6 +35,7 @@ import org.codice.ddf.admin.sources.fields.type.CswSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class UpdateCswConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -113,10 +114,8 @@ public class UpdateCswConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                DefaultMessages.NO_EXISTING_CONFIG,
+                SourceMessages.DUPLICATE_SOURCE_NAME);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
@@ -30,6 +30,7 @@ import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationFie
 import org.codice.ddf.admin.sources.opensearch.OpenSearchSourceUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class DiscoverOpenSearchSource
         extends BaseFunctionField<OpenSearchSourceConfigurationField> {
@@ -108,9 +109,7 @@ public class DiscoverOpenSearchSource
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        errorMessages.add(DefaultMessages.UNKNOWN_ENDPOINT);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.CANNOT_CONNECT,
+                DefaultMessages.UNKNOWN_ENDPOINT);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSource.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.opensearch.discover;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -24,6 +25,7 @@ import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.common.fields.common.ResponseField;
 import org.codice.ddf.admin.common.report.ReportWithResultImpl;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationField;
 import org.codice.ddf.admin.sources.opensearch.OpenSearchSourceUtils;
 
@@ -102,5 +104,13 @@ public class DiscoverOpenSearchSource
      */
     private void setOpenSearchSourceUtils(OpenSearchSourceUtils openSearchSourceUtils) {
         this.openSearchSourceUtils = openSearchSourceUtils;
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        errorMessages.add(DefaultMessages.UNKNOWN_ENDPOINT);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigurations.java
@@ -33,6 +33,7 @@ import org.codice.ddf.admin.sources.opensearch.OpenSearchSourceInfoField;
 import org.codice.ddf.admin.sources.utils.SourceUtilCommons;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class GetOpenSearchConfigurations
         extends BaseFunctionField<ListField<OpenSearchSourceInfoField>> {
@@ -117,8 +118,6 @@ public class GetOpenSearchConfigurations
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.NO_EXISTING_CONFIG);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigurations.java
@@ -17,6 +17,7 @@ import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.
 import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.SERVICE_PROPS_TO_OPENSEARCH_CONFIG;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -24,6 +25,7 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationField;
 import org.codice.ddf.admin.sources.fields.type.SourceConfigField;
@@ -111,5 +113,12 @@ public class GetOpenSearchConfigurations
     @Override
     public FunctionField<ListField<OpenSearchSourceInfoField>> newInstance() {
         return new GetOpenSearchConfigurations(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfiguration.java
@@ -19,15 +19,18 @@ import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.
 import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.openSearchConfigToServiceProps;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.sources.SourceMessages;
 import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
@@ -100,5 +103,13 @@ public class CreateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new CreateOpenSearchConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfiguration.java
@@ -35,6 +35,7 @@ import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationFie
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class CreateOpenSearchConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -107,9 +108,7 @@ public class CreateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                SourceMessages.DUPLICATE_SOURCE_NAME);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfiguration.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class DeleteOpenSearchConfiguration extends BaseFunctionField<BooleanField> {
     public static final String FIELD_NAME = "deleteOpenSearchSource";
@@ -84,9 +85,7 @@ public class DeleteOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                DefaultMessages.NO_EXISTING_CONFIG);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfiguration.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.opensearch.persist;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -21,6 +22,7 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
@@ -78,5 +80,13 @@ public class DeleteOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new DeleteOpenSearchConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfiguration.java
@@ -19,15 +19,18 @@ import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.
 import static org.codice.ddf.admin.sources.services.OpenSearchServiceProperties.openSearchConfigToServiceProps;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.sources.SourceMessages;
 import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
@@ -105,5 +108,14 @@ public class UpdateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new UpdateOpenSearchConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfiguration.java
@@ -35,6 +35,7 @@ import org.codice.ddf.admin.sources.fields.type.OpenSearchSourceConfigurationFie
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class UpdateOpenSearchConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -112,10 +113,8 @@ public class UpdateOpenSearchConfiguration extends BaseFunctionField<BooleanFiel
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                DefaultMessages.NO_EXISTING_CONFIG,
+                SourceMessages.DUPLICATE_SOURCE_NAME);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.wfs.discover;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -23,6 +24,7 @@ import org.codice.ddf.admin.common.fields.common.AddressField;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.common.fields.common.ResponseField;
 import org.codice.ddf.admin.common.report.ReportWithResultImpl;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.wfs.WfsSourceUtils;
 
@@ -92,6 +94,14 @@ public class DiscoverWfsSource extends BaseFunctionField<WfsSourceConfigurationF
     @Override
     public FunctionField<WfsSourceConfigurationField> newInstance() {
         return new DiscoverWfsSource(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
+        errorMessages.add(DefaultMessages.UNKNOWN_ENDPOINT);
+        return errorMessages;
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSource.java
@@ -29,6 +29,7 @@ import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.wfs.WfsSourceUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class DiscoverWfsSource extends BaseFunctionField<WfsSourceConfigurationField> {
 
@@ -98,10 +99,8 @@ public class DiscoverWfsSource extends BaseFunctionField<WfsSourceConfigurationF
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.CANNOT_CONNECT);
-        errorMessages.add(DefaultMessages.UNKNOWN_ENDPOINT);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.CANNOT_CONNECT,
+                DefaultMessages.UNKNOWN_ENDPOINT);
     }
 
     /**

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigurations.java
@@ -32,6 +32,7 @@ import org.codice.ddf.admin.sources.utils.SourceUtilCommons;
 import org.codice.ddf.admin.sources.wfs.WfsSourceInfoField;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class GetWfsConfigurations extends BaseFunctionField<ListField<WfsSourceInfoField>> {
 
@@ -112,8 +113,6 @@ public class GetWfsConfigurations extends BaseFunctionField<ListField<WfsSourceI
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.NO_EXISTING_CONFIG);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigurations.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigurations.java
@@ -17,12 +17,14 @@ import static org.codice.ddf.admin.sources.services.WfsServiceProperties.SERVICE
 import static org.codice.ddf.admin.sources.services.WfsServiceProperties.WFS_FACTORY_PIDS;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.sources.fields.type.SourceConfigField;
 import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
@@ -106,5 +108,12 @@ public class GetWfsConfigurations extends BaseFunctionField<ListField<WfsSourceI
     @Override
     public ListField<WfsSourceInfoField> getReturnType() {
         return RETURN_TYPE;
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfiguration.java
@@ -20,15 +20,18 @@ import static org.codice.ddf.admin.sources.services.WfsServiceProperties.wfsConf
 import static org.codice.ddf.admin.sources.services.WfsServiceProperties.wfsVersionToFactoryPid;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.sources.SourceMessages;
 import org.codice.ddf.admin.sources.fields.WfsVersion;
 import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
@@ -112,5 +115,13 @@ public class CreateWfsConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new CreateWfsConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfiguration.java
@@ -37,6 +37,7 @@ import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class CreateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -119,9 +120,7 @@ public class CreateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                SourceMessages.DUPLICATE_SOURCE_NAME);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfiguration.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class DeleteWfsConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -85,9 +86,7 @@ public class DeleteWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                DefaultMessages.NO_EXISTING_CONFIG);
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfiguration.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.sources.wfs.persist;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
@@ -21,6 +22,7 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.PidField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 
 import com.google.common.collect.ImmutableList;
@@ -79,5 +81,13 @@ public class DeleteWfsConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new DeleteWfsConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfiguration.java
@@ -20,15 +20,18 @@ import static org.codice.ddf.admin.sources.services.WfsServiceProperties.WFS2_FE
 import static org.codice.ddf.admin.sources.services.WfsServiceProperties.wfsConfigToServiceProps;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.ConfiguratorSuite;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.common.fields.base.BaseFunctionField;
 import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
 import org.codice.ddf.admin.common.services.ServiceCommons;
 import org.codice.ddf.admin.configurator.Configurator;
 import org.codice.ddf.admin.configurator.OperationReport;
+import org.codice.ddf.admin.sources.SourceMessages;
 import org.codice.ddf.admin.sources.fields.WfsVersion;
 import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
@@ -116,5 +119,14 @@ public class UpdateWfsConfiguration extends BaseFunctionField<BooleanField> {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new UpdateWfsConfiguration(configuratorSuite);
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        Set<String> errorMessages = super.getFunctionErrorCodes();
+        errorMessages.add(DefaultMessages.FAILED_PERSIST);
+        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
+        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
+        return errorMessages;
     }
 }

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfiguration.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfiguration.java
@@ -37,6 +37,7 @@ import org.codice.ddf.admin.sources.fields.type.WfsSourceConfigurationField;
 import org.codice.ddf.admin.sources.utils.SourceValidationUtils;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class UpdateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
@@ -123,10 +124,8 @@ public class UpdateWfsConfiguration extends BaseFunctionField<BooleanField> {
 
     @Override
     public Set<String> getFunctionErrorCodes() {
-        Set<String> errorMessages = super.getFunctionErrorCodes();
-        errorMessages.add(DefaultMessages.FAILED_PERSIST);
-        errorMessages.add(DefaultMessages.NO_EXISTING_CONFIG);
-        errorMessages.add(SourceMessages.DUPLICATE_SOURCE_NAME);
-        return errorMessages;
+        return ImmutableSet.of(DefaultMessages.FAILED_PERSIST,
+                DefaultMessages.NO_EXISTING_CONFIG,
+                SourceMessages.DUPLICATE_SOURCE_NAME);
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpecSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpecSpec.groovy
@@ -269,4 +269,29 @@ class DiscoverCswSourceSpecSpec extends SourceCommonsSpec {
         cswUtils.setRequestUtils(requestUtils)
         return cswUtils
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        DiscoverCswSource cannotConnectCsw = new DiscoverCswSource(Mock(ConfiguratorSuite))
+        cannotConnectCsw.setCswSourceUtils(prepareCswSourceUtils(200, badResponseBody, false))
+        cannotConnectCsw.setValue(getBaseDiscoverByAddressArgs())
+
+        DiscoverCswSource unknownEndpointCsw = new DiscoverCswSource(Mock(ConfiguratorSuite))
+        unknownEndpointCsw.setCswSourceUtils(prepareCswSourceUtils(200, noOutputSchemaCswResponse, true))
+        unknownEndpointCsw.setValue(getBaseDiscoverByUrlArgs(TEST_CSW_URL))
+
+        DiscoverCswSource missingFieldCsw = new DiscoverCswSource(Mock(ConfiguratorSuite))
+
+        when:
+        def errorCodes = discoverCsw.getFunctionErrorCodes()
+        def cannotConnectReport = cannotConnectCsw.getValue()
+        def unknownEndpointReport = unknownEndpointCsw.getValue()
+        def missingFieldReport = missingFieldCsw.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(cannotConnectReport.messages()[0].getCode())
+        errorCodes.contains(unknownEndpointReport.messages()[0].getCode())
+        errorCodes.contains(missingFieldReport.messages()[0].getCode())
+    }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpecSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpecSpec.groovy
@@ -280,18 +280,14 @@ class DiscoverCswSourceSpecSpec extends SourceCommonsSpec {
         unknownEndpointCsw.setCswSourceUtils(prepareCswSourceUtils(200, noOutputSchemaCswResponse, true))
         unknownEndpointCsw.setValue(getBaseDiscoverByUrlArgs(TEST_CSW_URL))
 
-        DiscoverCswSource missingFieldCsw = new DiscoverCswSource(Mock(ConfiguratorSuite))
-
         when:
         def errorCodes = discoverCsw.getFunctionErrorCodes()
         def cannotConnectReport = cannotConnectCsw.getValue()
         def unknownEndpointReport = unknownEndpointCsw.getValue()
-        def missingFieldReport = missingFieldCsw.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(cannotConnectReport.messages()[0].getCode())
         errorCodes.contains(unknownEndpointReport.messages()[0].getCode())
-        errorCodes.contains(missingFieldReport.messages()[0].getCode())
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
@@ -155,8 +155,7 @@ class GetCswConfigsSpec extends SourceCommonsSpec {
         def noExistingConfigReport = noExistingConfigFunc.getValue()
 
         then:
-        errorCodes.size() == 2
+        errorCodes.size() == 1
         errorCodes.contains(noExistingConfigReport.messages().get(0).getCode())
-        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
@@ -142,4 +142,21 @@ class GetCswConfigsSpec extends SourceCommonsSpec {
         managedServiceConfigs.get(S_PID_2).put(FACTORY_PID_KEY, TEST_FACTORY_PID)
         return managedServiceConfigs
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        GetCswConfigurations noExistingConfigFunc = new GetCswConfigurations(configuratorSuite)
+        functionArgs.put(PID, S_PID)
+        noExistingConfigFunc.setValue(functionArgs)
+        serviceActions.read(S_PID) >> [:]
+
+        when:
+        def errorCodes = getCswConfigsFunction.getFunctionErrorCodes()
+        def noExistingConfigReport = noExistingConfigFunc.getValue()
+
+        then:
+        errorCodes.size() == 2
+        errorCodes.contains(noExistingConfigReport.messages().get(0).getCode())
+        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
+    }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/CreateCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/CreateCswConfigurationSpec.groovy
@@ -158,6 +158,31 @@ class CreateCswConfigurationSpec extends SourceCommonsSpec {
         report.messages()*.getPath() == [SOURCE_NAME_PATH, ENDPOINT_URL_PATH, CSW_PROFILE_PATH]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        CreateCswConfiguration createDuplicateNameConfig = new CreateCswConfiguration(configuratorSuite)
+        createDuplicateNameConfig.setValue(createCswArgs())
+        serviceReader.getServices(_, _) >> federatedSources
+
+        CreateCswConfiguration createFailPersistConfig = new CreateCswConfiguration(configuratorSuite)
+        createFailPersistConfig.setValue(createCswArgs())
+        serviceReader.getServices(_, _) >> []
+
+        CreateCswConfiguration createMissingFieldConfig = new CreateCswConfiguration(configuratorSuite)
+
+        when:
+        def errorCodes = createCswConfiguration.getFunctionErrorCodes()
+        def duplicateNameReport = createDuplicateNameConfig.getValue()
+        def createFailPersistReport = createFailPersistConfig.getValue()
+        def createMissingFieldReport = createMissingFieldConfig.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(duplicateNameReport.messages().get(0).getCode())
+        errorCodes.contains(createFailPersistReport.messages().get(0).getCode())
+        errorCodes.contains(createMissingFieldReport.messages().get(0).getCode())
+    }
+
     def createCswArgs() {
         def config = new CswSourceConfigurationField()
                 .outputSchema(TEST_OUTPUT_SCHEMA)

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/CreateCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/CreateCswConfigurationSpec.groovy
@@ -168,19 +168,15 @@ class CreateCswConfigurationSpec extends SourceCommonsSpec {
         createFailPersistConfig.setValue(createCswArgs())
         serviceReader.getServices(_, _) >> []
 
-        CreateCswConfiguration createMissingFieldConfig = new CreateCswConfiguration(configuratorSuite)
-
         when:
         def errorCodes = createCswConfiguration.getFunctionErrorCodes()
         def duplicateNameReport = createDuplicateNameConfig.getValue()
         def createFailPersistReport = createFailPersistConfig.getValue()
-        def createMissingFieldReport = createMissingFieldConfig.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(duplicateNameReport.messages().get(0).getCode())
         errorCodes.contains(createFailPersistReport.messages().get(0).getCode())
-        errorCodes.contains(createMissingFieldReport.messages().get(0).getCode())
     }
 
     def createCswArgs() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfigurationSpec.groovy
@@ -132,19 +132,15 @@ class DeleteCswConfigurationSpec extends SourceCommonsSpec {
         configurator.commit(_, _) >> mockReport(true)
         deleteCswFailPersist.setValue(functionArgs)
 
-        DeleteCswConfiguration deleteCswMissingField = new DeleteCswConfiguration(configuratorSuite)
-
         when:
         def errorCodes = deleteCswConfiguration.getFunctionErrorCodes()
         def noExistingConfigReport = deleteCswNoExistingConfig.getValue()
         def failedPersistReport = deleteCswFailPersist.getValue()
-        def missingFieldReport = deleteCswMissingField.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(noExistingConfigReport.messages().get(0).getCode())
         errorCodes.contains(failedPersistReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
     }
 
     def createCswConfigToDelete() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/DeleteCswConfigurationSpec.groovy
@@ -121,6 +121,32 @@ class DeleteCswConfigurationSpec extends SourceCommonsSpec {
         report.messages()*.getPath() == [SERVICE_PID_PATH]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        DeleteCswConfiguration deleteCswNoExistingConfig = new DeleteCswConfiguration(configuratorSuite)
+        serviceActions.read(_ as String) >> [:]
+        deleteCswNoExistingConfig.setValue(functionArgs)
+
+        DeleteCswConfiguration deleteCswFailPersist = new DeleteCswConfiguration(configuratorSuite)
+        serviceActions.read(S_PID) >> configToDelete
+        configurator.commit(_, _) >> mockReport(true)
+        deleteCswFailPersist.setValue(functionArgs)
+
+        DeleteCswConfiguration deleteCswMissingField = new DeleteCswConfiguration(configuratorSuite)
+
+        when:
+        def errorCodes = deleteCswConfiguration.getFunctionErrorCodes()
+        def noExistingConfigReport = deleteCswNoExistingConfig.getValue()
+        def failedPersistReport = deleteCswFailPersist.getValue()
+        def missingFieldReport = deleteCswMissingField.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(noExistingConfigReport.messages().get(0).getCode())
+        errorCodes.contains(failedPersistReport.messages().get(0).getCode())
+        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
+    }
+
     def createCswConfigToDelete() {
         configToDelete = configToBeDeleted
         configToDelete.put(EVENT_SERVICE_ADDRESS, TEST_EVENT_SERVICE_ADDRESS)

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
@@ -223,6 +223,17 @@ class UpdateCswConfigurationSpec extends SourceCommonsSpec {
         report.messages()*.getPath() == [SERVICE_PID_PATH, SOURCE_NAME_PATH, ENDPOINT_URL_PATH, CSW_PROFILE_PATH]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        when:
+        def errorCodes = updateCswConfiguration.getFunctionErrorCodes()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(DefaultMessages.NO_EXISTING_CONFIG)
+        errorCodes.contains(DefaultMessages.FAILED_PERSIST)
+        errorCodes.contains(SourceMessages.DUPLICATE_SOURCE_NAME)
+    }
+
     def createCswUpdateArgs(String password) {
         return [(CswSourceConfigurationField.DEFAULT_FIELD_NAME): createCswSourceConfig(password).getValue()]
     }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
@@ -127,6 +127,31 @@ class DiscoverOpenSearchSpec extends SourceCommonsSpec {
         report.messages()*.getPath() == [URL_FIELD_PATH]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        DiscoverOpenSearchSource cannotConnectOpenSearch = new DiscoverOpenSearchSource(Mock(ConfiguratorSuite))
+        cannotConnectOpenSearch.setOpenSearchSourceUtils(prepareOpenSearchSourceUtils(200, osResponseBody, false))
+        cannotConnectOpenSearch.setValue(getBaseDiscoverByAddressArgs())
+
+        DiscoverOpenSearchSource unknownEndpointOpenSearch = new DiscoverOpenSearchSource(Mock(ConfiguratorSuite))
+        unknownEndpointOpenSearch.setOpenSearchSourceUtils(prepareOpenSearchSourceUtils(200, badResponseBody, true))
+        unknownEndpointOpenSearch.setValue(getBaseDiscoverByUrlArgs(TEST_OPEN_SEARCH_URL))
+
+        DiscoverOpenSearchSource missingFieldOpenSearch = new DiscoverOpenSearchSource(Mock(ConfiguratorSuite))
+
+        when:
+        def errorCodes = discoverOpenSearch.getFunctionErrorCodes()
+        def cannotConnectReport = cannotConnectOpenSearch.getValue()
+        def unknownEndpointReport = unknownEndpointOpenSearch.getValue()
+        def missingFieldReport = missingFieldOpenSearch.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(cannotConnectReport.messages()[0].getCode())
+        errorCodes.contains(unknownEndpointReport.messages()[0].getCode())
+        errorCodes.contains(missingFieldReport.messages()[0].getCode())
+    }
+
     def prepareOpenSearchSourceUtils(int statusCode, String responseBody, boolean endpointIsReachable) {
         def requestUtils = new TestRequestUtils(createMockFactory(statusCode, responseBody), endpointIsReachable)
         def openSearchUtils = new OpenSearchSourceUtils()

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
@@ -137,19 +137,15 @@ class DiscoverOpenSearchSpec extends SourceCommonsSpec {
         unknownEndpointOpenSearch.setOpenSearchSourceUtils(prepareOpenSearchSourceUtils(200, badResponseBody, true))
         unknownEndpointOpenSearch.setValue(getBaseDiscoverByUrlArgs(TEST_OPEN_SEARCH_URL))
 
-        DiscoverOpenSearchSource missingFieldOpenSearch = new DiscoverOpenSearchSource(Mock(ConfiguratorSuite))
-
         when:
         def errorCodes = discoverOpenSearch.getFunctionErrorCodes()
         def cannotConnectReport = cannotConnectOpenSearch.getValue()
         def unknownEndpointReport = unknownEndpointOpenSearch.getValue()
-        def missingFieldReport = missingFieldOpenSearch.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(cannotConnectReport.messages()[0].getCode())
         errorCodes.contains(unknownEndpointReport.messages()[0].getCode())
-        errorCodes.contains(missingFieldReport.messages()[0].getCode())
     }
 
     def prepareOpenSearchSourceUtils(int statusCode, String responseBody, boolean endpointIsReachable) {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
@@ -144,8 +144,7 @@ class GetOpenSearchConfigsSpec extends SourceCommonsSpec {
         def noExistingConfigReport = getOpenSearchConfigsFunction.getValue()
 
         then:
-        errorCodes.size() == 2
+        errorCodes.size() == 1
         errorCodes.contains(noExistingConfigReport.messages().get(0).code)
-        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
@@ -132,4 +132,20 @@ class GetOpenSearchConfigsSpec extends SourceCommonsSpec {
         assert sourceInfo.config().pid() == pid
         return true
     }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        functionArgs.put(PID, S_PID)
+        getOpenSearchConfigsFunction.setValue(functionArgs)
+        serviceActions.read(S_PID) >> [:]
+
+        when:
+        def errorCodes = getOpenSearchConfigsFunction.getFunctionErrorCodes()
+        def noExistingConfigReport = getOpenSearchConfigsFunction.getValue()
+
+        then:
+        errorCodes.size() == 2
+        errorCodes.contains(noExistingConfigReport.messages().get(0).code)
+        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
+    }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfigurationSpec.groovy
@@ -165,19 +165,15 @@ class CreateOpenSearchConfigurationSpec extends SourceCommonsSpec {
         createFailPersistConfig.setValue(createFunctionArgs())
         serviceReader.getServices(_, _) >> []
 
-        CreateOpenSearchConfiguration createMissingFieldConfig = new CreateOpenSearchConfiguration(configuratorSuite)
-
         when:
         def errorCodes = createOpenSearchConfiguration.getFunctionErrorCodes()
         def duplicateNameReport = createDuplicateNameConfig.getValue()
         def createFailPersistReport = createFailPersistConfig.getValue()
-        def createMissingFieldReport = createMissingFieldConfig.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(duplicateNameReport.messages().get(0).getCode())
         errorCodes.contains(createFailPersistReport.messages().get(0).getCode())
-        errorCodes.contains(createMissingFieldReport.messages().get(0).getCode())
     }
 
     def createFunctionArgs() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/CreateOpenSearchConfigurationSpec.groovy
@@ -54,6 +54,8 @@ class CreateOpenSearchConfigurationSpec extends SourceCommonsSpec {
 
     Configurator configurator
 
+    ConfiguratorSuite configuratorSuite
+
     FederatedSource federatedSource
 
     def federatedSources = []
@@ -71,7 +73,7 @@ class CreateOpenSearchConfigurationSpec extends SourceCommonsSpec {
         configuratorFactory = Mock(ConfiguratorFactory)
         configuratorFactory.getConfigurator() >> configurator
 
-        ConfiguratorSuite configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite = Mock(ConfiguratorSuite)
         configuratorSuite.configuratorFactory >> configuratorFactory
         configuratorSuite.serviceActions >> serviceActions
         configuratorSuite.serviceReader >> serviceReader
@@ -151,6 +153,31 @@ class CreateOpenSearchConfigurationSpec extends SourceCommonsSpec {
             it.getCode() == DefaultMessages.MISSING_REQUIRED_FIELD
         } == 2
         report.messages()*.getPath() == [SOURCE_NAME_PATH, ENDPOINT_URL_PATH]
+    }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        CreateOpenSearchConfiguration createDuplicateNameConfig = new CreateOpenSearchConfiguration(configuratorSuite)
+        createDuplicateNameConfig.setValue(createFunctionArgs())
+        serviceReader.getServices(_, _) >> federatedSources
+
+        CreateOpenSearchConfiguration createFailPersistConfig = new CreateOpenSearchConfiguration(configuratorSuite)
+        createFailPersistConfig.setValue(createFunctionArgs())
+        serviceReader.getServices(_, _) >> []
+
+        CreateOpenSearchConfiguration createMissingFieldConfig = new CreateOpenSearchConfiguration(configuratorSuite)
+
+        when:
+        def errorCodes = createOpenSearchConfiguration.getFunctionErrorCodes()
+        def duplicateNameReport = createDuplicateNameConfig.getValue()
+        def createFailPersistReport = createFailPersistConfig.getValue()
+        def createMissingFieldReport = createMissingFieldConfig.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(duplicateNameReport.messages().get(0).getCode())
+        errorCodes.contains(createFailPersistReport.messages().get(0).getCode())
+        errorCodes.contains(createMissingFieldReport.messages().get(0).getCode())
     }
 
     def createFunctionArgs() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/DeleteOpenSearchConfigurationSpec.groovy
@@ -109,18 +109,14 @@ class DeleteOpenSearchConfigurationSpec extends SourceCommonsSpec {
         configurator.commit(_, _) >> mockReport(true)
         deleteOpenSearchFailPersist.setValue(functionArgs)
 
-        DeleteOpenSearchConfiguration deleteOpenSearchMissingField = new DeleteOpenSearchConfiguration(configuratorSuite)
-
         when:
         def errorCodes = deleteOpenSearchConfigurationFunction.getFunctionErrorCodes()
         def noExistingConfigReport = deleteOpenSearchNoExistingConfig.getValue()
         def failedPersistReport = deleteOpenSearchFailPersist.getValue()
-        def missingFieldReport = deleteOpenSearchMissingField.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(noExistingConfigReport.messages().get(0).getCode())
         errorCodes.contains(failedPersistReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
@@ -210,6 +210,17 @@ class UpdateOpenSearchConfigurationSpec extends SourceCommonsSpec {
         report.messages()*.getPath() == [PID_PATH, SOURCE_NAME_PATH, ENDPOINT_URL_PATH]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        when:
+        def errorCodes = updateOpenSearchConfiguration.getFunctionErrorCodes()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(DefaultMessages.NO_EXISTING_CONFIG)
+        errorCodes.contains(DefaultMessages.FAILED_PERSIST)
+        errorCodes.contains(SourceMessages.DUPLICATE_SOURCE_NAME)
+    }
+
     def createUpdateFunctionArgs(String password) {
         return [(OpenSearchSourceConfigurationField.DEFAULT_FIELD_NAME): createOpenSearchSourceConfig(password).getValue()]
     }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
@@ -180,6 +180,31 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
         report.messages()*.getPath() == [URL_FIELD_PATH]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        DiscoverWfsSource cannotConnectWfs = new DiscoverWfsSource(Mock(ConfiguratorSuite))
+        cannotConnectWfs.setWfsSourceUtils(prepareOpenSearchSourceUtils(200, badResponseBody, false))
+        cannotConnectWfs.setValue(getBaseDiscoverByAddressArgs())
+
+        DiscoverWfsSource unknownEndpointWfs = new DiscoverWfsSource(Mock(ConfiguratorSuite))
+        unknownEndpointWfs.setWfsSourceUtils(prepareOpenSearchSourceUtils(200, badResponseBody, true))
+        unknownEndpointWfs.setValue(getBaseDiscoverByUrlArgs(TEST_WFS_URL))
+
+        DiscoverWfsSource missingFieldWfs = new DiscoverWfsSource(Mock(ConfiguratorSuite))
+
+        when:
+        def errorCodes = discoverWfs.getFunctionErrorCodes()
+        def cannotConnectReport = cannotConnectWfs.getValue()
+        def unknownEndpointReport = unknownEndpointWfs.getValue()
+        def missingFieldReport = missingFieldWfs.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(cannotConnectReport.messages()[0].getCode())
+        errorCodes.contains(unknownEndpointReport.messages()[0].getCode())
+        errorCodes.contains(missingFieldReport.messages()[0].getCode())
+    }
+
     def prepareOpenSearchSourceUtils(int statusCode, String responseBody, boolean endpointIsReachable) {
         def requestUtils = new TestRequestUtils(createMockFactory(statusCode, responseBody), endpointIsReachable)
         def wfsUtils = new WfsSourceUtils()

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
@@ -190,19 +190,15 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
         unknownEndpointWfs.setWfsSourceUtils(prepareOpenSearchSourceUtils(200, badResponseBody, true))
         unknownEndpointWfs.setValue(getBaseDiscoverByUrlArgs(TEST_WFS_URL))
 
-        DiscoverWfsSource missingFieldWfs = new DiscoverWfsSource(Mock(ConfiguratorSuite))
-
         when:
         def errorCodes = discoverWfs.getFunctionErrorCodes()
         def cannotConnectReport = cannotConnectWfs.getValue()
         def unknownEndpointReport = unknownEndpointWfs.getValue()
-        def missingFieldReport = missingFieldWfs.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(cannotConnectReport.messages()[0].getCode())
         errorCodes.contains(unknownEndpointReport.messages()[0].getCode())
-        errorCodes.contains(missingFieldReport.messages()[0].getCode())
     }
 
     def prepareOpenSearchSourceUtils(int statusCode, String responseBody, boolean endpointIsReachable) {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
@@ -156,8 +156,7 @@ class GetWfsConfigsSpec extends SourceCommonsSpec {
         def noExistingConfigReport = getWfsConfigsFunction.getValue()
 
         then:
-        errorCodes.size() == 2
+        errorCodes.size() == 1
         errorCodes.contains(noExistingConfigReport.messages().get(0).code)
-        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
@@ -33,6 +33,8 @@ class GetWfsConfigsSpec extends SourceCommonsSpec {
 
     ConfiguratorFactory configuratorFactory
 
+    ConfiguratorSuite configuratorSuite
+
     private ServiceActions serviceActions
 
     private ManagedServiceActions managedServiceActions
@@ -141,5 +143,21 @@ class GetWfsConfigsSpec extends SourceCommonsSpec {
         managedServiceConfigs.get(S_PID_1).put(FACTORY_PID_KEY, TEST_FACTORY_PID_1)
         managedServiceConfigs.get(S_PID_2).put(FACTORY_PID_KEY, TEST_FACTORY_PID_2)
         return managedServiceConfigs
+    }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        functionArgs.put(PID, S_PID)
+        getWfsConfigsFunction.setValue(functionArgs)
+        serviceActions.read(S_PID) >> [:]
+
+        when:
+        def errorCodes = getWfsConfigsFunction.getFunctionErrorCodes()
+        def noExistingConfigReport = getWfsConfigsFunction.getValue()
+
+        then:
+        errorCodes.size() == 2
+        errorCodes.contains(noExistingConfigReport.messages().get(0).code)
+        errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/CreateWfsConfigurationSpec.groovy
@@ -172,19 +172,15 @@ class CreateWfsConfigurationSpec extends SourceCommonsSpec {
         createFailPersistConfig.setValue(createWfsArgs())
         serviceReader.getServices(_, _) >> []
 
-        CreateWfsConfiguration createMissingFieldConfig = new CreateWfsConfiguration(configuratorSuite)
-
         when:
         def errorCodes = createWfsConfiguration.getFunctionErrorCodes()
         def duplicateNameReport = createDuplicateNameConfig.getValue()
         def createFailPersistReport = createFailPersistConfig.getValue()
-        def createMissingFieldReport = createMissingFieldConfig.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(duplicateNameReport.messages().get(0).getCode())
         errorCodes.contains(createFailPersistReport.messages().get(0).getCode())
-        errorCodes.contains(createMissingFieldReport.messages().get(0).getCode())
     }
 
     def createWfsArgs() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfigurationSpec.groovy
@@ -126,18 +126,14 @@ class DeleteWfsConfigurationSpec extends SourceCommonsSpec {
         configurator.commit(_, _) >> mockReport(true)
         deleteWfsFailPersist.setValue(functionArgs)
 
-        DeleteWfsConfiguration deleteWfsMissingField = new DeleteWfsConfiguration(configuratorSuite)
-
         when:
         def errorCodes = deleteWfsConfiguration.getFunctionErrorCodes()
         def noExistingConfigReport = deleteWfsNoExistingConfig.getValue()
         def failedPersistReport = deleteWfsFailPersist.getValue()
-        def missingFieldReport = deleteWfsMissingField.getValue()
 
         then:
-        errorCodes.size() == 3
+        errorCodes.size() == 2
         errorCodes.contains(noExistingConfigReport.messages().get(0).getCode())
         errorCodes.contains(failedPersistReport.messages().get(0).getCode())
-        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/DeleteWfsConfigurationSpec.groovy
@@ -30,6 +30,8 @@ class DeleteWfsConfigurationSpec extends SourceCommonsSpec {
 
     Configurator configurator
 
+    ConfiguratorSuite configuratorSuite
+
     private ServiceActions serviceActions
 
     static RESULT_ARGUMENT_PATH = [DeleteWfsConfiguration.FIELD_NAME]
@@ -50,7 +52,7 @@ class DeleteWfsConfigurationSpec extends SourceCommonsSpec {
         serviceActions = Mock(ServiceActions)
         def managedServiceActions = Mock(ManagedServiceActions)
 
-        def configuratorSuite = Mock(ConfiguratorSuite)
+        configuratorSuite = Mock(ConfiguratorSuite)
         configuratorSuite.configuratorFactory >> configuratorFactory
         configuratorSuite.serviceActions >> serviceActions
         configuratorSuite.managedServiceActions >> managedServiceActions
@@ -111,5 +113,31 @@ class DeleteWfsConfigurationSpec extends SourceCommonsSpec {
             it.getCode() == DefaultMessages.MISSING_REQUIRED_FIELD
         } == 1
         report.messages()*.getPath() == [PID_PATH]
+    }
+
+    def 'Returns all the possible error codes correctly'(){
+        setup:
+        DeleteWfsConfiguration deleteWfsNoExistingConfig = new DeleteWfsConfiguration(configuratorSuite)
+        serviceActions.read(S_PID) >> [:]
+        deleteWfsNoExistingConfig.setValue(functionArgs)
+
+        DeleteWfsConfiguration deleteWfsFailPersist = new DeleteWfsConfiguration(configuratorSuite)
+        serviceActions.read(S_PID) >> configToBeDeleted
+        configurator.commit(_, _) >> mockReport(true)
+        deleteWfsFailPersist.setValue(functionArgs)
+
+        DeleteWfsConfiguration deleteWfsMissingField = new DeleteWfsConfiguration(configuratorSuite)
+
+        when:
+        def errorCodes = deleteWfsConfiguration.getFunctionErrorCodes()
+        def noExistingConfigReport = deleteWfsNoExistingConfig.getValue()
+        def failedPersistReport = deleteWfsFailPersist.getValue()
+        def missingFieldReport = deleteWfsMissingField.getValue()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(noExistingConfigReport.messages().get(0).getCode())
+        errorCodes.contains(failedPersistReport.messages().get(0).getCode())
+        errorCodes.contains(missingFieldReport.messages().get(0).getCode())
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
@@ -216,6 +216,17 @@ class UpdateWfsConfigurationSpec extends SourceCommonsSpec {
         report.messages()*.getPath() == [PID_PATH, SOURCE_NAME_PATH, ENDPOINT_URL_PATH, WFS_VERSION_PATH]
     }
 
+    def 'Returns all the possible error codes correctly'(){
+        when:
+        def errorCodes = updateWfsConfiguration.getFunctionErrorCodes()
+
+        then:
+        errorCodes.size() == 3
+        errorCodes.contains(DefaultMessages.NO_EXISTING_CONFIG)
+        errorCodes.contains(DefaultMessages.FAILED_PERSIST)
+        errorCodes.contains(SourceMessages.DUPLICATE_SOURCE_NAME)
+    }
+
     def createWfsUpdateArgs(String password) {
         return [(WfsSourceConfigurationField.DEFAULT_FIELD_NAME): createWfsSourceConfig(password).getValue()]
     }

--- a/query/utils/src/main/java/org/codice/ddf/admin/utils/conn/discover/PingByAddress.java
+++ b/query/utils/src/main/java/org/codice/ddf/admin/utils/conn/discover/PingByAddress.java
@@ -14,6 +14,7 @@
 package org.codice.ddf.admin.utils.conn.discover;
 
 import java.util.List;
+import java.util.Set;
 
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.fields.FunctionField;
@@ -22,6 +23,7 @@ import org.codice.ddf.admin.common.fields.base.scalar.BooleanField;
 import org.codice.ddf.admin.common.fields.common.AddressField;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 
 public class PingByAddress extends TestFunctionField {
     public static final String NAME = "pingByAddress";
@@ -50,5 +52,10 @@ public class PingByAddress extends TestFunctionField {
     @Override
     public FunctionField<BooleanField> newInstance() {
         return new PingByAddress();
+    }
+
+    @Override
+    public Set<String> getFunctionErrorCodes() {
+        return ImmutableSet.of();
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Adding error codes to the schema
* Added getErrorCodes() and getFunctionErrorCodes() functions which return the possible errors
* Added the possible error codes in the description of each function
* Added error codes in the schema

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @tbatie @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)
Use graphiQL or the written tests.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
