### PR TITLE
DDF-2773 Add a builder for WebClients

### DIFF
--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
@@ -18,13 +18,13 @@ import static org.codice.ddf.admin.common.report.message.DefaultMessages.cannotC
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
-import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.core.Response;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.codice.ddf.admin.common.fields.common.CredentialsField;
 import org.codice.ddf.admin.common.fields.common.ResponseField;
@@ -35,12 +35,13 @@ import org.codice.ddf.cxf.SecureCxfClientFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import ddf.security.Subject;
+
 public class RequestUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestUtils.class);
 
-    private static final int CLIENT_TIMEOUT_MILLIS =
-            new Long(TimeUnit.SECONDS.toMillis(10)).intValue();
+    private static final int CLIENT_TIMEOUT_MILLIS = 10000;
 
     /**
      * Creates a secure CXF {@code WebClient} and sends a GET request to the URL given by the clientUrl and
@@ -55,23 +56,20 @@ public class RequestUtils {
      * @return {@link ReportWithResultImpl} containing a {@link ResponseField}, or containing an {@link org.codice.ddf.admin.api.report.ErrorMessage}
      */
     public ReportWithResultImpl<ResponseField> sendGetRequest(UrlField requestUrl,
-            CredentialsField creds, Map<String, String> queryParams) {
+            CredentialsField creds, Map<String, Object> queryParams) {
         ReportWithResultImpl<ResponseField> responseResult = new ReportWithResultImpl<>();
         responseResult.addMessages(endpointIsReachable(requestUrl));
         if (responseResult.containsErrorMsgs()) {
             return responseResult;
         }
 
-        ReportWithResultImpl<Response> httpResponse = executeGetRequest(requestUrl,
-                creds,
-                queryParams);
-        if (httpResponse.containsErrorMsgs()) {
-            responseResult.addMessages(httpResponse);
-            return responseResult;
-        }
+        WebClient webClient = createWebClientBuilder(requestUrl.getValue(),
+                creds.username(),
+                creds.password(),
+                null).queryParams(queryParams)
+                .build();
 
-        return new ReportWithResultImpl<>(responseFieldFromResponse(httpResponse.result(),
-                requestUrl));
+        return sendGetRequest(webClient, requestUrl);
     }
 
     /**
@@ -80,25 +78,24 @@ public class RequestUtils {
      * Possible Error Codes to return
      * - {@link org.codice.ddf.admin.common.report.message.DefaultMessages#CANNOT_CONNECT}
      *
-     * @param clientUrl   url to send GET request to
-     * @param creds       optional basic authentication
-     * @param queryParams additional query parameters
+     * @param webClient {@code WebClient} to send a GET request with
+     * @param urlField  the original request url
      * @return {@link Response} of the request
      */
