### PR TITLE
DDF-2773 Increase batch executor default time

### DIFF
--- a/query/common/src/main/java/org/codice/ddf/admin/common/PrioritizedBatchExecutor.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/PrioritizedBatchExecutor.java
@@ -42,7 +42,7 @@ public class PrioritizedBatchExecutor<T, R> {
 
     private static final int MAX_THREAD_POOL_SIZE = 64;
 
-    private static final int DEFAULT_WAIT_TIME_SEC = 10;
+    private static final int DEFAULT_WAIT_TIME_SEC = 60;
 
     private final ExecutorService threadPool;
 


### PR DESCRIPTION
#### What does this PR do?
Increases the default wait time for the `PrioritizedBatchExecutor` from 10 seconds to 60 seconds.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@tbatie @blen-desta @coyotesqrl 

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Screenshots (if appropriate)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
