### PR TITLE
DDF-2773 Not displaying passwords in the logs

### DIFF
--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/BaseObjectField.java
@@ -26,6 +26,7 @@ import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ObjectField;
 import org.codice.ddf.admin.api.report.ErrorMessage;
+import org.codice.ddf.admin.common.fields.common.PasswordField;
 
 import com.google.common.collect.ImmutableSet;
 
@@ -40,9 +41,13 @@ public abstract class BaseObjectField extends BaseDataType<Map<String, Object>>
     public Map<String, Object> getValue() {
         Map<String, Object> values = new HashMap<>();
 
-        for(Field field : getFields()) {
-            if(!(field instanceof FunctionField)) {
-                values.put(field.fieldName(), field.getValue());
+        for (Field field : getFields()) {
+            if (!(field instanceof FunctionField)) {
+                if (field.fieldName().equals(PasswordField.DEFAULT_FIELD_NAME) && ((PasswordField) field).isInternalProcess()){
+                    values.put(field.fieldName(), ((PasswordField) field).getRealPassword());
+                } else {
+                    values.put(field.fieldName(), field.getValue());
+                }
             }
         }
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
@@ -62,7 +62,7 @@ public class CredentialsField extends BaseObjectField {
         return password;
     }
 
-    public String password() {
+    public String realPassword() {
         return password.getRealPassword();
     }
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
@@ -35,12 +35,12 @@ public class CredentialsField extends BaseObjectField {
 
     private StringField username;
 
-    private StringField password;
+    private PasswordField password;
 
     public CredentialsField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
         this.username = new StringField(USERNAME_FIELD_NAME);
-        this.password = new StringField(PASSWORD_FIELD_NAME);
+        this.password = new PasswordField(PASSWORD_FIELD_NAME);
         updateInnerFieldPaths();
     }
 
@@ -58,12 +58,12 @@ public class CredentialsField extends BaseObjectField {
         return username;
     }
 
-    public StringField passwordField() {
+    public PasswordField passwordField() {
         return password;
     }
 
     public String password() {
-        return password.getValue();
+        return password.getRealPassword();
     }
 
     public String username() {

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
@@ -40,7 +40,7 @@ public class CredentialsField extends BaseObjectField {
     public CredentialsField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
         this.username = new StringField(USERNAME_FIELD_NAME);
-        this.password = new PasswordField(PASSWORD_FIELD_NAME);
+        this.password = new PasswordField();
         updateInnerFieldPaths();
     }
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PasswordField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PasswordField.java
@@ -15,6 +15,7 @@
 package org.codice.ddf.admin.common.fields.common;
 
 import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+import org.codice.ddf.admin.common.services.ServiceCommons;
 
 public class PasswordField extends StringField{
 
@@ -24,19 +25,11 @@ public class PasswordField extends StringField{
 
     public static final String DESCRIPTION = "Password used for authentication";
 
-    // A flag to indicate if a service being updated has a password of "secret".
-    public static final String FLAG_PASSWORD = "secret";
-
     // Determine which calls need the real password and which ones get the flag password
     private boolean internalProcess;
 
     public PasswordField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
-        internalProcess = false;
-    }
-
-    public PasswordField(String fieldName) {
-        super(fieldName, FIELD_TYPE_NAME, DESCRIPTION);
         internalProcess = false;
     }
 
@@ -51,7 +44,7 @@ public class PasswordField extends StringField{
             return null;
         }
         if(!internalProcess) {
-            return FLAG_PASSWORD;
+            return ServiceCommons.FLAG_PASSWORD;
         }
         return getRealPassword();
     }
@@ -68,7 +61,7 @@ public class PasswordField extends StringField{
     /**
      * Identifies internal calls versus graphQL calls.
      */
-    public void markAsInternalProcess(){
+    public void alwaysReturnPassword(){
         internalProcess = true;
     }
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PasswordField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PasswordField.java
@@ -1,0 +1,78 @@
+
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.common.fields.common;
+
+import org.codice.ddf.admin.common.fields.base.scalar.StringField;
+
+public class PasswordField extends StringField{
+
+    public static final String DEFAULT_FIELD_NAME = "password";
+
+    public static final String FIELD_TYPE_NAME = "Password";
+
+    public static final String DESCRIPTION = "Password used for authentication";
+
+    // A flag to indicate if a service being updated has a password of "secret".
+    public static final String FLAG_PASSWORD = "secret";
+
+    // Determine which calls need the real password and which ones get the flag password
+    private boolean internalProcess;
+
+    public PasswordField() {
+        super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
+        internalProcess = false;
+    }
+
+    public PasswordField(String fieldName) {
+        super(fieldName, FIELD_TYPE_NAME, DESCRIPTION);
+        internalProcess = false;
+    }
+
+    /**
+     * Returns the flag password if the calling process is graphQL. This is used to exclude the password when logging.
+     *
+     * @return {@code null}, {@code FLAG_PASSWORD}, or {@code value}
+     **/
+    @Override
+    public String getValue() {
+        if(super.getValue() == null){
+            return null;
+        }
+        if(!internalProcess) {
+            return FLAG_PASSWORD;
+        }
+        return getRealPassword();
+    }
+
+    /**
+     * Returns the real password that was stored. This method is only used internally.
+     *
+     * @return {@code value}
+     */
+    public String getRealPassword(){
+        return super.getValue();
+    }
+
+    /**
+     * Identifies internal calls versus graphQL calls.
+     */
+    public void markAsInternalProcess(){
+        internalProcess = true;
+    }
+
+    public boolean isInternalProcess() {
+        return internalProcess;
+    }
+}

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/CredentialsFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/CredentialsFieldTest.groovy
@@ -22,7 +22,7 @@ class CredentialsFieldTest extends Specification {
 
     static USERNAME_FIELD_PATH = [CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.USERNAME_FIELD_NAME]
 
-    static PASSWORD_FIELD_PATH = [CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.PASSWORD_FIELD_NAME]
+    static PASSWORD_FIELD_PATH = [CredentialsField.DEFAULT_FIELD_NAME, PasswordField.DEFAULT_FIELD_NAME]
 
     static String REAL_PASSWORD = "admin"
 

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/CredentialsFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/CredentialsFieldTest.groovy
@@ -24,6 +24,8 @@ class CredentialsFieldTest extends Specification {
 
     static PASSWORD_FIELD_PATH = [CredentialsField.DEFAULT_FIELD_NAME, CredentialsField.PASSWORD_FIELD_NAME]
 
+    static String REAL_PASSWORD = "admin"
+
     def setup() {
         credentialsField = new CredentialsField()
     }
@@ -70,5 +72,16 @@ class CredentialsFieldTest extends Specification {
         validationMsgs.size() == 1
         validationMsgs.get(0).getCode() == DefaultMessages.MISSING_REQUIRED_FIELD
         validationMsgs.get(0).getPath() == USERNAME_FIELD_PATH
+    }
+
+    def 'Verify if the set password is returned correctly'(){
+        setup:
+        credentialsField.password(REAL_PASSWORD)
+
+        when:
+        String password = credentialsField.password()
+
+        then:
+        password == REAL_PASSWORD
     }
 }

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/CredentialsFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/CredentialsFieldTest.groovy
@@ -79,7 +79,7 @@ class CredentialsFieldTest extends Specification {
         credentialsField.password(REAL_PASSWORD)
 
         when:
-        String password = credentialsField.password()
+        String password = credentialsField.realPassword()
 
         then:
         password == REAL_PASSWORD

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/PasswordFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/PasswordFieldTest.groovy
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.common.fields.common
+
+import spock.lang.Specification
+
+class PasswordFieldTest extends Specification{
+
+    static String REAL_PASSWORD = "admin"
+
+    PasswordField passwordField
+
+    def setup(){
+        passwordField = new PasswordField()
+    }
+
+    def 'Real password is not returned when getValue() is called and is not markAsInternalProcess'(){
+        setup:
+        passwordField.setValue(REAL_PASSWORD)
+
+        when:
+        String password = passwordField.getValue()
+
+        then:
+        password != REAL_PASSWORD
+    }
+
+    def 'Real password is returned when getRealPassword() is called'(){
+        setup:
+        passwordField.setValue(REAL_PASSWORD)
+
+        when:
+        String password = passwordField.getRealPassword()
+
+        then:
+        password == REAL_PASSWORD
+    }
+
+    def 'Real password is returned when password is markAsInternalProcess'(){
+        setup:
+        passwordField.setValue(REAL_PASSWORD)
+        passwordField.markAsInternalProcess()
+
+        when:
+        String password = passwordField.getValue()
+
+        then:
+        password == REAL_PASSWORD
+    }
+}

--- a/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/PasswordFieldTest.groovy
+++ b/query/common/src/test/groovy/org/codice/ddf/admin/common/fields/common/PasswordFieldTest.groovy
@@ -50,7 +50,7 @@ class PasswordFieldTest extends Specification{
     def 'Real password is returned when password is markAsInternalProcess'(){
         setup:
         passwordField.setValue(REAL_PASSWORD)
-        passwordField.markAsInternalProcess()
+        passwordField.alwaysReturnPassword()
 
         when:
         String password = passwordField.getValue()

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
@@ -248,7 +248,7 @@ public class ExtendedOsgiGraphQLServlet extends OsgiGraphQLServlet implements Ev
                 GraphQLFieldDefinition fieldDef, Map<String, Object> argumentValues, Exception e) {
             if (e instanceof FunctionDataFetcherException) {
                 for (ErrorMessage msg : ((FunctionDataFetcherException) e).getCustomMessages()) {
-                    LOGGER.debug("Unsuccessful GraphQL request:\n", e.toString());
+                    LOGGER.debug("Unsuccessful GraphQL request:\n", e);
                     executionContext.addError(new DataFetchingGraphQLError(msg));
                 }
             } else {

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/FunctionDataFetcherException.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/FunctionDataFetcherException.java
@@ -14,7 +14,6 @@
 package org.codice.ddf.admin.graphql.transform;
 
 import java.util.List;
-import java.util.Map;
 
 import org.boon.Boon;
 import org.codice.ddf.admin.api.report.ErrorMessage;
@@ -23,15 +22,16 @@ import com.google.common.collect.ImmutableMap;
 
 public class FunctionDataFetcherException extends RuntimeException {
 
-    private String functionName;
-    private Map<String, Object> args;
-
     private List<ErrorMessage> customMessage;
 
-    public FunctionDataFetcherException(String functionName, Map<String, Object> args, List<ErrorMessage> customMessage) {
-        super();
-        this.functionName = functionName;
-        this.args = args;
+    public FunctionDataFetcherException(String functionName, List<Object> args,
+            List<ErrorMessage> customMessage) {
+        super(Boon.toPrettyJson(ImmutableMap.of("functionName",
+                functionName,
+                "args",
+                args,
+                "errors",
+                customMessage)));
         this.customMessage = customMessage;
     }
 
@@ -40,14 +40,7 @@ public class FunctionDataFetcherException extends RuntimeException {
     }
 
     @Override
-    public String toString() {
-        return Boon.toPrettyJson(toMap());
-    }
-
-    private Map<String, Object> toMap() {
-        return ImmutableMap.of(
-                "functionName", functionName,
-                "args", args,
-                "errors", customMessage);
+    public synchronized Throwable fillInStackTrace() {
+        return this;
     }
 }

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformOutput.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformOutput.java
@@ -166,8 +166,12 @@ public class GraphQLTransformOutput {
         funcField.setValue(args);
         FunctionReport<DataType> result = funcField.getValue();
 
+        List<Object> arguments = funcField.getArguments().stream()
+                .map(Field::getValue)
+                .collect(Collectors.toList());
+
         if(!result.messages().isEmpty()) {
-            throw new FunctionDataFetcherException(funcField.fieldName(), args, result.messages());
+            throw new FunctionDataFetcherException(funcField.fieldName(), arguments, result.messages());
         } else if(result.isResultPresent()){
             return result.result().getValue();
         }

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
@@ -99,7 +99,7 @@ public class LdapServiceCommons {
             props.put(LdapClaimsHandlerServiceProperties.PASSWORD,
                     config.bindUserInfoField()
                             .credentialsField()
-                            .password());
+                            .realPassword());
             props.put(LdapClaimsHandlerServiceProperties.BIND_METHOD,
                     config.bindUserInfoField()
                             .bindMethod());
@@ -146,7 +146,7 @@ public class LdapServiceCommons {
             ldapStsConfig.put(LdapLoginServiceProperties.LDAP_BIND_USER_PASS,
                     config.bindUserInfoField()
                             .credentialsField()
-                            .password());
+                            .realPassword());
             ldapStsConfig.put(LdapLoginServiceProperties.BIND_METHOD,
                     config.bindUserInfoField()
                             .bindMethod());

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapTestingUtils.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapTestingUtils.java
@@ -134,7 +134,7 @@ public class LdapTestingUtils {
                     bindInfo.credentialsField()
                             .username(),
                     bindInfo.credentialsField()
-                            .password(),
+                            .realPassword(),
                     bindInfo.realm(),
                     null);
             connection.bind(bindRequest);

--- a/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
+++ b/query/security/ldap/src/test/groovy/org/codice/ddf/admin/ldap/discover/GetLdapConfigurationsSpec.groovy
@@ -57,7 +57,7 @@ class GetLdapConfigurationsSpec extends Specification {
         then:
         configs != null
         configs.getList().size() == 2
-        configs.getList()*.bindUserInfoField()*.credentialsField()*.password() as List ==
+        configs.getList()*.bindUserInfoField()*.credentialsField()*.realPassword() as List ==
                 [ServiceCommons.FLAG_PASSWORD, ServiceCommons.FLAG_PASSWORD]
     }
 

--- a/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
+++ b/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
@@ -48,7 +48,7 @@ public class LdapTestingCommons {
                         .password(TestLdapServer.getBasicAuthPassword());
         ldapBindUserInfo.credentialsField()
                 .passwordField()
-                .markAsInternalProcess();
+                .alwaysReturnPassword();
         return ldapBindUserInfo;
     }
 

--- a/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
+++ b/query/security/ldap/src/test/java/org/codice/ddf/admin/ldap/LdapTestingCommons.java
@@ -42,9 +42,14 @@ public class LdapTestingCommons {
     }
 
     public static LdapBindUserInfo simpleBindInfo() {
-        return new LdapBindUserInfo().bindMethod(LdapBindMethod.Simple.SIMPLE)
-                .username(TestLdapServer.getBasicAuthDn())
-                .password(TestLdapServer.getBasicAuthPassword());
+        LdapBindUserInfo ldapBindUserInfo =
+                new LdapBindUserInfo().bindMethod(LdapBindMethod.Simple.SIMPLE)
+                        .username(TestLdapServer.getBasicAuthDn())
+                        .password(TestLdapServer.getBasicAuthPassword());
+        ldapBindUserInfo.credentialsField()
+                .passwordField()
+                .markAsInternalProcess();
+        return ldapBindUserInfo;
     }
 
     public static LdapDirectorySettingsField initLdapSettings(String useCase) {

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/services/CswServiceProperties.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/services/CswServiceProperties.java
@@ -103,11 +103,11 @@ public class CswServiceProperties {
                         .putPropertyIfNotNull(FORCE_SPATIAL_FILTER, config.spatialOperatorField());
 
         String password = config.credentials()
-                .password();
+                .realPassword();
         if (password != null && !password.equals(FLAG_PASSWORD)) {
             builder.put(PASSWORD,
                     config.credentials()
-                            .password());
+                            .realPassword());
         }
 
         if (config.endpointUrl() != null && config.cswProfile()

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/services/OpenSearchServiceProperties.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/services/OpenSearchServiceProperties.java
@@ -72,11 +72,11 @@ public class OpenSearchServiceProperties {
                                         .usernameField());
 
         String password = config.credentials()
-                .password();
+                .realPassword();
         if (password != null && !password.equals(FLAG_PASSWORD)) {
             builder.put(PASSWORD,
                     config.credentials()
-                            .password());
+                            .realPassword());
         }
         return builder.build();
     }

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/services/WfsServiceProperties.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/services/WfsServiceProperties.java
@@ -85,11 +85,11 @@ public class WfsServiceProperties {
                                         .usernameField());
 
         String password = config.credentials()
-                .password();
+                .realPassword();
         if (password != null && !password.equals(FLAG_PASSWORD)) {
             builder.put(PASSWORD,
                     config.credentials()
-                            .password());
+                            .realPassword());
         }
         return builder.build();
     }

--- a/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
+++ b/query/sources/common/src/main/java/org/codice/ddf/admin/sources/utils/RequestUtils.java
@@ -56,7 +56,7 @@ public class RequestUtils {
             CredentialsField creds, Map<String, Object> queryParams) {
         WebClient webClient = createWebClientBuilder(requestUrl.getValue(),
                 creds.username(),
-                creds.password()).queryParams(queryParams)
+                creds.realPassword()).queryParams(queryParams)
                 .build();
 
         return sendGetRequest(webClient, requestUrl);
@@ -107,7 +107,7 @@ public class RequestUtils {
             CredentialsField creds, String contentType, String content) {
         WebClient webClient = createWebClientBuilder(urlField.getValue(),
                 creds.username(),
-                creds.password()).contentType(contentType)
+                creds.realPassword()).contentType(contentType)
                 .build();
 
         return sendPostRequest(webClient, urlField, content);

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/DiscoverCswSourceSpec.groovy
@@ -74,7 +74,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
         config.cswProfile() == CswProfile.DDFCswFederatedSource.CSW_FEDERATION_PROFILE_SOURCE
         config.outputSchema() == CswSourceUtils.METACARD_OUTPUT_SCHEMA
         config.spatialOperator() == NO_FILTER
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover CSWSpecification federation profile with URL'() {
@@ -91,7 +91,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
         config.cswProfile() == CswProfile.CswFederatedSource.CSW_SPEC_PROFILE_FEDERATED_SOURCE
         config.outputSchema() == CswSourceUtils.CSW_2_0_2_OUTPUT_SCHEMA
         config.spatialOperator() == NO_FILTER
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover GMD CSW federation profile with URL'() {
@@ -108,7 +108,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
         config.cswProfile() == CswProfile.GmdCswFederatedSource.GMD_CSW_ISO_FEDERATED_SOURCE
         config.outputSchema() == CswSourceUtils.GMD_OUTPUT_SCHEMA
         config.spatialOperator() == NO_FILTER
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover DDF federation profile using hostname and port'() {
@@ -125,7 +125,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
         config.cswProfile() == CswProfile.DDFCswFederatedSource.CSW_FEDERATION_PROFILE_SOURCE
         config.outputSchema() == CswSourceUtils.METACARD_OUTPUT_SCHEMA
         config.spatialOperator() == NO_FILTER
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
 
@@ -143,7 +143,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
         config.cswProfile() == CswProfile.CswFederatedSource.CSW_SPEC_PROFILE_FEDERATED_SOURCE
         config.outputSchema() == CswSourceUtils.CSW_2_0_2_OUTPUT_SCHEMA
         config.spatialOperator() == NO_FILTER
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover GMD CSW federation profile using hostname and port'() {
@@ -160,7 +160,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
         config.cswProfile() == CswProfile.GmdCswFederatedSource.GMD_CSW_ISO_FEDERATED_SOURCE
         config.outputSchema() == CswSourceUtils.GMD_OUTPUT_SCHEMA
         config.spatialOperator() == NO_FILTER
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Unknown endpoint error with bad HTTP status'() {
@@ -233,7 +233,7 @@ class DiscoverCswSourceSpec extends SourceCommonsSpec {
         config.cswProfile() == CswProfile.CswFederatedSource.CSW_SPEC_PROFILE_FEDERATED_SOURCE
         config.outputSchema() == CswSourceUtils.CSW_2_0_2_OUTPUT_SCHEMA
         config.spatialOperator() == NO_FILTER
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Unknown endpoint error when there is no output schema'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/discover/GetCswConfigsSpec.groovy
@@ -124,7 +124,7 @@ class GetCswConfigsSpec extends SourceCommonsSpec {
         assert sourceInfo.path()[-1] == index.toString()
         assert sourceInfo.isAvailable() == availability
         assert sourceInfo.config().endpointUrl() == properties.get(CswServiceProperties.CSW_URL)
-        assert sourceInfo.config().credentials().password() == FLAG_PASSWORD
+        assert sourceInfo.config().credentials().realPassword() == FLAG_PASSWORD
         assert sourceInfo.config().credentials().username() == TEST_USERNAME
         assert sourceInfo.config().sourceName() == sourceName
         assert sourceInfo.config().pid() == pid

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
@@ -244,7 +244,7 @@ class UpdateCswConfigurationSpec extends SourceCommonsSpec {
                 .cswProfile(TEST_CSW_PROFILE)
         config.endpointUrl(TEST_URL).sourceName(TEST_SOURCENAME)
                 .pid(S_PID)
-        config.credentials().username(TEST_USERNAME).password(password).passwordField().markAsInternalProcess()
+        config.credentials().username(TEST_USERNAME).password(password).passwordField().alwaysReturnPassword()
         return config
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/csw/persist/UpdateCswConfigurationSpec.groovy
@@ -244,7 +244,7 @@ class UpdateCswConfigurationSpec extends SourceCommonsSpec {
                 .cswProfile(TEST_CSW_PROFILE)
         config.endpointUrl(TEST_URL).sourceName(TEST_SOURCENAME)
                 .pid(S_PID)
-        config.credentials().username(TEST_USERNAME).password(password)
+        config.credentials().username(TEST_USERNAME).password(password).passwordField().markAsInternalProcess()
         return config
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/DiscoverOpenSearchSpec.groovy
@@ -57,7 +57,7 @@ class DiscoverOpenSearchSpec extends SourceCommonsSpec {
 
         then:
         config.endpointUrl() == TEST_OPEN_SEARCH_URL
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover OpenSearch Configuration using hostname and port'() {
@@ -71,7 +71,7 @@ class DiscoverOpenSearchSpec extends SourceCommonsSpec {
 
         then:
         !config.endpointUrl().isEmpty()
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Failure to discover OpenSearch configuration due to unrecognized response when using URL'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/discover/GetOpenSearchConfigsSpec.groovy
@@ -126,7 +126,7 @@ class GetOpenSearchConfigsSpec extends SourceCommonsSpec {
         def sourceInfo = (OpenSearchSourceInfoField) field
         assert sourceInfo.path()[-1] == index.toString()
         assert sourceInfo.isAvailable() == availability
-        assert sourceInfo.config().credentials().password() == FLAG_PASSWORD
+        assert sourceInfo.config().credentials().realPassword() == FLAG_PASSWORD
         assert sourceInfo.config().credentials().username() == TEST_USERNAME
         assert sourceInfo.config().sourceName() == sourceName
         assert sourceInfo.config().pid() == pid

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
@@ -228,7 +228,7 @@ class UpdateOpenSearchConfigurationSpec extends SourceCommonsSpec {
     def createOpenSearchSourceConfig(String password) {
         def config = new OpenSearchSourceConfigurationField()
         config.endpointUrl('https://localhost:8993').sourceName(TEST_SOURCENAME)
-                .pid(S_PID).credentials().username(TEST_USERNAME).password(password)
+                .pid(S_PID).credentials().username(TEST_USERNAME).password(password).passwordField().markAsInternalProcess()
         return config
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/opensearch/persist/UpdateOpenSearchConfigurationSpec.groovy
@@ -228,7 +228,7 @@ class UpdateOpenSearchConfigurationSpec extends SourceCommonsSpec {
     def createOpenSearchSourceConfig(String password) {
         def config = new OpenSearchSourceConfigurationField()
         config.endpointUrl('https://localhost:8993').sourceName(TEST_SOURCENAME)
-                .pid(S_PID).credentials().username(TEST_USERNAME).password(password).passwordField().markAsInternalProcess()
+                .pid(S_PID).credentials().username(TEST_USERNAME).password(password).passwordField().alwaysReturnPassword()
         return config
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/DiscoverWfsSourcesSpec.groovy
@@ -65,7 +65,7 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
         then:
         config.endpointUrl() == TEST_WFS_URL
         config.wfsVersion() == WfsVersion.Wfs1.WFS_VERSION_1
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover WFS 2.0.0 configuration using URL'() {
@@ -80,7 +80,7 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
         then:
         config.endpointUrl() == TEST_WFS_URL
         config.wfsVersion() == WfsVersion.Wfs2.WFS_VERSION_2
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover WFS 1.0.0 configuration using hostname and port'() {
@@ -95,7 +95,7 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
         then:
         !config.endpointUrl().isEmpty()
         config.wfsVersion() == WfsVersion.Wfs1.WFS_VERSION_1
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Successfully discover WFS 2.0.0 configuration using hostname and port'() {
@@ -110,7 +110,7 @@ class DiscoverWfsSourcesSpec extends SourceCommonsSpec {
         then:
         !config.endpointUrl().isEmpty()
         config.wfsVersion() == WfsVersion.Wfs2.WFS_VERSION_2
-        config.credentials().password() == FLAG_PASSWORD
+        config.credentials().realPassword() == FLAG_PASSWORD
     }
 
     def 'Unknown endpoint error when unrecognized WFS version is received'() {

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/discover/GetWfsConfigsSpec.groovy
@@ -130,7 +130,7 @@ class GetWfsConfigsSpec extends SourceCommonsSpec {
         def sourceInfo = (WfsSourceInfoField) field
         assert sourceInfo.path()[-1] == index.toString()
         assert sourceInfo.isAvailable() == availability
-        assert sourceInfo.config().credentials().password() == FLAG_PASSWORD
+        assert sourceInfo.config().credentials().realPassword() == FLAG_PASSWORD
         assert sourceInfo.config().credentials().username() == TEST_USERNAME
         assert sourceInfo.config().sourceName() == sourceName
         assert sourceInfo.config().pid() == pid

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
@@ -236,7 +236,7 @@ class UpdateWfsConfigurationSpec extends SourceCommonsSpec {
         config.wfsVersion(TEST_WFS_VERSION)
                 .endpointUrl('https://localhost:8993/geoserver/wfs').sourceName(TEST_SOURCENAME)
                 .pid(S_PID)
-                .credentials().username(TEST_USERNAME).password(password)
+                .credentials().username(TEST_USERNAME).password(password).passwordField().markAsInternalProcess()
         return config
     }
 }

--- a/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
+++ b/query/sources/impl/src/test/groovy/org/codice/ddf/admin/sources/wfs/persist/UpdateWfsConfigurationSpec.groovy
@@ -236,7 +236,7 @@ class UpdateWfsConfigurationSpec extends SourceCommonsSpec {
         config.wfsVersion(TEST_WFS_VERSION)
                 .endpointUrl('https://localhost:8993/geoserver/wfs').sourceName(TEST_SOURCENAME)
                 .pid(S_PID)
-                .credentials().username(TEST_USERNAME).password(password).passwordField().markAsInternalProcess()
+                .credentials().username(TEST_USERNAME).password(password).passwordField().alwaysReturnPassword()
         return config
     }
 }


### PR DESCRIPTION
#### What does this PR do?
Not displaying the real password in the logs. Instead, we will display the flag password.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@coyotesqrl @peterhuffer @tbatie 

#### How should this be tested? (List steps with links to updated documentation)
Making sure that the password you enter isn't displayed in the logs when you do `log:tail` using the wizard or graphiql.

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