-    public ReportWithResultImpl<Response> executeGetRequest(UrlField clientUrl,
-            CredentialsField creds, Map<String, String> queryParams) {
-        WebClient client = generateClient(clientUrl.getValue(), creds, queryParams);
-        ReportWithResultImpl<Response> report = new ReportWithResultImpl<>();
+    public ReportWithResultImpl<ResponseField> sendGetRequest(WebClient webClient,
+            UrlField urlField) {
+        ReportWithResultImpl<ResponseField> responseResult = new ReportWithResultImpl<>();
         Response response;
+
         try {
-            response = client.get();
+            response = webClient.get();
         } catch (ProcessingException e) {
-            report.addResultMessage(cannotConnectError());
-            return report;
+            responseResult.addResultMessage(cannotConnectError());
+            return responseResult;
         }
 
-        report.result(response);
-        return report;
+        responseResult.result(responseFieldFromResponse(response, urlField));
+        return responseResult;
     }
 
     /**
@@ -121,9 +118,36 @@ public class RequestUtils {
             return responseResult;
         }
 
-        WebClient client = generateClient(urlField.getValue(), creds, Collections.emptyMap());
-        Response response = client.type(contentType)
-                .post(content);
+        WebClient webClient = createWebClientBuilder(urlField.getValue(),
+                creds.username(),
+                creds.password(),
+                null).build();
+
+        return sendPostRequest(webClient, urlField, content);
+    }
+
+    /**
+     * Sends a POST request with the given webClient
+     * <p>
+     * Possible Error Codes to return
+     * - {@link org.codice.ddf.admin.common.report.message.DefaultMessages#CANNOT_CONNECT}
+     *
+     * @param webClient {@code WebClient} to send POST request with
+     * @param urlField  original request url field
+     * @param content   Body of the post request
+     * @return
+     */
+    public ReportWithResultImpl<ResponseField> sendPostRequest(WebClient webClient,
+            UrlField urlField, String content) {
+        ReportWithResultImpl<ResponseField> responseResult = new ReportWithResultImpl<>();
+        Response response;
+
+        try {
+            response = webClient.post(content);
+        } catch (ProcessingException e) {
+            responseResult.addArgumentMessage(cannotConnectError());
+            return responseResult;
+        }
 
         ResponseField responseField = responseFieldFromResponse(response, urlField);
 
@@ -164,29 +188,85 @@ public class RequestUtils {
         return report;
     }
 
-    private WebClient generateClient(String url, CredentialsField creds,
-            Map<String, String> queryParams) {
-        SecureCxfClientFactory<WebClient> clientFactory = createFactory(url, creds);
+    public class WebClientBuilder {
 
-        WebClient client = clientFactory.getClient();
+        private final WebClient webClient;
 
-        if (queryParams != null) {
-            queryParams.entrySet()
-                    .forEach(entry -> client.query(entry.getKey(), entry.getValue()));
+        private WebClientBuilder(String url, String username, String password,
+                @Nullable Subject subject) {
+            this(url, username, password, subject, WebClient.class);
         }
-        return client;
+
+        private WebClientBuilder(String url, String username, String password,
+                @Nullable Subject subject, Class clientServiceClass) {
+            SecureCxfClientFactory<WebClient> clientFactory =
+                    StringUtils.isEmpty(username) || StringUtils.isEmpty(password) ?
+                            new SecureCxfClientFactory<>(url, clientServiceClass) :
+                            new SecureCxfClientFactory<>(url,
+                                    clientServiceClass,
+                                    username,
+                                    password);
+
+            webClient = clientFactory.getWebClientForSubject(subject);
+        }
+
+        public WebClientBuilder queryParams(Map<String, Object> queryParams) {
+            queryParams.entrySet()
+                    .forEach(entry -> webClient.query(entry.getKey(), entry.getValue()));
+
+            return this;
+        }
+
+        public WebClientBuilder path(String path) {
+            webClient.path(path);
+            return this;
+        }
+
+        public WebClientBuilder contentType(String contentType) {
+            webClient.type(contentType);
+            return this;
+        }
+
+        public WebClientBuilder accept(String... mediaTypes) {
+            webClient.accept(mediaTypes);
+            return this;
+        }
+
+        public WebClientBuilder encoding(String encoding) {
+            webClient.encoding(encoding);
+            return this;
+        }
+
+        public WebClientBuilder acceptEncoding(String... acceptEncodings) {
+            webClient.acceptEncoding(acceptEncodings);
+            return this;
+        }
+
+        public WebClientBuilder header(String header, Object... values) {
+            webClient.header(header, values);
+            return this;
+        }
+
+        public WebClientBuilder headers(Map<String, Object> headers) {
+            headers.entrySet()
+                    .forEach(entry -> webClient.header(entry.getKey(), entry.getValue()));
+
+            return this;
+        }
+
+        public WebClient build() {
+            return webClient;
+        }
     }
 
-    /**
-     * This is broken out for testing purposes so that the SecureCxfClientFactory can be mocked out.
-     */
-    protected SecureCxfClientFactory<WebClient> createFactory(String url, CredentialsField creds) {
-        return creds.username() == null || creds.password() == null ? new SecureCxfClientFactory<>(
-                url,
-                WebClient.class) : new SecureCxfClientFactory<>(url,
-                WebClient.class,
-                creds.username(),
-                creds.password());
+    public WebClientBuilder createWebClientBuilder(String url, String username, String password,
+            Subject subject) {
+        return new WebClientBuilder(url, username, password, subject, WebClient.class);
+    }
+
+    public WebClientBuilder createWebClientBuilder(String url, String username, String password,
+            Subject subject, Class serviceClass) {
+        return new WebClientBuilder(url, username, password, subject, serviceClass);
     }
 
     private ResponseField responseFieldFromResponse(Response response, UrlField requestUrl) {

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
@@ -73,7 +73,7 @@ public class RequestUtils {
     }
 
     /**
-     * Executes a request by creating a Secure CXF Client from the provided url, credentials, and query params.
+     * Sends a GET request with the given {@code WebClient}
      * <p>
      * Possible Error Codes to return
      * - {@link org.codice.ddf.admin.common.report.message.DefaultMessages#CANNOT_CONNECT}
@@ -90,7 +90,7 @@ public class RequestUtils {
         try {
             response = webClient.get();
         } catch (ProcessingException e) {
-            responseResult.addResultMessage(cannotConnectError());
+            responseResult.addArgumentMessage(cannotConnectError(urlField.path()));
             return responseResult;
         }
 
@@ -121,13 +121,14 @@ public class RequestUtils {
         WebClient webClient = createWebClientBuilder(urlField.getValue(),
                 creds.username(),
                 creds.password(),
-                null).build();
+                null).contentType(contentType)
+                .build();
 
         return sendPostRequest(webClient, urlField, content);
     }
 
     /**
-     * Sends a POST request with the given webClient
+     * Sends a POST request with the given {@code WebClient}
      * <p>
      * Possible Error Codes to return
      * - {@link org.codice.ddf.admin.common.report.message.DefaultMessages#CANNOT_CONNECT}
@@ -145,7 +146,7 @@ public class RequestUtils {
         try {
             response = webClient.post(content);
         } catch (ProcessingException e) {
-            responseResult.addArgumentMessage(cannotConnectError());
+            responseResult.addArgumentMessage(cannotConnectError(urlField.path()));
             return responseResult;
         }
 

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/csw/CswSourceUtils.java
@@ -55,7 +55,7 @@ public class CswSourceUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CswSourceUtils.class);
 
-    public static final Map<String, String> GET_CAPABILITIES_PARAMS = ImmutableMap.of("service",
+    public static final Map<String, Object> GET_CAPABILITIES_PARAMS = ImmutableMap.of("service",
             "CSW",
             "request",
             "GetCapabilities");

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/opensearch/OpenSearchSourceUtils.java
@@ -57,7 +57,7 @@ public class OpenSearchSourceUtils {
             "https://%s:%d/catalog/query"),
             ImmutableList.of("http://%s:%d/services/catalog/query", "http://%s:%d/catalog/query"));
 
-    public static final Map<String, String> GET_CAPABILITIES_PARAMS = ImmutableMap.of("q",
+    public static final Map<String, Object> GET_CAPABILITIES_PARAMS = ImmutableMap.of("q",
             "test",
             "mr",
             "1",

--- a/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceUtils.java
+++ b/query/sources/impl/src/main/java/org/codice/ddf/admin/sources/wfs/WfsSourceUtils.java
@@ -52,7 +52,7 @@ public class WfsSourceUtils {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(WfsSourceUtils.class);
 
-    public static final Map<String, String> GET_CAPABILITIES_PARAMS = ImmutableMap.of("service",
+    public static final Map<String, Object> GET_CAPABILITIES_PARAMS = ImmutableMap.of("service",
             "WFS",
             "request",
             "GetCapabilities",

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpec.groovy
@@ -57,7 +57,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
     DiscoverCswSource discoverCsw
 
     def setup() {
-        discoverCsw = new DiscoverCswSource()
+        discoverCsw = new DiscoverCswSource(Mock(ConfiguratorSuite))
     }
 
     def 'Successfully discover DDF federation profile with URL'() {
@@ -286,8 +286,8 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
     }
 
     def prepareCswSourceUtils(int statusCode, String responseBody, boolean endpointIsReachable) {
-        def requestUtils = new TestRequestUtils(createMockFactory(statusCode, responseBody), endpointIsReachable)
-        def cswUtils = new CswSourceUtils()
+        def requestUtils = new TestRequestUtils(createMockWebClientBuilder(statusCode, responseBody), endpointIsReachable)
+        def cswUtils = new CswSourceUtils(Mock(ConfiguratorSuite))
         cswUtils.setRequestUtils(requestUtils)
         return cswUtils
     }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
@@ -151,8 +151,8 @@ class DiscoverOpenSearchSpec extends SourceCommonsSpec {
     }
 
     def prepareOpenSearchSourceUtils(int statusCode, String responseBody, boolean endpointIsReachable) {
-        def requestUtils = new TestRequestUtils(createMockFactory(statusCode, responseBody), endpointIsReachable)
-        def openSearchUtils = new OpenSearchSourceUtils()
+        def requestUtils = new TestRequestUtils(createMockWebClientBuilder(statusCode, responseBody), endpointIsReachable)
+        def openSearchUtils = new OpenSearchSourceUtils(Mock(ConfiguratorSuite))
         openSearchUtils.setRequestUtils(requestUtils)
         return openSearchUtils
     }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
@@ -129,11 +129,15 @@ class SourceCommonsSpec extends Specification {
 
         RequestUtils.WebClientBuilder webClientBuilder
 
-        boolean endpointIsReachable
+        Boolean endpointIsReachable
 
-        TestRequestUtils(RequestUtils.WebClientBuilder mockWebClientBuilder, boolean isReachable) {
+        TestRequestUtils(RequestUtils.WebClientBuilder mockWebClientBuilder, Boolean isReachable) {
             webClientBuilder = mockWebClientBuilder
             endpointIsReachable = isReachable
+        }
+
+        TestRequestUtils(RequestUtils.WebClientBuilder mockWebClientBuilder) {
+            webClientBuilder = mockWebClientBuilder
         }
 
         @Override
@@ -148,6 +152,10 @@ class SourceCommonsSpec extends Specification {
 
         @Override
         public ReportImpl endpointIsReachable(UrlField urlField) {
+            if(endpointIsReachable == null) {
+                return super.endpointIsReachable(urlField)
+            }
+
             def report = new ReportImpl()
             if (!endpointIsReachable) {
                 report.addArgumentMessage(new ErrorMessageImpl(TEST_ERROR_CODE))

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
@@ -35,6 +35,7 @@ import org.codice.ddf.admin.sources.utils.RequestUtils
 import org.codice.ddf.cxf.SecureCxfClientFactory
 import spock.lang.Specification
 
+import javax.ws.rs.core.MediaType
 import javax.ws.rs.core.Response
 
 class SourceCommonsSpec extends Specification {
@@ -82,6 +83,8 @@ class SourceCommonsSpec extends Specification {
     public static final String TEST_PASSWORD = "admin"
 
     public static final String TEST_SOURCENAME = "testSourceName"
+
+    public static final String TEST_CONTENT_TYPE = 'text/xml'
 
     static Map<String, Object> getBaseDiscoverByAddressArgs(String hostName = 'localhost', int port = 8993) {
         return [
@@ -159,10 +162,14 @@ class SourceCommonsSpec extends Specification {
         return report
     }
 
-    def createMockWebClientBuilder(int statusCode, String responseBody) {
+    def createMockWebClientBuilder(int statusCode, String responseBody, String contentType = TEST_CONTENT_TYPE) {
+        def mediaType = Spy(MediaType)
+        mediaType.toString() >> contentType
+
         def mockResponse = Mock(Response)
         mockResponse.getStatus() >> statusCode
         mockResponse.readEntity(String.class) >> responseBody
+        mockResponse.getMediaType() >> mediaType
 
         def mockWebClient = Mock(WebClient)
         mockWebClient.get() >> mockResponse

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
@@ -137,12 +137,12 @@ class SourceCommonsSpec extends Specification {
         }
 
         @Override
-        public RequestUtils.WebClientBuilder createWebClientBuilder(String url, String username, String password, Subject subject) {
+        public RequestUtils.WebClientBuilder createWebClientBuilder(String url, String username, String password) {
             return webClientBuilder
         }
 
         @Override
-        public RequestUtils.WebClientBuilder createWebClientBuilder(String url, String username, String password, Subject subject, Class serviceClass) {
+        public RequestUtils.WebClientBuilder createWebClientBuilder(String url, String username, String password, Class serviceClass) {
             return webClientBuilder
         }
 

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/test/SourceCommonsSpec.groovy
@@ -159,16 +159,24 @@ class SourceCommonsSpec extends Specification {
         return report
     }
 
-    RequestUtils.WebClientBuilder createMockWebClientBuilder(int statusCode, String responseBody) {
+    def createMockWebClientBuilder(int statusCode, String responseBody) {
         def mockResponse = Mock(Response)
         mockResponse.getStatus() >> statusCode
         mockResponse.readEntity(String.class) >> responseBody
 
         def mockWebClient = Mock(WebClient)
         mockWebClient.get() >> mockResponse
-        mockWebClient.post(_) >> mockResponse
+        mockWebClient.post(_ as Object) >> mockResponse
 
         def webClientBuilder = Mock(RequestUtils.WebClientBuilder)
+        webClientBuilder.queryParams(_) >> webClientBuilder
+        webClientBuilder.path(_) >> webClientBuilder
+        webClientBuilder.contentType(_) >> webClientBuilder
+        webClientBuilder.accept(_) >> webClientBuilder
+        webClientBuilder.encoding(_) >> webClientBuilder
+        webClientBuilder.acceptEncoding(_) >> webClientBuilder
+        webClientBuilder.header(_, _) >> webClientBuilder
+        webClientBuilder.headers(_) >> webClientBuilder
         webClientBuilder.build() >> mockWebClient
 
         return webClientBuilder

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
@@ -204,8 +204,8 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
     }
 
     def prepareOpenSearchSourceUtils(int statusCode, String responseBody, boolean endpointIsReachable) {
-        def requestUtils = new TestRequestUtils(createMockFactory(statusCode, responseBody), endpointIsReachable)
-        def wfsUtils = new WfsSourceUtils()
+        def requestUtils = new TestRequestUtils(createMockWebClientBuilder(statusCode, responseBody), endpointIsReachable)
+        def wfsUtils = new WfsSourceUtils(Mock(ConfiguratorSuite))
         wfsUtils.setRequestUtils(requestUtils)
         return wfsUtils
     }


### PR DESCRIPTION
#### What does this PR do?
- Adds a builder for WebClients. This was needed so clients who need to specify special headers, encodings, etc can do so easily.
- Adjust unit tests to accommodate this change.
- Update some usages of `addResultMessage` in favor of `addArgumentMessage`

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @blen-desta 

#### How should this be tested? (List steps with links to updated documentation)
Ensure that discovery of sources is still working as expected.

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
