### PR TITLE
DDF-2773 Throttle GraphQL requests to prevent malicious use

### DIFF
--- a/query/graphql/pom.xml
+++ b/query/graphql/pom.xml
@@ -126,6 +126,16 @@
             <version>${osgi.compendium.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlets</artifactId>
+            <version>9.3.14.v20161028</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-util</artifactId>
+            <version>9.4.6.v20170531</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -139,7 +149,8 @@
                         <Import-Package>
                             !com.sun.tools.javac*,
                             !org.apache.tools.ant*,
-                            !org.eclipse.*,
+                            !org.eclipse.core.runtime,
+                            !org.eclipse.jdt.*,
                             *
                         </Import-Package>
                         <Embed-Dependency>

--- a/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
+++ b/query/graphql/src/main/java/org/codice/ddf/admin/graphql/servlet/ExtendedOsgiGraphQLServlet.java
@@ -81,6 +81,10 @@ public class ExtendedOsgiGraphQLServlet extends OsgiGraphQLServlet implements Ev
 
     private static final int MAX_REQUEST_SIZE = 1_000_000;
 
+    private static final int MAX_QUERY_SIZE = 10;
+
+    public static final String INVALID_BATCH_SIZE_MSG = "Invalid batch request size. The batch request size must be an integer less than or equal to " + MAX_QUERY_SIZE;
+
     public static final String INVALID_CONTENT_LENGTH_MSG = "Invalid Content-Length header value. The Content-Length must be an integer less than or equal to " + MAX_REQUEST_SIZE + " bytes";
 
     public static final String MISSING_CONTENT_LENGTH_HEADER_MSG = "Content-Length header is required.";
@@ -160,6 +164,14 @@ public class ExtendedOsgiGraphQLServlet extends OsgiGraphQLServlet implements Ev
 
         try {
             List<String> splitReqs = splitQueries(originalReqContent);
+
+            if(splitReqs.size() > MAX_QUERY_SIZE){
+                originalResponse.getWriter()
+                        .write(INVALID_BATCH_SIZE_MSG);
+                originalResponse.setStatus(429);
+                return;
+            }
+
             for (String reqStr : splitReqs) {
                 DelegateResponse response = new DelegateResponse(originalResponse);
                 super.doPost(new DelegateRequest(originalRequest, reqStr), response);

--- a/query/graphql/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/query/graphql/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -37,4 +37,13 @@
             </entry>
         </service-properties>
     </service>
+
+    <service id="DoSFilter" interface="javax.servlet.Filter">
+        <service-properties>
+            <entry key="filter-name" value="DoSFilter"/>
+            <entry key="urlPatterns" value="/admin/hub/graphql/*"/>
+            <entry key="maxRequestsPerSec" value="10"/>
+        </service-properties>
+        <bean class="org.eclipse.jetty.servlets.DoSFilter"/>
+    </service>
 </blueprint>


### PR DESCRIPTION
#### What does this PR do?

Throttle GraphQL requests to prevent malicious use
* Uses the Jetty Dos Filter to do so

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@coyotesqrl @tbatie @peterhuffer 

#### How should this be tested? (List steps with links to updated documentation)

To test the DoS Filter,

1- Turn on jetty logs

- `log:set DEBUG org.eclipse.jetty.servlets` - DoS filter's logs
- `log:set DEBUG org.eclipse.jetty.servlet` - ServletHandler's logs (shows you the filter chains)

2- Set the `maxRequestsPerSec` and `throttledRequests` in graphql's blueprint to 1
3- Use the wizard, graphiql or (even better) ChrisB's script ([index.js.zip](https://github.com/connexta/admin-console-beta/files/1286337/index.js.zip)) to make 100 (or more) requests. I purposefully have an incorrect port to see the logs.

In the logs you should see:
- `call filter DoSFilter`
- `Filtering Request(POST https://localhost:8993/admin/hub/graphql)@39560d86`
- `Allowing Request(POST https://localhost:8993/admin/hub/graphql)@39560d86`
- `DOS ALERT: Request delayed=100ms, ip=127.0.0.1, session=null, user=null`

and if you add `<entry key="delayMs" value="0"/>` in blueprint you will be able to see
- `DOS ALERT: Request throttled ip=127.0.0.1, session=null, user=null`
- `Throttling Request(POST https://localhost:8993/admin/hub/graphql)@2d81a663`

To test the batched request size restriction, use this script: [index2.js.zip](https://github.com/connexta/admin-console-beta/files/1286342/index2.js.zip) which sends a request with 12 queries in it.


#### What are the relevant tickets?
[DDF-2773](https://codice.atlassian.net/browse/DDF-2773)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests