### PR TITLE
Bump material-ui version to 0.19.1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -41,7 +41,7 @@
     "flexbox-react": "4.2.1",
     "graphql": "^0.9.1",
     "immutable": "^3.8.1",
-    "material-ui": "^0.18.3",
+    "material-ui": "^0.19.1",
     "prop-types": "^15.5.8",
     "react": "^15.1.0",
     "react-apollo": "^1.4.2",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -3607,9 +3607,9 @@ material-colors@^1.2.1:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/material-colors/-/material-colors-1.2.5.tgz#5292593e6754cb1bcc2b98030e4e0d6a3afc9ea1"
 
-material-ui@^0.18.3:
-  version "0.18.3"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.18.3.tgz#db1cf7190b322b304867e7ffb96b17ef79443bc9"
+material-ui@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.19.1.tgz#6be8072c3d1df9a2c93a840afab47952f2af5653"
   dependencies:
     babel-runtime "^6.23.0"
     inline-style-prefixer "^3.0.2"
@@ -3619,7 +3619,7 @@ material-ui@^0.18.3:
     prop-types "^15.5.7"
     react-event-listener "^0.4.5"
     react-transition-group "^1.1.2"
-    recompose "0.23.4"
+    recompose "0.24.0"
     simple-assign "^0.1.0"
     warning "^3.0.0"
 
@@ -4847,9 +4847,9 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-recompose@0.23.4:
-  version "0.23.4"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.23.4.tgz#af09e4e08424effa449c9b793037166f7b30644a"
+recompose@0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.24.0.tgz#262e93f974439eb17e7779824d88cce90492a5dd"
   dependencies:
     change-emitter "^0.1.2"
     fbjs "^0.8.1"


### PR DESCRIPTION
#### What does this PR do?

Bumps material-ui version to 0.19.1

#### Who is reviewing it?

@garrettfreibott 
@blen-desta 

#### How should this be tested? (List steps with links to updated documentation)

Test that the attribute mapping stage no longer allows white space to be entered for the user attribute.
