### PR TITLE
Fixed LDAP recommended settings query.

### DIFF
--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -211,7 +211,7 @@ const DirectorySettings = (props) => {
           tooltip='The attribute of the user entry that, when combined with the Base User DN, forms the reference value, e.g. XXX=jsmith,ou=users,dc=example,dc=com'
           visible={isAttrStore}
           disabled={disabled}
-          options={options.groupAttributesHoldingMember} />
+          options={options.memberAttributesReferencedInGroup} />
 
         <InputAuto
           id='baseGroupDn'
@@ -276,7 +276,7 @@ export default graphql(gql`
         userDns
         groupsDns
         userNameAttributes
-        groupAttributesHoldingMember
+        memberAttributesReferencedInGroup
         groupObjectClasses
         groupAttributesHoldingMember
         queryBases


### PR DESCRIPTION
#### What does this PR do?

Fixes LDAP recommended settings query.

#### Who is reviewing it?

@garrettfreibott 
@tbatie 

#### How should this be tested?

Go though LDAP wizard ensuring the nothing broke and that the correct recommended setting query is sent.

#### Any background context you want to provide?

When migrating the wizards to graphql, a mistake was made with the recommended settings query. This fix resolves that mistake.

#### What are the relevant tickets?

[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
