### PR TITLE
DDF-3328 Update LDAP login configuration to separate the user attributes for group membership and login

### DIFF
--- a/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
+++ b/query/security/common/src/main/java/org/codice/ddf/admin/security/common/services/LdapLoginServiceProperties.java
@@ -32,7 +32,9 @@ public class LdapLoginServiceProperties {
   //    public static final String KDC_ADDRESS = "kdcAddress";
   public static final String REALM = "realm";
 
-  public static final String USER_NAME_ATTRIBUTE = "userNameAttribute";
+  public static final String LOGIN_USER_ATTRIBUTE = "loginUserAtttribute";
+
+  public static final String MEMBERSHIP_USER_ATTRIBUTE = "membershipUserAttribute";
 
   public static final String USER_BASE_DN = "userBaseDn";
 

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
@@ -146,9 +146,15 @@ public class LdapServiceCommons {
       ldapStsConfig.put(
           LdapLoginServiceProperties.LOGIN_USER_ATTRIBUTE,
           config.settingsField().usernameAttribute());
+
+      // TODO: oconnormi - 10/02/17 The ui needs to be updated to include a field for the group
+      // member user attribute
       ldapStsConfig.put(
           LdapLoginServiceProperties.MEMBERSHIP_USER_ATTRIBUTE,
-          config.settingsField().groupAttributeHoldingMember());
+          config.settingsField().groupAttributeHoldingMember() == null
+              ? config.settingsField().usernameAttribute()
+              : config.settingsField().groupAttributeHoldingMember());
+
       ldapStsConfig.put(
           LdapLoginServiceProperties.USER_BASE_DN, config.settingsField().baseUserDn());
       ldapStsConfig.put(

--- a/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
+++ b/query/security/ldap/src/main/java/org/codice/ddf/admin/ldap/commons/LdapServiceCommons.java
@@ -144,8 +144,11 @@ public class LdapServiceCommons {
       ldapStsConfig.put(LdapLoginServiceProperties.REALM, config.bindUserInfoField().realm());
 
       ldapStsConfig.put(
-          LdapLoginServiceProperties.USER_NAME_ATTRIBUTE,
+          LdapLoginServiceProperties.LOGIN_USER_ATTRIBUTE,
           config.settingsField().usernameAttribute());
+      ldapStsConfig.put(
+          LdapLoginServiceProperties.MEMBERSHIP_USER_ATTRIBUTE,
+          config.settingsField().groupAttributeHoldingMember());
       ldapStsConfig.put(
           LdapLoginServiceProperties.USER_BASE_DN, config.settingsField().baseUserDn());
       ldapStsConfig.put(
@@ -218,7 +221,9 @@ public class LdapServiceCommons {
 
     LdapDirectorySettingsField settings =
         new LdapDirectorySettingsField()
-            .usernameAttribute(mapValue(props, LdapLoginServiceProperties.USER_NAME_ATTRIBUTE))
+            .usernameAttribute(mapValue(props, LdapLoginServiceProperties.LOGIN_USER_ATTRIBUTE))
+            .groupAttributeHoldingMember(
+                mapValue(props, LdapLoginServiceProperties.MEMBERSHIP_USER_ATTRIBUTE))
             .baseUserDn(mapValue(props, LdapLoginServiceProperties.USER_BASE_DN))
             .baseGroupDn(mapValue(props, LdapLoginServiceProperties.GROUP_BASE_DN))
             .useCase(AUTHENTICATION);


### PR DESCRIPTION
#### What does this PR do?

Adds an additional field to the LDAP authentication configuration

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?

@tbatie @coyotesqrl 

#### How should this be tested? (List steps with links to updated documentation)

#### Any background context you want to provide?

#### What are the relevant tickets?
[DDF-3328](https://codice.atlassian.net/browse/DDF-3328)