### PR TITLE
DDF-2773 AdminConsole WCPM not allow trailing slashes to context paths

### DIFF
--- a/query/common/src/main/java/org/codice/ddf/admin/common/report/message/DefaultMessages.java
+++ b/query/common/src/main/java/org/codice/ddf/admin/common/report/message/DefaultMessages.java
@@ -53,6 +53,8 @@ public class DefaultMessages {
 
     public static final String SIMILAR_SERVICE_EXISTS = "SIMILAR_SERVICE_EXISTS";
 
+    public static final String INVALID_PATH_TRAILING_SLASH = "INVALID_PATH_TRAILING_SLASH";
+
     public static ErrorMessage failedTestSetup() {
         return new ErrorMessageImpl(FAILED_TEST_SETUP);
     }
@@ -135,5 +137,9 @@ public class DefaultMessages {
 
     public static ErrorMessage similarServiceExists(List<String> path) {
         return new ErrorMessageImpl(SIMILAR_SERVICE_EXISTS, path);
+    }
+
+    public static ErrorMessage invalidPathTrailingSlash(List<String> path) {
+        return new ErrorMessageImpl(INVALID_PATH_TRAILING_SLASH, path);
     }
 }

--- a/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveContextPoliciesSpec.groovy
+++ b/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveContextPoliciesSpec.groovy
@@ -281,18 +281,45 @@ class SaveContextPoliciesSpec extends Specification {
         report.getResult() == null
     }
 
+    def 'Fail when context path has a trailing slash'(){
+        setup:
+        operationReport.containsFailedResults() >> false
+        testData.policies[1].paths = ['/test/', '/test', 'wrong/', '/invalid/']
+
+        when:
+        saveContextPoliciesFunction.setArguments(testData)
+        Report report = saveContextPoliciesFunction.execute()
+
+        then:
+        report.getErrorMessages().size() == 4
+
+        report.getErrorMessages()[0].code == DefaultMessages.INVALID_CONTEXT_PATH
+        report.getErrorMessages()[0].path == [WcpmFieldProvider.NAME, SaveContextPolices.FUNCTION_FIELD_NAME, BaseFunctionField.ARGUMENT, 'policies', '1', 'paths', '2']
+
+        report.getErrorMessages()[1].code == DefaultMessages.INVALID_PATH_TRAILING_SLASH
+        report.getErrorMessages()[1].path == [WcpmFieldProvider.NAME, SaveContextPolices.FUNCTION_FIELD_NAME, BaseFunctionField.ARGUMENT, 'policies', '1', 'paths', '0']
+
+        report.getErrorMessages()[2].code == DefaultMessages.INVALID_PATH_TRAILING_SLASH
+        report.getErrorMessages()[2].path == [WcpmFieldProvider.NAME, SaveContextPolices.FUNCTION_FIELD_NAME, BaseFunctionField.ARGUMENT, 'policies', '1', 'paths', '2']
+
+        report.getErrorMessages()[3].code == DefaultMessages.INVALID_PATH_TRAILING_SLASH
+        report.getErrorMessages()[3].path == [WcpmFieldProvider.NAME, SaveContextPolices.FUNCTION_FIELD_NAME, BaseFunctionField.ARGUMENT, 'policies', '1', 'paths', '3']
+        report.getResult() == null
+    }
+
     def 'Returns all the possible error codes correctly'(){
         when:
         def errorCodes = saveContextPoliciesFunction.getErrorCodes()
 
         then:
-        errorCodes.size() == 8
+        errorCodes.size() == 9
         errorCodes.contains(DefaultMessages.FAILED_PERSIST)
         errorCodes.contains(DefaultMessages.INVALID_CONTEXT_PATH)
         errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
         errorCodes.contains(DefaultMessages.EMPTY_FIELD)
         errorCodes.contains(DefaultMessages.MISSING_KEY_VALUE)
         errorCodes.contains(DefaultMessages.UNSUPPORTED_ENUM)
+        errorCodes.contains(DefaultMessages.INVALID_PATH_TRAILING_SLASH)
         errorCodes.contains(SecurityMessages.INVALID_CLAIM_TYPE)
         errorCodes.contains(SecurityMessages.NO_ROOT_CONTEXT)
     }

--- a/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContextsTest.groovy
+++ b/query/security/wcpm/src/test/groovy/org/codice/ddf/admin/security/wcpm/persist/SaveWhitelistContextsTest.groovy
@@ -105,6 +105,21 @@ class SaveWhitelistContextsTest extends Specification {
         report.getResult() == null
     }
 
+    def 'Fail if context path has a trailing slash'() {
+        setup:
+        def testMap = ['paths': ['/test', '/path', '/test/']]
+        operationReport.containsFailedResults() >> false
+
+        when:
+        saveWhitelistContextsFunction.setArguments(testMap)
+        Report report = saveWhitelistContextsFunction.execute()
+
+        then:
+        report.getErrorMessages()[0].code == DefaultMessages.INVALID_PATH_TRAILING_SLASH
+        report.getErrorMessages()[0].path == [WcpmFieldProvider.NAME, SaveWhitelistContexts.FIELD_NAME, BaseFunctionField.ARGUMENT, 'paths', '2']
+        report.getResult() == null
+    }
+
     def 'Pass if list is empty (whitelist contexts not required)'() {
         setup:
         def testMap = ['paths': []]
@@ -139,10 +154,11 @@ class SaveWhitelistContextsTest extends Specification {
         def errorCodes = saveWhitelistContextsFunction.getErrorCodes()
 
         then:
-        errorCodes.size() == 4
+        errorCodes.size() == 5
         errorCodes.contains(DefaultMessages.FAILED_PERSIST)
         errorCodes.contains(DefaultMessages.INVALID_CONTEXT_PATH)
         errorCodes.contains(DefaultMessages.MISSING_REQUIRED_FIELD)
         errorCodes.contains(DefaultMessages.EMPTY_FIELD)
+        errorCodes.contains(DefaultMessages.INVALID_PATH_TRAILING_SLASH)
     }
 }

--- a/ui/src/main/webapp/lib/graphql-errors/index.js
+++ b/ui/src/main/webapp/lib/graphql-errors/index.js
@@ -24,7 +24,8 @@ const friendlyMessage = {
   NO_GROUPS_WITH_MEMBERS: 'No groups were found containing any members.',
   NO_REFERENCED_MEMBER: 'Unable to find a user with the member attribute specified for groups.',
   USER_ATTRIBUTE_NOT_FOUND: 'Could not find attribute on any users.',
-  INVALID_USER_ATTRIBUTE: 'Invalid LDAP user attribute.'
+  INVALID_USER_ATTRIBUTE: 'Invalid LDAP user attribute.',
+  INVALID_PATH_TRAILING_SLASH: 'No trailing slashes allowed.'
 }
 
 export const genericMessage = (code) => `There was a problem with the request to the server: ${code}`

--- a/ui/src/main/webapp/security/wcpm/policy.js
+++ b/ui/src/main/webapp/security/wcpm/policy.js
@@ -152,6 +152,10 @@ const isValidContextPath = (path) => {
   return /^(\/[A-Za-z0-9-._~:/?#[\]@!$&'()*+,;=`.%]*)+$/g.test(path)
 }
 
+const hasTrailingSlash = (path) => {
+  return /.+\/$/.test(path)
+}
+
 export const validator = (policy, { whitelisted = [], policies = [] } = {}) => {
   let errors = Map()
 
@@ -161,6 +165,8 @@ export const validator = (policy, { whitelisted = [], policies = [] } = {}) => {
     policy.paths.forEach((path, i) => {
       if (!isValidContextPath(path)) {
         errors = errors.setIn(['paths', i], 'Invalid context path')
+      } else if (hasTrailingSlash(path)) {
+        errors = errors.setIn(['paths', i], 'No trailing slashes allowed')
       } else if (policy.paths.slice(0, i).includes(path)) {
         errors = errors.setIn(['paths', i], 'Path already included in current policy')
       } else if (whitelisted.includes(path)) {

--- a/ui/src/main/webapp/security/wcpm/validator.spec.js
+++ b/ui/src/main/webapp/security/wcpm/validator.spec.js
@@ -44,6 +44,12 @@ describe('validators', () => {
       const errors = policyValidator(policy)
       expect(errors.isEmpty()).to.equal(true)
     })
+    it('should not allow trailing slashes in context path', () => {
+      const policy = createPolicy({ paths: ['/test/'], authTypes: ['GUEST'] })
+      const errors = policyValidator(policy)
+      expect(errors.isEmpty()).to.equal(false)
+      expect(errors.getIn(['paths', 0])).to.not.equal(undefined)
+    })
   })
   describe('validator(whitelist)', () => {
     it('should not allow invalid context paths', () => {
@@ -74,6 +80,14 @@ describe('validators', () => {
       const policies = [{ paths: ['/world'] }]
       const errors = whitelistValidator(whitelist, { policies })
       expect(errors.isEmpty()).to.equal(true)
+    })
+    it('should not allow trailing slashes in context path', () => {
+      const whitelist = ['/hello', '/world', '/test/']
+      const errors = whitelistValidator(whitelist)
+      expect(errors.isEmpty()).to.equal(false)
+      expect(errors.get(0)).to.equal(undefined)
+      expect(errors.get(1)).to.equal(undefined)
+      expect(errors.get(2)).to.not.equal(undefined)
     })
   })
 })

--- a/ui/src/main/webapp/security/wcpm/whitelist.js
+++ b/ui/src/main/webapp/security/wcpm/whitelist.js
@@ -52,12 +52,18 @@ const isValidContextPath = (path) => {
   return /^(\/[A-Za-z0-9-._~:/?#[\]@!$&'()*+,;=`.%]*)+$/g.test(path)
 }
 
+const hasTrailingSlash = (path) => {
+  return /.+\/$/.test(path)
+}
+
 export const validator = (whitelist, { policies = [] } = {}) => {
   let errors = IList()
 
   whitelist.forEach((path, i) => {
     if (!isValidContextPath(path)) {
       errors = errors.set(i, 'Invalid context path')
+    } else if (hasTrailingSlash(path)) {
+      errors = errors.set(i, 'No trailing slashes allowed')
     } else if (whitelist.slice(0, i).includes(path)) {
       errors = errors.set(i, 'Path already included in the whitelist')
     } else {


### PR DESCRIPTION
#### What does this PR do?
AdminConsole WCPM not allow trailing slashes to context paths.
Added validations on the frontend and backend.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @peterhuffer @djblue

#### How should this be tested? (List steps with links to updated documentation)
1- Unit tests
2- Going through the wizard and confirming that you can't add a whitelist context and/or a policy when there is a trailing slash in the context paths

#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [x] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
