### PR TITLE
Added unit tests to the LDAP wizard.

### DIFF
--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.js
@@ -324,6 +324,7 @@ const DirectorySettings = (props) => {
             return (
               <InputAuto
                 key={key}
+                id={key}
                 value={configs[key]}
                 onEdit={onEdit(key)}
                 errorText={error.message}
@@ -368,5 +369,7 @@ const DirectorySettings = (props) => {
     </div>
   )
 }
+
+export { DirectorySettings }
 
 export default withApollo(DirectorySettings)

--- a/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
+++ b/ui/src/main/webapp/wizards/ldap/stages/directory-settings.spec.js
@@ -1,0 +1,78 @@
+import React from 'react'
+
+import { expect } from 'chai'
+import { shallow } from 'enzyme'
+
+import { InputAuto } from 'admin-wizard/inputs'
+
+import { DirectorySettings } from './directory-settings'
+
+describe('<LDAP />', () => {
+  describe('<DirectorySettings />', () => {
+    it('should hide fields when `Authentication`', () => {
+      const wrapper = shallow(
+        <DirectorySettings
+          configs={{
+            ldapUseCase: 'Authentication'
+          }}
+          options={{}}
+          errors={[]}
+          onEdit={() => {}}
+        />
+      )
+
+      const inputs = wrapper.find(InputAuto)
+      expect(inputs).to.have.length(6)
+
+      const visible = inputs
+        .filterWhere((comp) => comp.prop('visible'))
+        .map((comp) => comp.prop('id'))
+
+      expect(visible).to.deep.equal([
+        'baseUserDn',
+        'userNameAttribute',
+        'baseGroupDn'
+      ])
+
+      const notVisible = wrapper.find(InputAuto)
+        .filterWhere((comp) => !comp.prop('visible'))
+        .map((comp) => comp.prop('id'))
+
+      expect(notVisible).to.deep.equal([
+        'memberAttributeReferencedInGroup',
+        'groupObjectClass',
+        'groupAttributeHoldingMember'
+      ])
+    })
+    it('should show all fields when `AttributeStore`', () => {
+      const wrapper = shallow(
+        <DirectorySettings
+          configs={{
+            ldapUseCase: 'AttributeStore'
+          }}
+          options={{}}
+          errors={[]}
+          onEdit={() => {}}
+        />
+      )
+
+      const visible = wrapper.find(InputAuto).filterWhere((comp) => comp.prop('visible'))
+      expect(visible).to.have.length(6, 'All fields should be visible.')
+    })
+    it('should show all fields when `AuthenticationAndAttributeStore`', () => {
+      const wrapper = shallow(
+        <DirectorySettings
+          configs={{
+            ldapUseCase: 'AuthenticationAndAttributeStore'
+          }}
+          options={{}}
+          errors={[]}
+          onEdit={() => {}}
+        />
+      )
+
+      const visible = wrapper.find(InputAuto).filterWhere((comp) => comp.prop('visible'))
+      expect(visible).to.have.length(6, 'All fields should be visible.')
+    })
+  })
+})


### PR DESCRIPTION
#### What does this PR do?

Added unit tests to prevent regression of `<DirectorySettings />` stage in the LDAP wizard.

#### Who is reviewing it?

@tbatie 
@garrettfreibott 
@coyotesqrl 

#### How should this be tested?

`mvn clean install` ui directory.
