### PR TITLE
DDF-3353 Delete buttons in the WCPM wizard appear in the policy they are meant to delete

### DIFF
--- a/ui/src/main/webapp/security/wcpm/components.js
+++ b/ui/src/main/webapp/security/wcpm/components.js
@@ -62,6 +62,10 @@ export const Subtitle = muiThemeable()(({ muiTheme, children }) => (
   <h4 style={{ margin: 0, color: muiTheme.palette.primary1Color }}>{children}</h4>
 ))
 
+const DeleteIconThemed = muiThemeable()(({ muiTheme }) => (
+  <DeleteIcon style={{ color: muiTheme.palette.errorColor }} />
+))
+
 export const EditRegion = ({ children, onEdit }) => (
   <div className={editRegion} style={{ position: 'relative' }}>
     <FloatingActionButton className={editButton} onClick={onEdit}>
@@ -102,7 +106,7 @@ export const DeleteButton = ({ onClick, style }) => (
       confirmableStyle={{ margin: '-10px 5px' }}
       tooltip='Delete'
       tooltipPosition='top-center'>
-      <DeleteIcon />
+      <DeleteIconThemed />
     </ConfirmDelete>
   </div>
 )

--- a/ui/src/main/webapp/security/wcpm/components.js
+++ b/ui/src/main/webapp/security/wcpm/components.js
@@ -94,12 +94,12 @@ export const CancelButton = ({ onClick }) => (
 
 const ConfirmDelete = confirmable(IconButton)
 
-export const DeleteButton = ({ onClick }) => (
-  <div style={{ position: 'absolute', right: '0px', bottom: '0px' }}>
+export const DeleteButton = ({ onClick, style }) => (
+  <div style={style}>
     <ConfirmDelete
       onClick={onClick}
       confirmableMessage='Confirm policy deletion?'
-      confirmableStyle={{ margin: '5px' }}
+      confirmableStyle={{ margin: '-10px 5px' }}
       tooltip='Delete'
       tooltipPosition='top-center'>
       <DeleteIcon />
@@ -107,16 +107,15 @@ export const DeleteButton = ({ onClick }) => (
   </div>
 )
 
-const VisibleDeleteButton = visible(DeleteButton)
+export const VisibleDeleteButton = visible(DeleteButton)
 
-export const ConfirmationPanel = ({ onSave, onCancel, allowDelete = false, onDelete }) => (
+export const ConfirmationPanel = ({ onSave, onCancel }) => (
   <Flexbox flexDirection='row' justifyContent='center' style={{ padding: '35px 0px 5px' }}>
     <CancelButton onClick={onCancel} />
     <RaisedButton
       primary
       label='Save'
       onClick={onSave} />
-    <VisibleDeleteButton visible={allowDelete} onClick={onDelete} />
   </Flexbox>
 )
 

--- a/ui/src/main/webapp/security/wcpm/policy.js
+++ b/ui/src/main/webapp/security/wcpm/policy.js
@@ -49,7 +49,10 @@ const PolicyEdit = (props) => {
 
   return (
     <Layout number={number}>
-      <VisibleDeleteButton style={{ position: 'absolute', right: '0px', top: '0px' }} onClick={onDelete} />
+      <VisibleDeleteButton
+        style={{ position: 'absolute', right: '0px', top: '0px' }}
+        visible={!policy.paths.includes('/') && !errors.hasRootContextError}
+        onClick={onDelete} />
       <Spinner submitting={loading}>
         <ContextPaths
           paths={policy.paths}
@@ -185,6 +188,13 @@ export const validator = (policy, { whitelisted = [], policies = [] } = {}) => {
 
   if (policy.realm === undefined || policy.realm === '') {
     errors = errors.set('realm', 'Must specify the realm')
+  }
+
+  const all = policies.filter(policy => !policy.editing).concat(policy)
+
+  if (!all.some((policy) => policy.paths.includes('/'))) {
+    errors = errors.setIn(['paths', policy.paths.size], 'A policy must contain the root context path')
+    errors = errors.setIn(['hasRootContextError'], true)
   }
 
   return errors

--- a/ui/src/main/webapp/security/wcpm/policy.js
+++ b/ui/src/main/webapp/security/wcpm/policy.js
@@ -8,7 +8,7 @@ import Flexbox from 'flexbox-react'
 
 import { Record, Map, List } from 'immutable'
 
-import { ConfirmationPanel, EditRegion, Header, ServerErrors } from './components'
+import { ConfirmationPanel, EditRegion, Header, ServerErrors, VisibleDeleteButton } from './components'
 
 import Divider from 'material-ui/Divider'
 
@@ -20,7 +20,7 @@ import Realms, { RealmsView } from './realms'
 import RequiredClaims, { RequiredClaimsView } from './required-claims'
 
 const Layout = ({ children, number }) => (
-  <div>
+  <div style={{ position: 'relative' }}>
     <div style={{ padding: 8 }}>
       <Header>Policy #{number}</Header>
     </div>
@@ -49,6 +49,7 @@ const PolicyEdit = (props) => {
 
   return (
     <Layout number={number}>
+      <VisibleDeleteButton style={{ position: 'absolute', right: '0px', top: '0px' }} onClick={onDelete} />
       <Spinner submitting={loading}>
         <ContextPaths
           paths={policy.paths}
@@ -77,9 +78,7 @@ const PolicyEdit = (props) => {
         <ServerErrors errors={serverErrors.claimsMapping} />
         <ConfirmationPanel
           onCancel={onCancel}
-          onSave={() => { onSave(policy) }}
-          allowDelete
-          onDelete={onDelete} />
+          onSave={() => { onSave(policy) }} />
         <ServerErrors errors={serverErrors.all} />
       </Spinner>
     </Layout>

--- a/ui/src/main/webapp/security/wcpm/validator.spec.js
+++ b/ui/src/main/webapp/security/wcpm/validator.spec.js
@@ -50,6 +50,16 @@ describe('validators', () => {
       expect(errors.isEmpty()).to.equal(false)
       expect(errors.getIn(['paths', 0])).to.not.equal(undefined)
     })
+    it('should not allow removing the root context path', () => {
+      const policy = createPolicy({ paths: ['/test'], authTypes: ['GUEST'] })
+      const errors = policyValidator(policy, {
+        policies: [
+              { editing: true }
+        ]
+      })
+      expect(errors.isEmpty()).to.equal(false)
+      expect(errors.get('hasRootContextError')).to.equal(true)
+    })
   })
   describe('validator(whitelist)', () => {
     it('should not allow invalid context paths', () => {

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -194,8 +194,7 @@ if (process.env.NODE_ENV === 'production') {
       inline: true,
       compress: true,
       hot: true,
-      host: '0.0.0.0',
-      port: 8181
+      host: '0.0.0.0'
     },
     plugins: [
       new HtmlWebpackPlugin(),


### PR DESCRIPTION
#### What does this PR do?
The WCPM wizard's policies now have the delete button when they are being edited. It used to be on the bottom right corner of the page.

#### Who is reviewing it (please choose AT LEAST two reviewers that need to approve the PR before it can get merged)?
@garrettfreibott @blen-desta @djblue 

#### How should this be tested? (List steps with links to updated documentation)
1. Build admin-console-beta
2. Build a downstream project. 
3. Go to the Admin UI, then to "setup". Click on the edit icon for a policy.
3. The Delete button should appear where the edit icon was.
4. Test the delete button works by
    - Clicking on the button
    - Clicking "No" on the confirmation
    - Clicking "Yes" on the confirmation (should delete policy)
    - Clicking "Yes" on the Policy where the **Context Path** is `/`. This policy should not be able to delete from WCPM. 
5. Test this for Chrome, Firefox, and IE

#### What are the relevant tickets?
[](https://codice.atlassian.net/browse/)

#### Checklist:
- [ ] Documentation Updated
- [ ] Update / Add Unit Tests
- [ ] Update / Add Integration Tests
