### PR TITLE
DDF-2773: Masking password in logs

### DIFF
--- a/query/api/src/main/java/org/codice/ddf/admin/api/fields/ScalarField.java
+++ b/query/api/src/main/java/org/codice/ddf/admin/api/fields/ScalarField.java
@@ -20,6 +20,6 @@ public interface ScalarField<S> extends DataType<S> {
     ScalarType scalarType();
 
     enum ScalarType {
-        STRING, INTEGER, FLOAT, BOOLEAN
+        STRING, INTEGER, FLOAT, BOOLEAN, HIDDEN_STRING
     }
 }

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/BaseHiddenField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/BaseHiddenField.java
@@ -26,7 +26,7 @@ import com.google.common.collect.ImmutableSet;
 
 public class BaseHiddenField extends BaseScalarField<String> {
 
-    public static final String DEFAULT_FIELD_NAME  = "hidden password";
+    private static final String DEFAULT_FIELD_NAME  = "hidden";
 
     protected BaseHiddenField(String fieldName, String fieldTypeName, String description) {
         super(fieldName, fieldTypeName, description, HIDDEN_STRING);

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/BaseHiddenField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/base/scalar/BaseHiddenField.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Codice Foundation
+ * <p>
+ * This is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser
+ * General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or any later version.
+ * <p>
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details. A copy of the GNU Lesser General Public License
+ * is distributed along with this program and can be found at
+ * <http://www.gnu.org/licenses/lgpl.html>.
+ **/
+package org.codice.ddf.admin.common.fields.base.scalar;
+
+import static org.codice.ddf.admin.api.fields.ScalarField.ScalarType.HIDDEN_STRING;
+import static org.codice.ddf.admin.common.report.message.DefaultMessages.emptyFieldError;
+
+import java.util.List;
+import java.util.Set;
+
+import org.codice.ddf.admin.api.report.ErrorMessage;
+import org.codice.ddf.admin.common.report.message.DefaultMessages;
+
+import com.google.common.collect.ImmutableSet;
+
+public class BaseHiddenField extends BaseScalarField<String> {
+
+    public static final String DEFAULT_FIELD_NAME  = "hidden password";
+
+    protected BaseHiddenField(String fieldName, String fieldTypeName, String description) {
+        super(fieldName, fieldTypeName, description, HIDDEN_STRING);
+    }
+
+    public BaseHiddenField(String fieldName) {
+        this(fieldName, null, null);
+    }
+
+    public BaseHiddenField() {
+        this(DEFAULT_FIELD_NAME);
+    }
+
+    @Override
+    public List<ErrorMessage> validate() {
+        List<ErrorMessage> validationMsgs = super.validate();
+
+        if(!validationMsgs.isEmpty()) {
+            return validationMsgs;
+        }
+
+        if(getValue() != null && getValue().isEmpty()) {
+            validationMsgs.add(emptyFieldError(path()));
+        }
+
+        return validationMsgs;
+    }
+
+    @Override
+    public BaseHiddenField isRequired(boolean required) {
+        super.isRequired(required);
+        return this;
+    }
+
+    @Override
+    public Set<String> getErrorCodes() {
+        return new ImmutableSet.Builder<String>()
+                .addAll(super.getErrorCodes())
+                .add(DefaultMessages.EMPTY_FIELD)
+                .build();
+    }
+
+}

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/CredentialsField.java
@@ -35,12 +35,12 @@ public class CredentialsField extends BaseObjectField {
 
     private StringField username;
 
-    private StringField password;
+    private PasswordField password;
 
     public CredentialsField() {
         super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
         this.username = new StringField(USERNAME_FIELD_NAME);
-        this.password = new StringField(PASSWORD_FIELD_NAME);
+        this.password = new PasswordField(PASSWORD_FIELD_NAME);
         updateInnerFieldPaths();
     }
 
@@ -58,7 +58,7 @@ public class CredentialsField extends BaseObjectField {
         return username;
     }
 
-    public StringField passwordField() {
+    public PasswordField passwordField() {
         return password;
     }
 

--- a/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PasswordField.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/fields/common/PasswordField.java
@@ -11,26 +11,23 @@
  * is distributed along with this program and can be found at
  * <http://www.gnu.org/licenses/lgpl.html>.
  **/
-package org.codice.ddf.admin.graphql.transform;
+package org.codice.ddf.admin.common.fields.common;
 
-import java.util.List;
+import org.codice.ddf.admin.common.fields.base.scalar.BaseHiddenField;
 
-import org.codice.ddf.admin.api.report.ErrorMessage;
+public class PasswordField extends BaseHiddenField {
 
-public class FunctionDataFetcherException extends RuntimeException {
+    public static final String DEFAULT_FIELD_NAME = "password";
 
-    private List<ErrorMessage> customMessage;
+    public static final String FIELD_TYPE_NAME = "Password";
 
-    public FunctionDataFetcherException(String message, List<ErrorMessage> customMessage) {
-        super(message);
-        this.customMessage = customMessage;
+    public static final String DESCRIPTION = "Password used for authentication.";
+
+    public PasswordField() {
+        super(DEFAULT_FIELD_NAME, FIELD_TYPE_NAME, DESCRIPTION);
     }
 
-    public List<ErrorMessage> getCustomMessages() {
-        return customMessage;
-    }
-
-    public synchronized Throwable fillInStackTrace() {
-        return this;
+    public PasswordField(String fieldName) {
+        super(fieldName, FIELD_TYPE_NAME, DESCRIPTION);
     }
 }

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
@@ -248,7 +248,7 @@ public class ExtendedOsgiGraphQLServlet extends OsgiGraphQLServlet implements Ev
                 GraphQLFieldDefinition fieldDef, Map<String, Object> argumentValues, Exception e) {
             if (e instanceof FunctionDataFetcherException) {
                 for (ErrorMessage msg : ((FunctionDataFetcherException) e).getCustomMessages()) {
-                    LOGGER.debug("Unsuccessful GraphQL request:\n", e.toString());
+                    LOGGER.debug("Unsuccessful GraphQL request:\n", e);
                     executionContext.addError(new DataFetchingGraphQLError(msg));
                 }
             } else {

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/FunctionDataFetcherException.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/FunctionDataFetcherException.java
@@ -14,23 +14,69 @@
 package org.codice.ddf.admin.graphql.transform;
 
 import java.util.List;
+import java.util.Map;
 
+import org.boon.Boon;
 import org.codice.ddf.admin.api.report.ErrorMessage;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 
 public class FunctionDataFetcherException extends RuntimeException {
 
-    private List<ErrorMessage> customMessage;
+    private List<ErrorMessage> customMessages;
 
-    public FunctionDataFetcherException(String message, List<ErrorMessage> customMessage) {
-        super(message);
-        this.customMessage = customMessage;
+    private static final List<String> BLACK_LIST_WORDS = ImmutableList.of("password");
+
+    private static final String HIDDEN_FLAG = "*****";
+
+    public FunctionDataFetcherException(String functionName, List<Object> args,
+            List<ErrorMessage> customMessages) {
+        super(filterString(functionName, args, customMessages));
+        this.customMessages = customMessages;
     }
 
     public List<ErrorMessage> getCustomMessages() {
-        return customMessage;
+        return customMessages;
     }
 
+    /**
+     * Overrides the {@code fillInStackTrace} method to suppress the stack trace that is
+     * printed by GraphQL.
+     **/
+    @Override
     public synchronized Throwable fillInStackTrace() {
         return this;
+    }
+
+    public static String filterString(String functionName, List<Object> args,
+            List<ErrorMessage> customMessage) {
+        return Boon.toPrettyJson(blackList(toMap(functionName, args, customMessage)));
+    }
+
+    private static Object blackList(Object result) {
+        if (result instanceof List) {
+            ((List) result).forEach(FunctionDataFetcherException::blackList);
+        } else if (result instanceof Map) {
+            for (Map.Entry<String, Object> entry : ((Map<String, Object>) result).entrySet()) {
+                if (entry.getValue() instanceof Map || entry.getValue() instanceof List) {
+                    blackList(entry.getValue());
+                } else {
+                    boolean containsBlackListWord = BLACK_LIST_WORDS.stream()
+                            .anyMatch(blackListWord -> entry.getKey()
+                                    .toLowerCase()
+                                    .contains(blackListWord.toLowerCase()));
+                    if (containsBlackListWord) {
+                        entry.setValue(HIDDEN_FLAG);
+                    }
+                }
+            }
+        }
+        return result;
+    }
+
+    private static Map<String, Object> toMap(String functionName, List<Object> args,
+            List<ErrorMessage> customMessage) {
+        return ImmutableMap.of("functionName", functionName, "args", args, "errors", customMessage);
     }
 }

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformOutput.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformOutput.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import org.boon.Boon;
 import org.codice.ddf.admin.api.DataType;
 import org.codice.ddf.admin.api.Field;
 import org.codice.ddf.admin.api.FieldProvider;
@@ -27,12 +28,14 @@ import org.codice.ddf.admin.api.fields.FunctionField;
 import org.codice.ddf.admin.api.fields.ListField;
 import org.codice.ddf.admin.api.fields.ObjectField;
 import org.codice.ddf.admin.api.fields.ScalarField;
+import org.codice.ddf.admin.api.report.ErrorMessage;
 import org.codice.ddf.admin.api.report.FunctionReport;
 import org.codice.ddf.admin.graphql.GraphQLTypesProviderImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 import graphql.schema.DataFetchingEnvironment;
@@ -167,7 +170,7 @@ public class GraphQLTransformOutput {
         FunctionReport<DataType> result = funcField.getValue();
 
         if(!result.messages().isEmpty()) {
-            throw new FunctionDataFetcherException(funcField.fieldName(), args, result.messages());
+            throw new FunctionDataFetcherException(toPrettyString(funcField, result.messages()), result.messages());
         } else if(result.isResultPresent()){
             return result.result().getValue();
         }
@@ -199,5 +202,40 @@ public class GraphQLTransformOutput {
                 transformScalar.getScalarTypesProvider(),
                 transformEnum.getEnumTypeProvider(),
                 outputTypeProvider);
+    }
+
+    private String toPrettyString(FunctionField<DataType> funcField,
+            List<ErrorMessage> customMessage) {
+        String functionName = funcField.fieldName();
+        List<Object> args = funcField.getArguments()
+                .stream()
+                .map(Field::getValue)
+                .collect(Collectors.toList());
+
+        return Boon.toPrettyJson(hidePassword(toMap(functionName, args, customMessage)));
+    }
+
+    private Object hidePassword(Object result) {
+        if (result instanceof List) {
+            for (Object obj : (ArrayList) result) {
+                hidePassword(obj);
+            }
+        } else if (result instanceof Map) {
+            Map<String, Object> innerMap = (Map) result;
+            for (String str : innerMap.keySet()) {
+                if (!(innerMap.get(str) instanceof HashMap)
+                        && !(innerMap.get(str) instanceof ArrayList) && str.contains("pass")) {
+                    innerMap.replace(str, "***");
+                } else {
+                    hidePassword(innerMap.get(str));
+                }
+            }
+        }
+        return result;
+    }
+
+    private Map<String, Object> toMap(String functionName, List<Object> args,
+            List<ErrorMessage> customMessage) {
+        return ImmutableMap.of("functionName", functionName, "args", args, "errors", customMessage);
     }
 }

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformScalar.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/transform/GraphQLTransformScalar.java
@@ -23,26 +23,31 @@ import graphql.schema.GraphQLScalarType;
 public class GraphQLTransformScalar {
 
     GraphQLTypesProviderImpl<GraphQLScalarType> scalarTypesProvider;
-    private Coercing encryptPasswordCoercing;
+
+    private static final String HIDDEN_FLAG = "*****";
+
+    private static final Coercing HIDDEN_COERCING  = new Coercing() {
+        @Override
+        public Object serialize(Object input) {
+            return HIDDEN_FLAG;
+        }
+
+        @Override
+        public Object parseValue(Object input) {
+            return Scalars.GraphQLString.getCoercing()
+                    .parseValue(input);
+        }
+
+        @Override
+        public Object parseLiteral(Object input) {
+            return Scalars.GraphQLString.getCoercing()
+                    .parseLiteral(input);
+        }
+
+    };
 
     public GraphQLTransformScalar() {
         scalarTypesProvider = new GraphQLTypesProviderImpl<>();
-        encryptPasswordCoercing = new Coercing() {
-            @Override
-            public Object serialize(Object input) {
-                return "***";
-            }
-
-            @Override
-            public Object parseValue(Object input) {
-                return Scalars.GraphQLString.getCoercing().parseValue(input);
-            }
-
-            @Override
-            public Object parseLiteral(Object input) {
-                return Scalars.GraphQLString.getCoercing().parseLiteral(input);
-            }
-        };
     }
 
     public GraphQLScalarType resolveScalarType(ScalarField field) {
@@ -75,7 +80,7 @@ public class GraphQLTransformScalar {
             break;
         case HIDDEN_STRING:
             type = field.fieldTypeName() == null ? Scalars.GraphQLString :
-                    new GraphQLScalarType(field.fieldTypeName(), field.description(), encryptPasswordCoercing);
+                    new GraphQLScalarType(field.fieldTypeName(), field.description(), HIDDEN_COERCING);
         }
 
         scalarTypesProvider.addType(field.fieldTypeName(), type);

--- a/query/graphql/src/test/groovy/org/codice/ddf/admin/graphql/test/FunctionDataFetcherExceptionTest.groovy
+++ b/query/graphql/src/test/groovy/org/codice/ddf/admin/graphql/test/FunctionDataFetcherExceptionTest.groovy
@@ -1,0 +1,56 @@
+package org.codice.ddf.admin.graphql.test
+
+import com.google.common.collect.ImmutableList
+import com.google.common.collect.ImmutableMap
+import org.boon.Boon
+import org.codice.ddf.admin.api.report.ErrorMessage
+import org.codice.ddf.admin.common.report.message.DefaultMessages
+import org.codice.ddf.admin.graphql.transform.FunctionDataFetcherException
+import spock.lang.Specification
+
+class FunctionDataFetcherExceptionTest extends Specification {
+
+    private static final String HIDDEN_FLAG = "*****"
+    FunctionDataFetcherException fetcherException
+
+    def 'Successfully hide passwords in logs'() {
+        setup:
+        Map given = [
+                "password": "admin",
+                "username": "admin"
+        ]
+        Map expected = [
+                "password": HIDDEN_FLAG,
+                "username": "admin"
+        ]
+        def expectedResult = Boon.toPrettyJson(ImmutableMap.of("functionName", "updateCswSource", "args", createArgs(expected), "errors", createErrors()))
+        fetcherException = new FunctionDataFetcherException("updateCswSource", createArgs(given), createErrors())
+
+        when:
+        def result = fetcherException.filterString("updateCswSource", createArgs(given), createErrors())
+
+        then:
+        result == expectedResult
+    }
+
+    List<Object> createArgs(Map creds) {
+        Map args = [
+                "cswProfile"        : "null",
+                "endpointUrl"       : "null",
+                "pid"               : "",
+                "cswSpatialOperator": "NO_FILTER",
+                "sourceName"        : "",
+                "cswOutputSchema"   : "null",
+                "creds"             : creds
+        ]
+
+        return ImmutableList.of(args)
+    }
+
+    List<ErrorMessage> createErrors() {
+        return ImmutableList.of(DefaultMessages.cannotConnectError(),
+                DefaultMessages.noExistingConfigError(),
+                DefaultMessages.failedPersistError(),
+                DefaultMessages.unknownEndpointError())
+    }
+}


### PR DESCRIPTION
#### What does this PR do?
Passwords will be hidden in the logs.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @peterhuffer @tbatie 

#### How should this be tested? (List steps with links to updated documentation)
Using graphiql send incorrect queries which will trigger an exception that will print the query. The password in that log should be replaced by `***`

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
