### PR TITLE
Hide unused fields in LDAP wizard when not required.

### DIFF
--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -152,7 +152,6 @@ const configInputs = [
     optionKey: 'userDns',
     label: 'Base User DN',
     tooltip: 'Distinguished name of the LDAP directory in which users can be found.'
-
   },
   {
     key: 'userNameAttribute',
@@ -164,7 +163,8 @@ const configInputs = [
     key: 'memberAttributeReferencedInGroup',
     optionKey: 'memberAttributesReferencedInGroup',
     label: 'Member Attribute Referenced in Groups',
-    tooltip: 'The attribute of the user entry that, when combined with the Base User DN, forms the reference value, e.g. XXX=jsmith,ou=users,dc=example,dc=com'
+    tooltip: 'The attribute of the user entry that, when combined with the Base User DN, forms the reference value, e.g. XXX=jsmith,ou=users,dc=example,dc=com',
+    attrStoreOnly: true
   },
   {
     key: 'baseGroupDn',
@@ -176,13 +176,15 @@ const configInputs = [
     key: 'groupObjectClass',
     optionKey: 'groupObjectClasses',
     label: 'LDAP Group ObjectClass',
-    tooltip: 'ObjectClass that defines the structure for group membership in LDAP. Typically groupOfNames.'
+    tooltip: 'ObjectClass that defines the structure for group membership in LDAP. Typically groupOfNames.',
+    attrStoreOnly: true
   },
   {
     key: 'groupAttributeHoldingMember',
     optionKey: 'groupAttributesHoldingMember',
     label: 'Group Attribute Holding Member References',
-    tooltip: 'Multivalued-attribute on the group entry that holds references to users.'
+    tooltip: 'Multivalued-attribute on the group entry that holds references to users.',
+    attrStoreOnly: true
   },
   {
     key: 'queryBase',
@@ -313,7 +315,7 @@ const DirectorySettings = (props) => {
       <Body>
         {configInputs
           .filter(({ label }) => label !== undefined)
-          .map(({ key, optionKey, label, tooltip }) => {
+          .map(({ key, optionKey, label, tooltip, attrStoreOnly = false }) => {
             const error = errors.find((err) => key === err.path[err.path.length - 1]) || {}
 
             return (
@@ -324,6 +326,7 @@ const DirectorySettings = (props) => {
                 errorText={error.message}
                 label={label}
                 tooltip={tooltip}
+                visible={!attrStoreOnly || isAttrStore}
                 options={options[optionKey]} />
             )
           })}


### PR DESCRIPTION
#### What does this PR do?

The following fields are not required when using LDAP only as an
authentication store.

- `memberAttributeReferencedInGroup`
- `groupObjectClass`
- `groupAttributeHoldingMember`

As such, they are now no longer being display when the user selects
`Authentication` as the LDAP use case. This fixes an issues intoduced by
the refactoring changes in `9005fb58bf6b64b90557ab90e0ba21fef1bc2c3e`.

#### Who is reviewing it?

@tbatie 
@oconnormi 
@garrettfreibott 

#### How should this be tested?

Try all three use cases in LDAP wizard ensuring that the aforementioned fields are hidden when being used for Authentication.

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
